### PR TITLE
Sharpen home page, navbar, and footer for a crisper look

### DIFF
--- a/frontend/vuejs/src/apps/home/components/organisms/sections/FeaturesSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/FeaturesSection.vue
@@ -29,7 +29,7 @@
           class="relative"
         >
           <!-- Card with solid background -->
-          <div class="relative h-full p-8 rounded-2xl bg-white dark:bg-white border border-gray-200 dark:border-gray-300 transition-colors duration-300 shadow-md">
+          <div class="relative h-full p-8 rounded-2xl bg-white dark:bg-white border border-gray-200/80 dark:border-gray-300 crisp-card transition-colors duration-300">
             
             <!-- Title -->
             <h3 class="relative text-xl font-semibold text-gray-900 dark:text-black transition-colors duration-300 mb-5 text-center">
@@ -95,5 +95,12 @@ export default defineComponent({
 </script>
 
 <style scoped>
-/* Styles removed - cards now use simple shadows */
+/* Crisp, sharply-defined cards: hairline edge + tight layered shadow */
+.crisp-card {
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.03),
+    0 1px 2px rgba(15, 23, 42, 0.06),
+    0 4px 10px -2px rgba(15, 23, 42, 0.07),
+    0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
 </style>

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/KeyFeaturesSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/KeyFeaturesSection.vue
@@ -30,7 +30,7 @@
           class="relative"
         >
           <!-- Card with solid background -->
-          <div class="relative h-full p-8 rounded-2xl bg-white dark:bg-white border border-gray-200 dark:border-gray-300 transition-colors duration-300 shadow-md">
+          <div class="relative h-full p-8 rounded-2xl bg-white dark:bg-white border border-gray-200/80 dark:border-gray-300 crisp-card transition-colors duration-300">
             
             <!-- Title -->
             <h3 class="relative text-xl font-semibold text-gray-900 dark:text-black transition-colors duration-300 mb-5 text-center">
@@ -114,5 +114,12 @@ export default defineComponent({
 </script>
 
 <style scoped>
-/* Styles removed - cards now use simple shadows */
+/* Crisp, sharply-defined cards: hairline edge + tight layered shadow */
+.crisp-card {
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.03),
+    0 1px 2px rgba(15, 23, 42, 0.06),
+    0 4px 10px -2px rgba(15, 23, 42, 0.07),
+    0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
 </style>

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/StatsSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/StatsSection.vue
@@ -19,7 +19,7 @@
         <div 
           v-for="(stat, index) in stats" 
           :key="index"
-          class="relative text-center p-10 rounded-2xl bg-white dark:bg-white border border-gray-200 dark:border-gray-300 transition-colors duration-300 shadow-md"
+          class="relative text-center p-10 rounded-2xl bg-white dark:bg-white border border-gray-200/80 dark:border-gray-300 crisp-card transition-colors duration-300"
         >
           <p class="relative text-lg text-gray-600 dark:text-black mb-3 transition-colors duration-300">{{ stat.label }}</p>
           <div class="relative text-5xl md:text-6xl font-semibold text-gray-900 dark:text-black transition-colors duration-300">
@@ -33,7 +33,7 @@
         <div 
           v-for="(metric, index) in metrics" 
           :key="index"
-          class="relative p-8 rounded-2xl bg-white dark:bg-white border border-gray-200 dark:border-gray-300 transition-colors duration-300 shadow-md"
+          class="relative p-8 rounded-2xl bg-white dark:bg-white border border-gray-200/80 dark:border-gray-300 crisp-card transition-colors duration-300"
         >
           <!-- Icon and Title (side by side) -->
           <div class="relative flex items-center gap-3 mb-4">
@@ -101,5 +101,12 @@ export default defineComponent({
 </script>
 
 <style scoped>
-/* Styles removed - cards now use simple shadows */
+/* Crisp, sharply-defined cards: hairline edge + tight layered shadow */
+.crisp-card {
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.03),
+    0 1px 2px rgba(15, 23, 42, 0.06),
+    0 4px 10px -2px rgba(15, 23, 42, 0.07),
+    0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
 </style>

--- a/frontend/vuejs/src/apps/home/views/About.vue
+++ b/frontend/vuejs/src/apps/home/views/About.vue
@@ -1,7 +1,7 @@
 <!-- About Page - Clean Apple/Cursor-inspired design matching Home -->
 <template>
   <DefaultLayout :isHomeNav="true">
-    <div class="min-h-screen bg-white dark:bg-[#0a0a0a] relative overflow-hidden transition-colors duration-500">
+    <div class="home-page min-h-screen bg-white dark:bg-[#0a0a0a] relative overflow-hidden transition-colors duration-500">
       <!-- Minimal background -->
       <div class="fixed inset-0 pointer-events-none">
         <!-- Subtle gradient -->
@@ -52,7 +52,7 @@
             <!-- Mission cards -->
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               <div v-for="(card, index) in missionCards" :key="index" class="relative">
-                <div class="relative h-full p-8 rounded-2xl bg-white dark:bg-white border border-gray-200 dark:border-gray-300 transition-colors duration-300 shadow-md">
+                <div class="relative h-full p-8 rounded-2xl bg-white dark:bg-white border border-gray-200/80 dark:border-gray-300 crisp-card transition-colors duration-300">
                   <!-- Content -->
                   <h3 class="text-xl font-semibold text-gray-900 dark:text-black transition-colors duration-300 mb-5">
                     {{ card.title }}
@@ -88,7 +88,7 @@
             <!-- Features grid -->
             <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
               <div v-for="(feature, index) in features" :key="index" class="relative">
-                <div class="relative h-full p-8 rounded-2xl bg-white dark:bg-white border border-gray-200 dark:border-gray-300 transition-colors duration-300 shadow-md">
+                <div class="relative h-full p-8 rounded-2xl bg-white dark:bg-white border border-gray-200/80 dark:border-gray-300 crisp-card transition-colors duration-300">
                   <!-- Content -->
                   <h3 class="text-xl font-semibold text-gray-900 dark:text-black transition-colors duration-300 mb-5 text-center">
                     {{ feature.title }}
@@ -124,7 +124,7 @@
             <!-- User types grid -->
             <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
               <div v-for="(userType, index) in userTypes" :key="index" class="relative">
-                <div class="relative h-full p-8 rounded-2xl bg-white dark:bg-white border border-gray-200 dark:border-gray-300 transition-colors duration-300 shadow-md">
+                <div class="relative h-full p-8 rounded-2xl bg-white dark:bg-white border border-gray-200/80 dark:border-gray-300 crisp-card transition-colors duration-300">
                   <!-- Content -->
                   <h3 class="text-xl font-semibold text-gray-900 dark:text-black transition-colors duration-300 mb-5">
                     {{ userType.title }}
@@ -229,6 +229,30 @@ export default defineComponent({
 </script>
 
 <style scoped>
+/* Crisp, sharp text rendering across the page */
+.home-page {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+.home-page :deep(h1),
+.home-page :deep(h2),
+.home-page :deep(h3) {
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  font-feature-settings: 'kern' 1, 'liga' 1, 'calt' 1;
+}
+
+/* Crisp, sharply-defined cards: hairline edge + tight layered shadow */
+.crisp-card {
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.03),
+    0 1px 2px rgba(15, 23, 42, 0.06),
+    0 4px 10px -2px rgba(15, 23, 42, 0.07),
+    0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
+
 /* Minimal scrollbar matching Home page */
 :deep(::-webkit-scrollbar) {
   width: 8px;

--- a/frontend/vuejs/src/apps/home/views/Home.vue
+++ b/frontend/vuejs/src/apps/home/views/Home.vue
@@ -1,7 +1,7 @@
 <!-- Home landing page - Clean Apple/Cursor-inspired design -->
 <template>
   <DefaultLayout :isHomeNav="true">
-    <div class="min-h-screen bg-white dark:bg-[#0a0a0a] relative overflow-hidden transition-colors duration-500">
+    <div class="home-page min-h-screen bg-white dark:bg-[#0a0a0a] relative overflow-hidden transition-colors duration-500">
       <!-- Enhanced minimal background with subtle noise texture effect -->
       <div class="fixed inset-0 pointer-events-none">
         <!-- Subtle gradient - very minimal -->
@@ -75,6 +75,21 @@ export default defineComponent({
 </script>
 
 <style scoped>
+/* Crisp, sharp text rendering across the landing page */
+.home-page {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+.home-page :deep(h1),
+.home-page :deep(h2),
+.home-page :deep(h3) {
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  font-feature-settings: 'kern' 1, 'liga' 1, 'calt' 1;
+}
+
 /* Refined minimal scrollbar */
 :deep(::-webkit-scrollbar) {
   width: 8px;

--- a/frontend/vuejs/src/shared/components/organisms/navigation/BaseFooter.vue
+++ b/frontend/vuejs/src/shared/components/organisms/navigation/BaseFooter.vue
@@ -1,5 +1,5 @@
 <template>
-  <footer class="relative bg-white dark:bg-[#0a0a0a] border-t border-gray-200 dark:border-white/10 transition-colors duration-300">
+  <footer class="crisp-footer relative bg-white dark:bg-[#0a0a0a] border-t border-gray-200 dark:border-white/[0.12] transition-colors duration-300">
     <div class="relative max-w-7xl mx-auto px-6 sm:px-8 lg:px-12">
       
       <!-- Main footer content -->
@@ -93,7 +93,7 @@
       </div>
 
       <!-- Bottom bar -->
-      <div class="py-6 border-t border-gray-200 dark:border-white/10 transition-colors duration-300">
+      <div class="py-6 border-t border-gray-200 dark:border-white/[0.12] transition-colors duration-300">
         <div class="flex items-center justify-between">
           <p class="text-gray-500 dark:text-white/50 text-sm transition-colors duration-300">
             &copy; {{ currentYear }} Imagi. All rights reserved.
@@ -112,3 +112,12 @@ import { ThemeToggle } from '@/shared/components/atoms'
 
 const currentYear = computed(() => new Date().getFullYear())
 </script>
+
+<style scoped>
+/* Crisp, sharp text rendering for the footer */
+.crisp-footer {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+</style>

--- a/frontend/vuejs/src/shared/components/organisms/navigation/BaseNavbar.vue
+++ b/frontend/vuejs/src/shared/components/organisms/navigation/BaseNavbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav class="fixed w-full z-50 bg-white/80 dark:bg-[#0a0a0a]/80 backdrop-blur-xl border-b border-gray-200/80 dark:border-white/5 transition-colors duration-300">
+  <nav class="crisp-nav fixed w-full z-50 bg-white/80 dark:bg-[#0a0a0a]/80 backdrop-blur-xl border-b border-gray-200/80 dark:border-white/[0.08] transition-colors duration-300">
     <div class="relative max-w-7xl mx-auto pl-6 pr-6 sm:pl-8 sm:pr-8 lg:pl-12 lg:pr-12">
       <div class="relative flex items-center h-14">
         <!-- Left section -->
@@ -31,6 +31,18 @@ import { ImagiLogo } from '@/shared/components/molecules'
 </script>
 
 <style scoped>
+/* Crisp, sharp text rendering + hairline separator that stays 1px at any DPI */
+.crisp-nav {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+  box-shadow: 0 1px 0 0 rgba(15, 23, 42, 0.02);
+}
+
+:global(.dark) .crisp-nav {
+  box-shadow: 0 1px 0 0 rgba(255, 255, 255, 0.03);
+}
+
 nav {
   width: 100%;
   overflow: visible;


### PR DESCRIPTION
## What

Refines the visual polish of the landing experience to look sharper and more crisp, **without changing the general design, layout, spacing, or color scheme**.

The page previously read slightly soft: cards used a generic `shadow-md` and text wasn't antialiased. These changes tighten the edges and text rendering while keeping everything in the same position and size.

## Changes

- **Crisper text rendering** — added antialiased font smoothing + `optimizeLegibility` (and heading kerning/ligatures) across the Home and About pages (`.home-page`) and the shared navbar/footer.
- **Sharper cards** — replaced the soft `shadow-md` with a `.crisp-card` treatment: a 1px hairline edge plus a tight, layered drop shadow so cards read defined instead of fuzzy. Applied to Stats, Features, Key Features, and the About page sections.
- **Refined card borders** — tightened to `gray-200/80` for a cleaner hairline.
- **Navbar** — added a precise 1px box-shadow separator (light + dark) so the bottom edge stays crisp at any pixel density, and sharpened the dark-mode bottom border (`white/5` → `white/8`).
- **Footer** — sharpened both dark-mode hairline dividers (`white/10` → `white/12`).

## Scope note

`BaseNavbar` and `BaseFooter` are shared components, so the crispness applies app-wide on the navbar/footer (not only the home page) — keeping the design consistent across routes.

## Verification

- Confirmed via computed-style inspection that the antialiasing, hairline shadow, and new border values are applied on the live `nav`, `footer`, and card elements.
- Screenshotted the Stats/Features/Key Features card sections and the footer in the browser preview — edges and text render crisply.
- No layout/spacing/color changes; no compile errors (the only console/server errors are pre-existing backend health-check failures because Django isn't running locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)