### PR TITLE
Auto-provision worktree dev environments via SessionStart hook

### DIFF
--- a/.claude/hooks/dev-setup.sh
+++ b/.claude/hooks/dev-setup.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Per-worktree dev environment setup, shared by the SessionStart hook and
+# launch.json. Targets:
+#   symlink   - point this worktree's db.sqlite3 at the main checkout's DB
+#   frontend  - npm install
+#   backend   - link DB + pipenv install + migrate
+#   all       - everything (used by the SessionStart hook to pre-warm)
+#
+# Installs are guarded by an atomic mkdir lock so the background hook run and a
+# foreground preview_start run can't clobber each other's node_modules / venv.
+
+set -uo pipefail
+
+# Worktree root (this file lives in <root>/.claude/hooks/).
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+# Canonical checkout = parent of the shared .git dir. Worktrees resolve to the
+# main checkout; the main checkout resolves to itself.
+GIT_COMMON="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+if [ -n "$GIT_COMMON" ]; then
+  MAIN_ROOT="$(dirname "$GIT_COMMON")"
+else
+  MAIN_ROOT="$ROOT"
+fi
+
+LOCK_DIR="$ROOT/.claude/.locks"
+mkdir -p "$LOCK_DIR"
+
+log() { echo "[dev-setup] $*"; }
+
+with_lock() { # with_lock <name> <command...>
+  local name="$1"; shift
+  local lock="$LOCK_DIR/$name"
+  local waited=0
+  until mkdir "$lock" 2>/dev/null; do
+    sleep 1; waited=$((waited + 1))
+    if [ "$waited" -ge 600 ]; then
+      log "timed out waiting for '$name' lock; running anyway"
+      break
+    fi
+  done
+  "$@"; local rc=$?
+  rmdir "$lock" 2>/dev/null || true
+  return $rc
+}
+
+link_db() {
+  # The main checkout owns the real file; nothing to link.
+  if [ "$ROOT" = "$MAIN_ROOT" ]; then
+    return 0
+  fi
+  local target="$MAIN_ROOT/backend/django/db.sqlite3"
+  local link="$ROOT/backend/django/db.sqlite3"
+  # Don't destroy a real DB someone created directly in this worktree.
+  if [ -e "$link" ] && [ ! -L "$link" ]; then
+    log "WARNING: $link is a real file, not a symlink — leaving it untouched."
+    log "         Delete it and re-run to share the main checkout's DB instead."
+    return 0
+  fi
+  ln -sfn "$target" "$link"
+  log "db.sqlite3 -> $target"
+}
+
+install_frontend() {
+  with_lock frontend bash -c "cd '$ROOT/frontend/vuejs' && npm install"
+}
+
+link_env() {
+  # Share the main checkout's backend .env so secrets are available everywhere.
+  if [ "$ROOT" = "$MAIN_ROOT" ]; then
+    return 0
+  fi
+  local target="$MAIN_ROOT/backend/django/.env"
+  local link="$ROOT/backend/django/.env"
+  if [ ! -e "$target" ]; then
+    return 0  # no shared .env to link; backend falls back to dev defaults
+  fi
+  if [ -e "$link" ] && [ ! -L "$link" ]; then
+    log "WARNING: $link is a real file, not a symlink — leaving it untouched."
+    return 0
+  fi
+  ln -sfn "$target" "$link"
+  log ".env -> $target"
+}
+
+install_backend() {
+  link_db
+  link_env
+  with_lock backend bash -c "cd '$ROOT/backend/django' && pipenv install && pipenv run python manage.py migrate"
+}
+
+case "${1:-all}" in
+  symlink)  link_db; link_env ;;
+  frontend) install_frontend ;;
+  backend)  install_backend ;;
+  all)      link_db; link_env; install_frontend; install_backend ;;
+  *)        log "unknown target: ${1:-}"; exit 1 ;;
+esac

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -3,15 +3,15 @@
   "configurations": [
     {
       "name": "frontend-vite",
-      "runtimeExecutable": "npm",
-      "runtimeArgs": ["run", "dev"],
+      "runtimeExecutable": "bash",
+      "runtimeArgs": ["-c", "bash ../../.claude/hooks/dev-setup.sh frontend; npm run dev"],
       "cwd": "frontend/vuejs",
       "port": 5173
     },
     {
       "name": "backend-django",
-      "runtimeExecutable": "pipenv",
-      "runtimeArgs": ["run", "python", "manage.py", "runserver"],
+      "runtimeExecutable": "bash",
+      "runtimeArgs": ["-c", "bash ../../.claude/hooks/dev-setup.sh backend; pipenv run python manage.py runserver"],
       "cwd": "backend/django",
       "port": 8000
     }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/dev-setup.sh symlink; nohup bash .claude/hooks/dev-setup.sh all > .claude/.dev-setup.log 2>&1 &",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 
+# Claude Code dev-setup artifacts
+.claude/.locks/
+.claude/.dev-setup.log
+
 # IDE
 .vscode/*
 !.vscode/extensions.json


### PR DESCRIPTION
## What changed

New worktree sessions had no `node_modules`, no pipenv virtualenv, and no database (all gitignored, so they don't travel into a worktree). Clicking preview started nothing. This adds a shared `dev-setup.sh` wired into both a **SessionStart hook** and **launch.json**.

Each worktree now, on session start:

- **Shares one SQLite database** — symlinks `backend/django/db.sqlite3` to the main checkout's DB, so migrations and data are shared across all worktrees (no `settings.py` change; Django already uses `BASE_DIR / 'db.sqlite3'`).
- **Shares one `.env`** — symlinks `backend/django/.env` to the main checkout, so Stripe/OpenAI-agent secrets are live everywhere. Edits to the main `.env` propagate instantly.
- **Pre-installs deps in the background** — `npm install` + `pipenv install` + `migrate` run non-blocking (logged to `.claude/.dev-setup.log`), so preview is fast once warmed.

## Why this is safe

- Both the background hook and `preview_start` install through the same script, serialized by an atomic `mkdir` lock, so concurrent installs can't corrupt `node_modules`/the venv.
- Symlink steps refuse to overwrite a *real* (non-symlink) `db.sqlite3` or `.env` placed directly in a worktree, and no-op cleanly in the main checkout itself.

## Files

| File | Role |
|---|---|
| `.claude/hooks/dev-setup.sh` | Source of truth: `symlink` / `frontend` / `backend` / `all`. |
| `.claude/settings.json` | SessionStart hook → symlink now, installs in background. |
| `.claude/launch.json` | Preview servers call the same script before starting. |
| `.gitignore` | Ignores `.claude/.locks/` and `.claude/.dev-setup.log`. |

## Notes for reviewer

All of `.claude/` is committed, so this propagates to every new worktree automatically. The hook is confirmed firing on session resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)