### PR TITLE
Sleeker home page design with refined dark mode and interactions

### DIFF
--- a/frontend/vuejs/src/apps/home/components/organisms/sections/CTASection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/CTASection.vue
@@ -1,45 +1,53 @@
 <!-- CTA Section - Clean Apple/Cursor-inspired design -->
 <template>
   <section class="relative py-24 sm:py-32 px-6 sm:px-8 lg:px-12 bg-white dark:bg-[#0a0a0a] transition-colors duration-500 overflow-hidden">
-    
-    <div class="relative max-w-4xl mx-auto text-center">
-      
-      <!-- Content -->
-      <h2 class="text-4xl sm:text-5xl md:text-6xl font-semibold text-gray-900 dark:text-white mb-6 tracking-tight transition-colors duration-300">
-        {{ title }}
-      </h2>
-      
-      <p class="text-xl text-gray-700 dark:text-white/70 mb-10 max-w-2xl mx-auto transition-colors duration-300">
-        {{ description }}
-      </p>
-      
-      <!-- Buttons with 3D printed styling -->
-      <div class="flex flex-col sm:flex-row gap-4 justify-center">
-        <router-link 
-          :to="getAuthenticatedRedirect"
-          class="btn-3d group relative inline-flex items-center justify-center gap-3 px-8 py-4 bg-gradient-to-b from-gray-800 via-gray-900 to-gray-950 dark:from-white dark:via-gray-50 dark:to-gray-100 text-white dark:text-gray-900 rounded-full font-medium text-lg transition-all duration-300 overflow-hidden border border-gray-700/50 dark:border-gray-300/50"
-        >
-          <!-- Top edge highlight for 3D effect -->
-          <span class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/30 to-transparent dark:via-white/60"></span>
-          <!-- Bottom edge shadow for depth -->
-          <span class="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-black/30 to-transparent dark:via-black/10"></span>
-          <span class="relative">{{ primaryButtonText }}</span>
-          <svg class="relative w-5 h-5 transition-transform duration-300 group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
-          </svg>
-        </router-link>
-        
-        <router-link 
-          v-if="showSecondaryButton"
-          :to="secondaryButtonTo"
-          class="btn-3d group relative inline-flex items-center justify-center gap-2 px-8 py-4 bg-gradient-to-b from-gray-800 via-gray-900 to-gray-950 dark:from-white dark:via-gray-50 dark:to-gray-100 text-white dark:text-gray-900 rounded-full font-medium text-lg transition-all duration-300 overflow-hidden border border-gray-700/50 dark:border-gray-300/50"
-        >
-          <!-- Top edge highlight for 3D effect -->
-          <span class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/30 to-transparent dark:via-white/60"></span>
-          <!-- Bottom edge shadow for depth -->
-          <span class="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-black/30 to-transparent dark:via-black/10"></span>
-          <span class="relative">{{ secondaryButtonText }}</span>
-        </router-link>
+
+    <div class="relative max-w-5xl mx-auto">
+
+      <!-- Elegant gradient-bordered panel -->
+      <div class="relative rounded-3xl p-px bg-gradient-to-br from-gray-200 via-gray-100 to-gray-200 dark:from-white/15 dark:via-white/[0.04] dark:to-white/15 overflow-hidden">
+        <div class="relative rounded-[calc(1.5rem-1px)] bg-gray-50 dark:bg-[#0d0d0d] px-8 py-16 sm:px-12 sm:py-20 text-center overflow-hidden">
+
+          <!-- Ambient glow inside the panel -->
+          <div class="absolute inset-0 pointer-events-none">
+            <div class="absolute top-0 left-1/2 -translate-x-1/2 w-[600px] h-[300px] bg-gradient-radial from-blue-400/10 dark:from-blue-500/[0.12] via-transparent to-transparent rounded-full blur-3xl"></div>
+            <div class="absolute bottom-0 right-1/4 w-[400px] h-[300px] bg-gradient-radial from-violet-400/[0.07] dark:from-violet-500/[0.08] via-transparent to-transparent rounded-full blur-3xl"></div>
+          </div>
+
+          <!-- Content -->
+          <h2 class="relative text-4xl sm:text-5xl md:text-6xl font-semibold text-gray-900 dark:text-white mb-6 tracking-tight transition-colors duration-300">
+            {{ title }}
+          </h2>
+
+          <p class="relative text-xl text-gray-600 dark:text-white/70 mb-10 max-w-2xl mx-auto transition-colors duration-300">
+            {{ description }}
+          </p>
+
+          <!-- Buttons with 3D printed styling -->
+          <div class="relative flex flex-col sm:flex-row gap-4 justify-center">
+            <router-link
+              :to="getAuthenticatedRedirect"
+              class="btn-3d group relative inline-flex items-center justify-center gap-3 px-8 py-4 bg-gradient-to-b from-gray-800 via-gray-900 to-gray-950 dark:from-white dark:via-gray-50 dark:to-gray-100 text-white dark:text-gray-900 rounded-full font-medium text-lg transition-all duration-300 overflow-hidden border border-gray-700/50 dark:border-gray-300/50 hover:-translate-y-0.5"
+            >
+              <!-- Top edge highlight for 3D effect -->
+              <span class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/30 to-transparent dark:via-white/60"></span>
+              <!-- Bottom edge shadow for depth -->
+              <span class="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-black/30 to-transparent dark:via-black/10"></span>
+              <span class="relative">{{ primaryButtonText }}</span>
+              <svg class="relative w-5 h-5 transition-transform duration-300 group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+              </svg>
+            </router-link>
+
+            <router-link
+              v-if="showSecondaryButton"
+              :to="secondaryButtonTo"
+              class="group relative inline-flex items-center justify-center gap-2 px-8 py-4 rounded-full font-medium text-lg text-gray-900 dark:text-white border border-gray-300 dark:border-white/15 bg-white/60 dark:bg-white/[0.04] backdrop-blur-md transition-all duration-300 hover:-translate-y-0.5 hover:border-gray-400 dark:hover:border-white/25"
+            >
+              <span class="relative">{{ secondaryButtonText }}</span>
+            </router-link>
+          </div>
+        </div>
       </div>
     </div>
   </section>
@@ -84,13 +92,13 @@ export default defineComponent({
   setup(props) {
     const authStore = useAuthStore()
     const isAuthenticated = computed(() => authStore.isAuthenticated)
-    
+
     const getAuthenticatedRedirect = computed(() => {
-      return isAuthenticated.value 
+      return isAuthenticated.value
         ? (typeof props.primaryButtonTo === 'string' ? props.primaryButtonTo : '/products/imagi/projects')
         : '/auth/signin'
     })
-    
+
     return {
       isAuthenticated,
       getAuthenticatedRedirect
@@ -103,7 +111,7 @@ export default defineComponent({
 /* 3D Printed Button Effect */
 .btn-3d {
   transform: translateZ(0);
-  box-shadow: 
+  box-shadow:
     /* Tight shadow for immediate depth */
     0 2px 3px -1px rgba(0, 0, 0, 0.4),
     /* Medium shadow for body lift */
@@ -118,8 +126,19 @@ export default defineComponent({
     inset 0 -4px 8px -2px rgba(0, 0, 0, 0.3);
 }
 
+.btn-3d:hover {
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.4),
+    0 10px 20px -4px rgba(0, 0, 0, 0.38),
+    0 22px 42px -10px rgba(0, 0, 0, 0.32),
+    0 32px 60px -14px rgba(0, 0, 0, 0.24),
+    0 3px 0 -1px rgba(0, 0, 0, 0.5),
+    inset 0 2px 4px 0 rgba(255, 255, 255, 0.25),
+    inset 0 -4px 8px -2px rgba(0, 0, 0, 0.3);
+}
+
 .dark .btn-3d {
-  box-shadow: 
+  box-shadow:
     /* Tight shadow for immediate depth */
     0 2px 3px -1px rgba(0, 0, 0, 0.1),
     /* Medium shadow for body lift */
@@ -131,6 +150,17 @@ export default defineComponent({
     0 3px 0 -1px rgba(0, 0, 0, 0.15),
     /* Inset highlights */
     inset 0 3px 6px 0 rgba(255, 255, 255, 0.9),
+    inset 0 -4px 8px -2px rgba(0, 0, 0, 0.08);
+}
+
+.dark .btn-3d:hover {
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.12),
+    0 10px 20px -4px rgba(0, 0, 0, 0.12),
+    0 22px 42px -10px rgba(0, 0, 0, 0.12),
+    0 32px 60px -14px rgba(0, 0, 0, 0.1),
+    0 3px 0 -1px rgba(0, 0, 0, 0.15),
+    inset 0 3px 6px 0 rgba(255, 255, 255, 0.95),
     inset 0 -4px 8px -2px rgba(0, 0, 0, 0.08);
 }
 </style>

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/FeaturesSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/FeaturesSection.vue
@@ -1,47 +1,56 @@
 <!-- Features Section - Clean Apple/Cursor-inspired design -->
 <template>
   <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-white dark:bg-[#0a0a0a] transition-colors duration-500 overflow-hidden">
-    
+
     <!-- Subtle ambient background -->
     <div class="absolute inset-0 pointer-events-none">
-      <div class="absolute top-1/2 left-1/2 w-[800px] h-[400px] bg-gradient-radial from-gray-200/30 dark:from-white/[0.02] via-transparent to-transparent rounded-full blur-3xl transform -translate-x-1/2 -translate-y-1/2"></div>
+      <div class="absolute top-1/2 left-1/2 w-[800px] h-[400px] bg-gradient-radial from-blue-200/20 dark:from-blue-500/[0.04] via-transparent to-transparent rounded-full blur-3xl transform -translate-x-1/2 -translate-y-1/2"></div>
     </div>
-    
+
     <div class="relative max-w-6xl mx-auto">
-      
+
       <!-- Section header -->
       <div class="text-center mb-16 md:mb-20">
-        <p class="text-sm font-medium text-gray-600 dark:text-white/60 uppercase tracking-widest mb-4 transition-colors duration-300">How it works</p>
+        <span class="inline-flex items-center gap-2 px-3 py-1 mb-5 rounded-full border border-gray-200/80 dark:border-white/10 bg-white/70 dark:bg-white/[0.04] backdrop-blur-md text-xs font-semibold uppercase tracking-widest text-gray-600 dark:text-white/60 transition-colors duration-300">
+          <span class="w-1.5 h-1.5 rounded-full bg-gradient-to-r from-blue-500 to-violet-500"></span>
+          How it works
+        </span>
         <h2 class="text-4xl sm:text-5xl md:text-6xl font-semibold text-gray-900 dark:text-white mb-6 tracking-tight transition-colors duration-300">
           Your product-building partner
         </h2>
-        <p class="text-xl text-gray-700 dark:text-white/70 max-w-2xl mx-auto transition-colors duration-300">
+        <p class="text-xl text-gray-600 dark:text-white/70 max-w-2xl mx-auto transition-colors duration-300">
           Three simple tools that work together to help you build, test, and launch web applications.
         </p>
       </div>
 
       <!-- Features grid with enhanced cards -->
       <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-        
-        <div 
-          v-for="(feature, index) in features" 
-          :key="index"
-          class="relative"
-        >
-          <!-- Card with solid background -->
-          <div class="relative h-full p-8 rounded-2xl bg-white dark:bg-white border border-gray-200/80 dark:border-gray-300 crisp-card transition-colors duration-300">
-            
-            <!-- Title -->
-            <h3 class="relative text-xl font-semibold text-gray-900 dark:text-black transition-colors duration-300 mb-5 text-center">
-              {{ feature.title }}
-            </h3>
-            
-            <!-- Description -->
-            <p class="relative text-gray-600 dark:text-black leading-relaxed transition-colors duration-300 text-center">
-              {{ feature.description }}
-            </p>
 
+        <div
+          v-for="(feature, index) in features"
+          :key="index"
+          class="sleek-card group relative h-full overflow-hidden p-8 rounded-2xl bg-white dark:bg-white/[0.03] border border-gray-200/80 dark:border-white/10 transition-all duration-300"
+        >
+          <span class="card-topline"></span>
+
+          <!-- Step number + icon -->
+          <div class="relative flex items-center justify-between mb-6">
+            <div class="flex items-center justify-center w-12 h-12 rounded-xl bg-gradient-to-br from-blue-500/10 to-violet-500/10 dark:from-blue-500/20 dark:to-violet-500/20 border border-blue-500/10 dark:border-white/10 transition-all duration-300 group-hover:scale-105">
+              <i :class="[feature.icon, 'text-xl text-blue-600 dark:text-blue-300']"></i>
+            </div>
+            <span class="text-sm font-semibold text-gray-300 dark:text-white/20 tabular-nums transition-colors duration-300">0{{ index + 1 }}</span>
           </div>
+
+          <!-- Title -->
+          <h3 class="relative text-xl font-semibold text-gray-900 dark:text-white transition-colors duration-300 mb-3">
+            {{ feature.title }}
+          </h3>
+
+          <!-- Description -->
+          <p class="relative text-gray-600 dark:text-white/60 leading-relaxed transition-colors duration-300">
+            {{ feature.description }}
+          </p>
+
         </div>
 
       </div>
@@ -95,12 +104,59 @@ export default defineComponent({
 </script>
 
 <style scoped>
-/* Crisp, sharply-defined cards: hairline edge + tight layered shadow */
-.crisp-card {
+/* Crisp, sharply-defined cards: hairline edge + tight layered shadow, with subtle hover lift */
+.sleek-card {
   box-shadow:
     0 0 0 1px rgba(15, 23, 42, 0.03),
     0 1px 2px rgba(15, 23, 42, 0.06),
     0 4px 10px -2px rgba(15, 23, 42, 0.07),
     0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
+
+.sleek-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(59, 130, 246, 0.25);
+  box-shadow:
+    0 0 0 1px rgba(59, 130, 246, 0.06),
+    0 2px 4px rgba(15, 23, 42, 0.06),
+    0 10px 20px -4px rgba(15, 23, 42, 0.10),
+    0 24px 48px -14px rgba(59, 130, 246, 0.18);
+}
+
+.dark .sleek-card {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.4),
+    0 8px 24px -12px rgba(0, 0, 0, 0.6);
+}
+
+.dark .sleek-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(96, 165, 250, 0.3);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.4),
+    0 12px 32px -10px rgba(0, 0, 0, 0.7),
+    0 0 32px -8px rgba(59, 130, 246, 0.25);
+}
+
+/* Gradient accent line that appears along the top edge on hover */
+.card-topline {
+  position: absolute;
+  top: 0;
+  left: 1.5rem;
+  right: 1.5rem;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(59, 130, 246, 0.6), rgba(139, 92, 246, 0.6), transparent);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.sleek-card:hover .card-topline {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sleek-card:hover {
+    transform: none;
+  }
 }
 </style>

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/HeroSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/HeroSection.vue
@@ -1,24 +1,40 @@
 <!-- Hero Section - Clean Apple/Cursor-inspired design -->
 <template>
   <section class="relative py-32 sm:py-40 md:py-48 px-6 sm:px-8 lg:px-12 bg-white dark:bg-[#0a0a0a] transition-colors duration-500 overflow-hidden">
-    
+
+    <!-- Ambient gradient orbs for depth -->
+    <div class="absolute inset-0 pointer-events-none overflow-hidden">
+      <div class="absolute -top-32 left-1/2 -translate-x-1/2 w-[760px] h-[520px] bg-gradient-radial from-blue-400/10 dark:from-blue-500/[0.12] via-transparent to-transparent rounded-full blur-3xl"></div>
+      <div class="absolute top-1/3 -left-20 w-[420px] h-[420px] bg-gradient-radial from-violet-400/[0.07] dark:from-violet-500/[0.08] via-transparent to-transparent rounded-full blur-3xl animate-pulse-slow"></div>
+      <div class="absolute top-1/4 -right-20 w-[420px] h-[420px] bg-gradient-radial from-cyan-400/[0.06] dark:from-cyan-500/[0.07] via-transparent to-transparent rounded-full blur-3xl animate-pulse-slow"></div>
+    </div>
+
     <div class="relative max-w-4xl mx-auto text-center">
-      
+
+      <!-- Eyebrow badge -->
+      <div class="reveal flex justify-center mb-8" style="animation-delay: 0ms">
+        <span class="group inline-flex items-center gap-2 pl-2 pr-4 py-1.5 rounded-full border border-gray-200/80 dark:border-white/10 bg-white/70 dark:bg-white/[0.04] backdrop-blur-md text-xs font-medium text-gray-700 dark:text-white/70 shadow-sm transition-colors duration-300">
+          <span class="inline-flex items-center justify-center px-2 py-0.5 rounded-full bg-gradient-to-r from-blue-500 to-violet-500 text-white text-[10px] font-semibold tracking-wide">NEW</span>
+          <span>Build web apps with AI</span>
+        </span>
+      </div>
+
       <!-- Hero title -->
-      <h1 class="text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-semibold text-gray-900 dark:text-white mb-6 tracking-tight leading-[1.1] transition-colors duration-300">
-        Turn ideas into web apps
+      <h1 class="reveal text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-semibold text-gray-900 dark:text-white mb-6 tracking-tight leading-[1.05] transition-colors duration-300" style="animation-delay: 80ms">
+        Turn ideas into
+        <span class="bg-gradient-to-r from-blue-600 via-violet-500 to-cyan-500 dark:from-blue-400 dark:via-violet-400 dark:to-cyan-300 bg-clip-text text-transparent">web apps</span>
       </h1>
 
       <!-- Subtitle -->
-      <p class="text-lg sm:text-xl text-gray-700 dark:text-white/80 tracking-wide font-medium mb-10 max-w-3xl mx-auto transition-colors duration-300">
+      <p class="reveal text-lg sm:text-xl text-gray-600 dark:text-white/70 tracking-wide font-medium mb-10 max-w-2xl mx-auto leading-relaxed transition-colors duration-300" style="animation-delay: 160ms">
         Imagi is a suite of AI tools that empowers non-technical developers to build web applications. Design visually, chat with AI, and launch to the web—fast, affordable, and approachable.
       </p>
 
       <!-- CTA buttons -->
-      <div class="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+      <div class="reveal flex flex-col sm:flex-row gap-4 justify-center mb-14" style="animation-delay: 240ms">
         <router-link
           :to="startBuildingRoute"
-          class="btn-3d group relative inline-flex items-center justify-center gap-3 px-8 py-4 bg-gradient-to-b from-gray-800 via-gray-900 to-gray-950 dark:from-white dark:via-gray-50 dark:to-gray-100 text-white dark:text-gray-900 rounded-full font-medium text-lg transition-all duration-300 overflow-hidden border border-gray-700/50 dark:border-gray-300/50"
+          class="btn-3d group relative inline-flex items-center justify-center gap-3 px-8 py-4 bg-gradient-to-b from-gray-800 via-gray-900 to-gray-950 dark:from-white dark:via-gray-50 dark:to-gray-100 text-white dark:text-gray-900 rounded-full font-medium text-lg transition-all duration-300 overflow-hidden border border-gray-700/50 dark:border-gray-300/50 hover:-translate-y-0.5"
         >
           <!-- Top edge highlight for 3D effect -->
           <span class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/30 to-transparent dark:via-white/60"></span>
@@ -32,24 +48,16 @@
       </div>
 
       <!-- Value props - centered and minimal -->
-      <div class="flex flex-wrap items-center justify-center gap-3 text-xs transition-colors duration-300">
-        <span class="flex items-center gap-2 px-3.5 py-2 rounded-full bg-gray-100 dark:bg-white transition-all duration-300 whitespace-nowrap">
-          <div class="w-4 h-4 rounded-full bg-emerald-100 dark:bg-emerald-100 flex items-center justify-center transition-all duration-300">
-            <i class="fas fa-check text-[9px] text-emerald-600 dark:text-emerald-600"></i>
-          </div>
-          <span class="text-gray-900 dark:text-gray-900 font-medium">Prototype and validate ideas quickly</span>
-        </span>
-        <span class="flex items-center gap-2 px-3.5 py-2 rounded-full bg-gray-100 dark:bg-white transition-all duration-300 whitespace-nowrap">
-          <div class="w-4 h-4 rounded-full bg-emerald-100 dark:bg-emerald-100 flex items-center justify-center transition-all duration-300">
-            <i class="fas fa-check text-[9px] text-emerald-600 dark:text-emerald-600"></i>
-          </div>
-          <span class="text-gray-900 dark:text-gray-900 font-medium">No coding experience required</span>
-        </span>
-        <span class="flex items-center gap-2 px-3.5 py-2 rounded-full bg-gray-100 dark:bg-white transition-all duration-300 whitespace-nowrap">
-          <div class="w-4 h-4 rounded-full bg-emerald-100 dark:bg-emerald-100 flex items-center justify-center transition-all duration-300">
-            <i class="fas fa-check text-[9px] text-emerald-600 dark:text-emerald-600"></i>
-          </div>
-          <span class="text-gray-900 dark:text-gray-900 font-medium">Deploy to the web in minutes</span>
+      <div class="reveal flex flex-wrap items-center justify-center gap-3 text-xs transition-colors duration-300" style="animation-delay: 320ms">
+        <span
+          v-for="(prop, index) in valueProps"
+          :key="index"
+          class="flex items-center gap-2 px-3.5 py-2 rounded-full bg-white/70 dark:bg-white/[0.04] border border-gray-200/70 dark:border-white/10 backdrop-blur-md transition-all duration-300 whitespace-nowrap hover:border-gray-300 dark:hover:border-white/20"
+        >
+          <span class="w-4 h-4 rounded-full bg-emerald-100 dark:bg-emerald-500/15 flex items-center justify-center transition-all duration-300">
+            <i class="fas fa-check text-[9px] text-emerald-600 dark:text-emerald-400"></i>
+          </span>
+          <span class="text-gray-700 dark:text-white/80 font-medium">{{ prop }}</span>
         </span>
       </div>
 
@@ -72,16 +80,46 @@ export default defineComponent({
         : { name: 'login' }
     })
 
-    return { startBuildingRoute }
+    const valueProps = [
+      'Prototype and validate ideas quickly',
+      'No coding experience required',
+      'Deploy to the web in minutes'
+    ]
+
+    return { startBuildingRoute, valueProps }
   }
 })
 </script>
 
 <style scoped>
+/* Staggered entrance */
+.reveal {
+  opacity: 0;
+  animation: hero-reveal 0.7s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+@keyframes hero-reveal {
+  0% {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal {
+    opacity: 1;
+    animation: none;
+  }
+}
+
 /* 3D Printed Button Effect */
 .btn-3d {
   transform: translateZ(0);
-  box-shadow: 
+  box-shadow:
     /* Tight shadow for immediate depth */
     0 2px 3px -1px rgba(0, 0, 0, 0.4),
     /* Medium shadow for body lift */
@@ -96,8 +134,19 @@ export default defineComponent({
     inset 0 -4px 8px -2px rgba(0, 0, 0, 0.3);
 }
 
+.btn-3d:hover {
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.4),
+    0 10px 20px -4px rgba(0, 0, 0, 0.38),
+    0 22px 42px -10px rgba(0, 0, 0, 0.32),
+    0 32px 60px -14px rgba(0, 0, 0, 0.24),
+    0 3px 0 -1px rgba(0, 0, 0, 0.5),
+    inset 0 2px 4px 0 rgba(255, 255, 255, 0.25),
+    inset 0 -4px 8px -2px rgba(0, 0, 0, 0.3);
+}
+
 .dark .btn-3d {
-  box-shadow: 
+  box-shadow:
     /* Tight shadow for immediate depth */
     0 2px 3px -1px rgba(0, 0, 0, 0.1),
     /* Medium shadow for body lift */
@@ -109,6 +158,17 @@ export default defineComponent({
     0 3px 0 -1px rgba(0, 0, 0, 0.15),
     /* Inset highlights */
     inset 0 3px 6px 0 rgba(255, 255, 255, 0.9),
+    inset 0 -4px 8px -2px rgba(0, 0, 0, 0.08);
+}
+
+.dark .btn-3d:hover {
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.12),
+    0 10px 20px -4px rgba(0, 0, 0, 0.12),
+    0 22px 42px -10px rgba(0, 0, 0, 0.12),
+    0 32px 60px -14px rgba(0, 0, 0, 0.1),
+    0 3px 0 -1px rgba(0, 0, 0, 0.15),
+    inset 0 3px 6px 0 rgba(255, 255, 255, 0.95),
     inset 0 -4px 8px -2px rgba(0, 0, 0, 0.08);
 }
 </style>

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/KeyFeaturesSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/KeyFeaturesSection.vue
@@ -1,66 +1,70 @@
 <!-- Key Features Section - Clean Apple/Cursor-inspired design -->
 <template>
-  <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-gray-100 dark:bg-[#0d0d0d] transition-colors duration-500 overflow-hidden">
-    
+  <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-gray-50 dark:bg-[#0d0d0d] transition-colors duration-500 overflow-hidden">
+
     <!-- Subtle ambient glow -->
     <div class="absolute inset-0 pointer-events-none">
-      <div class="absolute top-0 right-1/4 w-[500px] h-[500px] bg-gradient-radial from-blue-500/[0.03] via-transparent to-transparent rounded-full blur-3xl"></div>
-      <div class="absolute bottom-0 left-1/4 w-[500px] h-[500px] bg-gradient-radial from-purple-500/[0.03] via-transparent to-transparent rounded-full blur-3xl"></div>
+      <div class="absolute top-0 right-1/4 w-[500px] h-[500px] bg-gradient-radial from-blue-500/[0.05] via-transparent to-transparent rounded-full blur-3xl"></div>
+      <div class="absolute bottom-0 left-1/4 w-[500px] h-[500px] bg-gradient-radial from-violet-500/[0.05] via-transparent to-transparent rounded-full blur-3xl"></div>
     </div>
-    
+
     <div class="relative max-w-6xl mx-auto">
-      
+
       <!-- Section header -->
       <div class="text-center mb-16 md:mb-20">
-        <p class="text-sm font-medium text-gray-600 dark:text-white/60 uppercase tracking-widest mb-4 transition-colors duration-300">Key Features</p>
+        <span class="inline-flex items-center gap-2 px-3 py-1 mb-5 rounded-full border border-gray-200/80 dark:border-white/10 bg-white/70 dark:bg-white/[0.04] backdrop-blur-md text-xs font-semibold uppercase tracking-widest text-gray-600 dark:text-white/60 transition-colors duration-300">
+          <span class="w-1.5 h-1.5 rounded-full bg-gradient-to-r from-blue-500 to-violet-500"></span>
+          Key Features
+        </span>
         <h2 class="text-4xl sm:text-5xl md:text-6xl font-semibold text-gray-900 dark:text-white mb-6 tracking-tight transition-colors duration-300">
           Built for everyone
         </h2>
-        <p class="text-xl text-gray-700 dark:text-white/70 max-w-2xl mx-auto transition-colors duration-300">
+        <p class="text-xl text-gray-600 dark:text-white/70 max-w-2xl mx-auto transition-colors duration-300">
           Everything you need to turn ideas into working web applications, without the complexity.
         </p>
       </div>
 
       <!-- Features grid with enhanced cards -->
       <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-        
-        <div 
-          v-for="(feature, index) in features" 
+
+        <div
+          v-for="(feature, index) in features"
           :key="index"
-          class="relative"
+          class="sleek-card group relative h-full overflow-hidden p-8 rounded-2xl bg-white dark:bg-white/[0.03] border border-gray-200/80 dark:border-white/10 transition-all duration-300"
         >
-          <!-- Card with solid background -->
-          <div class="relative h-full p-8 rounded-2xl bg-white dark:bg-white border border-gray-200/80 dark:border-gray-300 crisp-card transition-colors duration-300">
-            
-            <!-- Title -->
-            <h3 class="relative text-xl font-semibold text-gray-900 dark:text-black transition-colors duration-300 mb-5 text-center">
-              {{ feature.title }}
-            </h3>
-            
-            <!-- Description -->
-            <p class="relative text-gray-600 dark:text-black leading-relaxed mb-5 transition-colors duration-300 text-center">
-              {{ feature.description }}
-            </p>
+          <span class="card-topline"></span>
 
-            <!-- Feature highlights with green checkmarks -->
-            <div class="relative flex justify-center">
-              <ul class="space-y-3 inline-flex flex-col">
-                <li 
-                  v-for="(highlight, hIndex) in feature.highlights" 
-                  :key="hIndex"
-                  class="flex items-start gap-3"
-                >
-                  <div class="flex-shrink-0 mt-1">
-                    <div class="w-5 h-5 rounded-full bg-emerald-100 dark:bg-emerald-100 flex items-center justify-center transition-all duration-300">
-                      <i class="fas fa-check text-[10px] text-emerald-600 dark:text-emerald-600"></i>
-                    </div>
-                  </div>
-                  <span class="text-gray-600 dark:text-black text-sm transition-colors duration-300">{{ highlight }}</span>
-                </li>
-              </ul>
+          <!-- Icon -->
+          <div class="relative mb-6">
+            <div class="flex items-center justify-center w-12 h-12 rounded-xl bg-gradient-to-br from-blue-500/10 to-violet-500/10 dark:from-blue-500/20 dark:to-violet-500/20 border border-blue-500/10 dark:border-white/10 transition-all duration-300 group-hover:scale-105">
+              <i :class="[feature.icon, 'text-xl text-blue-600 dark:text-blue-300']"></i>
             </div>
-
           </div>
+
+          <!-- Title -->
+          <h3 class="relative text-xl font-semibold text-gray-900 dark:text-white transition-colors duration-300 mb-3">
+            {{ feature.title }}
+          </h3>
+
+          <!-- Description -->
+          <p class="relative text-gray-600 dark:text-white/60 leading-relaxed mb-6 transition-colors duration-300">
+            {{ feature.description }}
+          </p>
+
+          <!-- Feature highlights with green checkmarks -->
+          <ul class="relative space-y-3 pt-5 border-t border-gray-100 dark:border-white/[0.06]">
+            <li
+              v-for="(highlight, hIndex) in feature.highlights"
+              :key="hIndex"
+              class="flex items-center gap-3"
+            >
+              <span class="flex-shrink-0 w-5 h-5 rounded-full bg-emerald-100 dark:bg-emerald-500/15 flex items-center justify-center transition-all duration-300">
+                <i class="fas fa-check text-[10px] text-emerald-600 dark:text-emerald-400"></i>
+              </span>
+              <span class="text-gray-600 dark:text-white/60 text-sm transition-colors duration-300">{{ highlight }}</span>
+            </li>
+          </ul>
+
         </div>
 
       </div>
@@ -114,12 +118,59 @@ export default defineComponent({
 </script>
 
 <style scoped>
-/* Crisp, sharply-defined cards: hairline edge + tight layered shadow */
-.crisp-card {
+/* Crisp, sharply-defined cards: hairline edge + tight layered shadow, with subtle hover lift */
+.sleek-card {
   box-shadow:
     0 0 0 1px rgba(15, 23, 42, 0.03),
     0 1px 2px rgba(15, 23, 42, 0.06),
     0 4px 10px -2px rgba(15, 23, 42, 0.07),
     0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
+
+.sleek-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(59, 130, 246, 0.25);
+  box-shadow:
+    0 0 0 1px rgba(59, 130, 246, 0.06),
+    0 2px 4px rgba(15, 23, 42, 0.06),
+    0 10px 20px -4px rgba(15, 23, 42, 0.10),
+    0 24px 48px -14px rgba(59, 130, 246, 0.18);
+}
+
+.dark .sleek-card {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.4),
+    0 8px 24px -12px rgba(0, 0, 0, 0.6);
+}
+
+.dark .sleek-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(96, 165, 250, 0.3);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.4),
+    0 12px 32px -10px rgba(0, 0, 0, 0.7),
+    0 0 32px -8px rgba(59, 130, 246, 0.25);
+}
+
+/* Gradient accent line that appears along the top edge on hover */
+.card-topline {
+  position: absolute;
+  top: 0;
+  left: 1.5rem;
+  right: 1.5rem;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(59, 130, 246, 0.6), rgba(139, 92, 246, 0.6), transparent);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.sleek-card:hover .card-topline {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sleek-card:hover {
+    transform: none;
+  }
 }
 </style>

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/StatsSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/StatsSection.vue
@@ -1,52 +1,57 @@
 <!-- Stats Section - Clean Apple/Cursor-inspired design -->
 <template>
-  <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-gray-100 dark:bg-[#0d0d0d] transition-colors duration-500">
+  <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-gray-50 dark:bg-[#0d0d0d] transition-colors duration-500">
     <div class="max-w-6xl mx-auto">
-      
+
       <!-- Section header -->
       <div class="text-center mb-16">
-        <p class="text-sm font-medium text-gray-600 dark:text-white/60 uppercase tracking-widest mb-4 transition-colors duration-300">Why Imagi</p>
+        <span class="inline-flex items-center gap-2 px-3 py-1 mb-5 rounded-full border border-gray-200/80 dark:border-white/10 bg-white/70 dark:bg-white/[0.04] backdrop-blur-md text-xs font-semibold uppercase tracking-widest text-gray-600 dark:text-white/60 transition-colors duration-300">
+          <span class="w-1.5 h-1.5 rounded-full bg-gradient-to-r from-blue-500 to-violet-500"></span>
+          Why Imagi
+        </span>
         <h2 class="text-4xl sm:text-5xl md:text-6xl font-semibold text-gray-900 dark:text-white mb-6 tracking-tight transition-colors duration-300">
           Fast, affordable, approachable
         </h2>
-        <p class="text-xl text-gray-700 dark:text-white/70 max-w-2xl mx-auto transition-colors duration-300">
+        <p class="text-xl text-gray-600 dark:text-white/70 max-w-2xl mx-auto transition-colors duration-300">
           Your practical partner for building web applications. We handle the technical complexity while you focus on your ideas.
         </p>
       </div>
 
       <!-- Stats grid -->
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-3xl mx-auto mb-16">
-        <div 
-          v-for="(stat, index) in stats" 
+        <div
+          v-for="(stat, index) in stats"
           :key="index"
-          class="relative text-center p-10 rounded-2xl bg-white dark:bg-white border border-gray-200/80 dark:border-gray-300 crisp-card transition-colors duration-300"
+          class="sleek-card group relative overflow-hidden text-center p-10 rounded-2xl bg-white dark:bg-white/[0.03] border border-gray-200/80 dark:border-white/10 transition-all duration-300"
         >
-          <p class="relative text-lg text-gray-600 dark:text-black mb-3 transition-colors duration-300">{{ stat.label }}</p>
-          <div class="relative text-5xl md:text-6xl font-semibold text-gray-900 dark:text-black transition-colors duration-300">
-            {{ stat.value }}<span v-if="stat.unit" class="text-3xl text-gray-600 dark:text-black ml-1">{{ stat.unit }}</span>
+          <span class="card-topline"></span>
+          <p class="relative text-lg text-gray-500 dark:text-white/50 mb-3 transition-colors duration-300">{{ stat.label }}</p>
+          <div class="relative text-5xl md:text-6xl font-semibold tracking-tight bg-gradient-to-br from-gray-900 to-gray-600 dark:from-white dark:to-white/70 bg-clip-text text-transparent transition-colors duration-300">
+            {{ stat.value }}<span v-if="stat.unit" class="text-3xl text-gray-400 dark:text-white/40 ml-1">{{ stat.unit }}</span>
           </div>
         </div>
       </div>
 
       <!-- Use case cards -->
       <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-        <div 
-          v-for="(metric, index) in metrics" 
+        <div
+          v-for="(metric, index) in metrics"
           :key="index"
-          class="relative p-8 rounded-2xl bg-white dark:bg-white border border-gray-200/80 dark:border-gray-300 crisp-card transition-colors duration-300"
+          class="sleek-card group relative overflow-hidden p-8 rounded-2xl bg-white dark:bg-white/[0.03] border border-gray-200/80 dark:border-white/10 transition-all duration-300"
         >
+          <span class="card-topline"></span>
           <!-- Icon and Title (side by side) -->
           <div class="relative flex items-center gap-3 mb-4">
-            <div class="flex items-center justify-center w-12 h-12 rounded-2xl bg-gray-200 dark:bg-gray-200 flex-shrink-0 transition-colors duration-300">
-              <i :class="[metric.icon, 'text-xl text-gray-700 dark:text-gray-700']"></i>
+            <div class="flex items-center justify-center w-12 h-12 rounded-xl bg-gradient-to-br from-blue-500/10 to-violet-500/10 dark:from-blue-500/20 dark:to-violet-500/20 border border-blue-500/10 dark:border-white/10 flex-shrink-0 transition-all duration-300 group-hover:scale-105">
+              <i :class="[metric.icon, 'text-xl text-blue-600 dark:text-blue-300']"></i>
             </div>
-            <h3 class="text-lg font-semibold text-gray-900 dark:text-black transition-colors duration-300">
+            <h3 class="text-lg font-semibold text-gray-900 dark:text-white transition-colors duration-300">
               {{ metric.title }}
             </h3>
           </div>
-          
+
           <!-- Description -->
-          <p class="relative text-gray-600 dark:text-black text-base leading-relaxed transition-colors duration-300">
+          <p class="relative text-gray-600 dark:text-white/60 text-base leading-relaxed transition-colors duration-300">
             {{ metric.description }}
           </p>
         </div>
@@ -101,12 +106,59 @@ export default defineComponent({
 </script>
 
 <style scoped>
-/* Crisp, sharply-defined cards: hairline edge + tight layered shadow */
-.crisp-card {
+/* Crisp, sharply-defined cards: hairline edge + tight layered shadow, with subtle hover lift */
+.sleek-card {
   box-shadow:
     0 0 0 1px rgba(15, 23, 42, 0.03),
     0 1px 2px rgba(15, 23, 42, 0.06),
     0 4px 10px -2px rgba(15, 23, 42, 0.07),
     0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
+
+.sleek-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(59, 130, 246, 0.25);
+  box-shadow:
+    0 0 0 1px rgba(59, 130, 246, 0.06),
+    0 2px 4px rgba(15, 23, 42, 0.06),
+    0 10px 20px -4px rgba(15, 23, 42, 0.10),
+    0 24px 48px -14px rgba(59, 130, 246, 0.18);
+}
+
+.dark .sleek-card {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.4),
+    0 8px 24px -12px rgba(0, 0, 0, 0.6);
+}
+
+.dark .sleek-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(96, 165, 250, 0.3);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.4),
+    0 12px 32px -10px rgba(0, 0, 0, 0.7),
+    0 0 32px -8px rgba(59, 130, 246, 0.25);
+}
+
+/* Gradient accent line that appears along the top edge on hover */
+.card-topline {
+  position: absolute;
+  top: 0;
+  left: 1.5rem;
+  right: 1.5rem;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(59, 130, 246, 0.6), rgba(139, 92, 246, 0.6), transparent);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.sleek-card:hover .card-topline {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sleek-card:hover {
+    transform: none;
+  }
 }
 </style>


### PR DESCRIPTION
- Redesign dark mode cards as glassmorphic panels instead of solid white,
  fixing the jarring white-on-black look across Stats, Features, and
  Key Features sections
- Add subtle hover lift, gradient top-edge accent, and glow to all cards
- Hero: add eyebrow badge, gradient accent on headline, staggered entrance
  animation, ambient gradient orbs, and dark-mode-consistent value pills
- Add gradient pill eyebrows and icon treatments to section headers
- Wrap CTA in an elegant gradient-bordered panel with ambient glow
- Respect prefers-reduced-motion for hover/entrance effects

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VyBj33hYbrB7H8aonMkiDv