### PR TITLE
Restore baby-blue homepage design (over sleeker redesign) + remove CTA hover glow

### DIFF
--- a/frontend/vuejs/src/apps/home/components/organisms/sections/CTASection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/CTASection.vue
@@ -1,53 +1,41 @@
 <!-- CTA Section - Clean Apple/Cursor-inspired design -->
 <template>
-  <section class="relative py-24 sm:py-32 px-6 sm:px-8 lg:px-12 bg-white dark:bg-[#0a0a0a] transition-colors duration-500 overflow-hidden">
+  <section class="relative py-24 sm:py-32 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-orange-600 border-t border-orange-200/60 dark:border-orange-500/[0.12] transition-colors duration-500 overflow-hidden">
 
-    <div class="relative max-w-5xl mx-auto">
+    <div class="relative max-w-4xl mx-auto text-center">
 
-      <!-- Elegant gradient-bordered panel -->
-      <div class="relative rounded-3xl p-px bg-gradient-to-br from-gray-200 via-gray-100 to-gray-200 dark:from-white/15 dark:via-white/[0.04] dark:to-white/15 overflow-hidden">
-        <div class="relative rounded-[calc(1.5rem-1px)] bg-gray-50 dark:bg-[#0d0d0d] px-8 py-16 sm:px-12 sm:py-20 text-center overflow-hidden">
+      <!-- Content -->
+      <h2 class="text-4xl sm:text-5xl md:text-6xl font-semibold text-blue-950 dark:text-white mb-6 tracking-tight text-balance transition-colors duration-300">
+        {{ title }}
+      </h2>
 
-          <!-- Ambient glow inside the panel -->
-          <div class="absolute inset-0 pointer-events-none">
-            <div class="absolute top-0 left-1/2 -translate-x-1/2 w-[600px] h-[300px] bg-gradient-radial from-blue-400/10 dark:from-blue-500/[0.12] via-transparent to-transparent rounded-full blur-3xl"></div>
-            <div class="absolute bottom-0 right-1/4 w-[400px] h-[300px] bg-gradient-radial from-violet-400/[0.07] dark:from-violet-500/[0.08] via-transparent to-transparent rounded-full blur-3xl"></div>
-          </div>
-
-          <!-- Content -->
-          <h2 class="relative text-4xl sm:text-5xl md:text-6xl font-semibold text-gray-900 dark:text-white mb-6 tracking-tight transition-colors duration-300">
-            {{ title }}
-          </h2>
-
-          <p class="relative text-xl text-gray-600 dark:text-white/70 mb-10 max-w-2xl mx-auto transition-colors duration-300">
-            {{ description }}
-          </p>
-
-          <!-- Buttons with 3D printed styling -->
-          <div class="relative flex flex-col sm:flex-row gap-4 justify-center">
-            <router-link
-              :to="getAuthenticatedRedirect"
-              class="btn-3d group relative inline-flex items-center justify-center gap-3 px-8 py-4 bg-gradient-to-b from-gray-800 via-gray-900 to-gray-950 dark:from-white dark:via-gray-50 dark:to-gray-100 text-white dark:text-gray-900 rounded-full font-medium text-lg transition-all duration-300 overflow-hidden border border-gray-700/50 dark:border-gray-300/50 hover:-translate-y-0.5"
-            >
-              <!-- Top edge highlight for 3D effect -->
-              <span class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/30 to-transparent dark:via-white/60"></span>
-              <!-- Bottom edge shadow for depth -->
-              <span class="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-black/30 to-transparent dark:via-black/10"></span>
-              <span class="relative">{{ primaryButtonText }}</span>
-              <svg class="relative w-5 h-5 transition-transform duration-300 group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
-              </svg>
-            </router-link>
-
-            <router-link
-              v-if="showSecondaryButton"
-              :to="secondaryButtonTo"
-              class="group relative inline-flex items-center justify-center gap-2 px-8 py-4 rounded-full font-medium text-lg text-gray-900 dark:text-white border border-gray-300 dark:border-white/15 bg-white/60 dark:bg-white/[0.04] backdrop-blur-md transition-all duration-300 hover:-translate-y-0.5 hover:border-gray-400 dark:hover:border-white/25"
-            >
-              <span class="relative">{{ secondaryButtonText }}</span>
-            </router-link>
-          </div>
-        </div>
+      <p class="text-xl text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty mb-10 max-w-2xl mx-auto transition-colors duration-300">
+        {{ description }}
+      </p>
+      
+      <!-- Buttons with 3D printed styling -->
+      <div class="flex flex-col sm:flex-row gap-4 justify-center">
+        <router-link
+          :to="getAuthenticatedRedirect"
+          class="btn-3d btn-accent group relative inline-flex items-center justify-center gap-3 px-8 py-4 text-blue-950 rounded-full font-medium text-lg overflow-hidden border border-white/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
+        >
+          <!-- Top edge highlight for 3D effect -->
+          <span class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/70 to-transparent"></span>
+          <!-- Bottom edge shadow for depth -->
+          <span class="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-blue-900/15 to-transparent"></span>
+          <span class="relative">{{ primaryButtonText }}</span>
+          <svg class="relative w-5 h-5 transition-transform duration-300 group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+          </svg>
+        </router-link>
+        
+        <router-link 
+          v-if="showSecondaryButton"
+          :to="secondaryButtonTo"
+          class="group relative inline-flex items-center justify-center gap-2 px-8 py-4 bg-transparent text-orange-700 dark:text-orange-300 rounded-full font-medium text-lg overflow-hidden border-2 border-orange-500/60 dark:border-orange-400/50 hover:bg-orange-50 dark:hover:bg-orange-500/10 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500/40 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
+        >
+          <span class="relative">{{ secondaryButtonText }}</span>
+        </router-link>
       </div>
     </div>
   </section>
@@ -92,13 +80,13 @@ export default defineComponent({
   setup(props) {
     const authStore = useAuthStore()
     const isAuthenticated = computed(() => authStore.isAuthenticated)
-
+    
     const getAuthenticatedRedirect = computed(() => {
-      return isAuthenticated.value
+      return isAuthenticated.value 
         ? (typeof props.primaryButtonTo === 'string' ? props.primaryButtonTo : '/products/imagi/projects')
         : '/auth/signin'
     })
-
+    
     return {
       isAuthenticated,
       getAuthenticatedRedirect
@@ -110,57 +98,27 @@ export default defineComponent({
 <style scoped>
 /* Soft 3D button effect - tight, layered, crisp. Blue-tinted shadows to suit the light baby-blue fill. */
 .btn-3d {
-  transform: translateZ(0);
+  transform: translateY(0) translateZ(0);
+  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
   box-shadow:
-    /* Tight shadow for immediate depth */
-    0 2px 3px -1px rgba(0, 0, 0, 0.4),
-    /* Medium shadow for body lift */
-    0 6px 12px -3px rgba(0, 0, 0, 0.35),
-    /* Large diffuse shadow */
-    0 16px 32px -8px rgba(0, 0, 0, 0.3),
-    0 24px 48px -12px rgba(0, 0, 0, 0.2),
-    /* Bottom edge thickness */
-    0 3px 0 -1px rgba(0, 0, 0, 0.5),
-    /* Inset highlights */
-    inset 0 2px 4px 0 rgba(255, 255, 255, 0.2),
-    inset 0 -4px 8px -2px rgba(0, 0, 0, 0.3);
+    0 1px 2px rgba(30, 58, 138, 0.14),
+    0 4px 10px -2px rgba(30, 58, 138, 0.16),
+    0 10px 20px -6px rgba(30, 58, 138, 0.18),
+    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
+    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.12);
 }
 
-.btn-3d:hover {
-  box-shadow:
-    0 4px 6px -1px rgba(0, 0, 0, 0.4),
-    0 10px 20px -4px rgba(0, 0, 0, 0.38),
-    0 22px 42px -10px rgba(0, 0, 0, 0.32),
-    0 32px 60px -14px rgba(0, 0, 0, 0.24),
-    0 3px 0 -1px rgba(0, 0, 0, 0.5),
-    inset 0 2px 4px 0 rgba(255, 255, 255, 0.25),
-    inset 0 -4px 8px -2px rgba(0, 0, 0, 0.3);
+.btn-3d:active {
+  transform: translateY(0) translateZ(0);
+  transition-duration: 0.1s;
 }
 
-.dark .btn-3d {
-  box-shadow:
-    /* Tight shadow for immediate depth */
-    0 2px 3px -1px rgba(0, 0, 0, 0.1),
-    /* Medium shadow for body lift */
-    0 6px 12px -3px rgba(0, 0, 0, 0.1),
-    /* Large diffuse shadow */
-    0 16px 32px -8px rgba(0, 0, 0, 0.1),
-    0 24px 48px -12px rgba(0, 0, 0, 0.08),
-    /* Bottom edge thickness */
-    0 3px 0 -1px rgba(0, 0, 0, 0.15),
-    /* Inset highlights */
-    inset 0 3px 6px 0 rgba(255, 255, 255, 0.9),
-    inset 0 -4px 8px -2px rgba(0, 0, 0, 0.08);
+/* Soft baby-blue gradient fill */
+.btn-accent {
+  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
 }
 
-.dark .btn-3d:hover {
-  box-shadow:
-    0 4px 6px -1px rgba(0, 0, 0, 0.12),
-    0 10px 20px -4px rgba(0, 0, 0, 0.12),
-    0 22px 42px -10px rgba(0, 0, 0, 0.12),
-    0 32px 60px -14px rgba(0, 0, 0, 0.1),
-    0 3px 0 -1px rgba(0, 0, 0, 0.15),
-    inset 0 3px 6px 0 rgba(255, 255, 255, 0.95),
-    inset 0 -4px 8px -2px rgba(0, 0, 0, 0.08);
+.dark .btn-accent {
+  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
 }
 </style>

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/FeaturesSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/FeaturesSection.vue
@@ -1,24 +1,16 @@
 <!-- Features Section - Clean Apple/Cursor-inspired design -->
 <template>
-  <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-white dark:bg-[#0a0a0a] transition-colors duration-500 overflow-hidden">
-
-    <!-- Subtle ambient background -->
-    <div class="absolute inset-0 pointer-events-none">
-      <div class="absolute top-1/2 left-1/2 w-[800px] h-[400px] bg-gradient-radial from-blue-200/20 dark:from-blue-500/[0.04] via-transparent to-transparent rounded-full blur-3xl transform -translate-x-1/2 -translate-y-1/2"></div>
-    </div>
+  <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-orange-600 border-t border-orange-200/60 dark:border-orange-500/[0.12] transition-colors duration-500 overflow-hidden">
 
     <div class="relative max-w-6xl mx-auto">
 
       <!-- Section header -->
       <div class="text-center mb-16 md:mb-20">
-        <span class="inline-flex items-center gap-2 px-3 py-1 mb-5 rounded-full border border-gray-200/80 dark:border-white/10 bg-white/70 dark:bg-white/[0.04] backdrop-blur-md text-xs font-semibold uppercase tracking-widest text-gray-600 dark:text-white/60 transition-colors duration-300">
-          <span class="w-1.5 h-1.5 rounded-full bg-gradient-to-r from-blue-500 to-violet-500"></span>
-          How it works
-        </span>
-        <h2 class="text-4xl sm:text-5xl md:text-6xl font-semibold text-gray-900 dark:text-white mb-6 tracking-tight transition-colors duration-300">
+        <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-blue-200/70 dark:border-blue-400/30 bg-blue-50/80 dark:bg-blue-600 text-xs font-semibold text-blue-700 dark:text-white uppercase tracking-[0.18em] mb-5 transition-colors duration-300">How it works</p>
+        <h2 class="text-4xl sm:text-5xl md:text-6xl font-semibold text-blue-950 dark:text-white mb-6 tracking-tight text-balance transition-colors duration-300">
           Your product-building partner
         </h2>
-        <p class="text-xl text-gray-600 dark:text-white/70 max-w-2xl mx-auto transition-colors duration-300">
+        <p class="text-xl text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty max-w-2xl mx-auto transition-colors duration-300">
           Three simple tools that work together to help you build, test, and launch web applications.
         </p>
       </div>
@@ -29,28 +21,33 @@
         <div
           v-for="(feature, index) in features"
           :key="index"
-          class="sleek-card group relative h-full overflow-hidden p-8 rounded-2xl bg-white dark:bg-white/[0.03] border border-gray-200/80 dark:border-white/10 transition-all duration-300"
+          class="relative"
         >
-          <span class="card-topline"></span>
+          <!-- Card with tinted background matching its accent color -->
+          <div
+            class="relative h-full p-8 rounded-2xl border crisp-card transition-colors duration-300"
+            :class="index % 2 === 1 ? 'bg-white border-orange-200/70' : 'bg-white border-blue-200/70'"
+          >
 
-          <!-- Step number + icon -->
-          <div class="relative flex items-center justify-between mb-6">
-            <div class="flex items-center justify-center w-12 h-12 rounded-xl bg-gradient-to-br from-blue-500/10 to-violet-500/10 dark:from-blue-500/20 dark:to-violet-500/20 border border-blue-500/10 dark:border-white/10 transition-all duration-300 group-hover:scale-105">
-              <i :class="[feature.icon, 'text-xl text-blue-600 dark:text-blue-300']"></i>
+            <!-- Icon -->
+            <div
+              class="relative flex items-center justify-center w-12 h-12 rounded-xl mx-auto mb-5 ring-1 transition-colors duration-300"
+              :class="index % 2 === 1 ? 'bg-orange-100 ring-orange-900/[0.08]' : 'bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] ring-blue-900/[0.08]'"
+            >
+              <i :class="[feature.icon, 'text-lg', index % 2 === 1 ? 'text-orange-600' : 'text-blue-600']"></i>
             </div>
-            <span class="text-sm font-semibold text-gray-300 dark:text-white/20 tabular-nums transition-colors duration-300">0{{ index + 1 }}</span>
+
+            <!-- Title -->
+            <h3 class="relative text-xl font-semibold tracking-tight text-blue-950 transition-colors duration-300 mb-4 text-center">
+              {{ feature.title }}
+            </h3>
+
+            <!-- Description -->
+            <p class="relative text-blue-950/70 leading-relaxed text-pretty transition-colors duration-300 text-center">
+              {{ feature.description }}
+            </p>
+
           </div>
-
-          <!-- Title -->
-          <h3 class="relative text-xl font-semibold text-gray-900 dark:text-white transition-colors duration-300 mb-3">
-            {{ feature.title }}
-          </h3>
-
-          <!-- Description -->
-          <p class="relative text-gray-600 dark:text-white/60 leading-relaxed transition-colors duration-300">
-            {{ feature.description }}
-          </p>
-
         </div>
 
       </div>
@@ -104,59 +101,12 @@ export default defineComponent({
 </script>
 
 <style scoped>
-/* Crisp, sharply-defined cards: hairline edge + tight layered shadow, with subtle hover lift */
-.sleek-card {
+/* Crisp, sharply-defined cards: hairline edge + tight layered shadow */
+.crisp-card {
   box-shadow:
     0 0 0 1px rgba(15, 23, 42, 0.03),
     0 1px 2px rgba(15, 23, 42, 0.06),
     0 4px 10px -2px rgba(15, 23, 42, 0.07),
     0 12px 28px -10px rgba(15, 23, 42, 0.10);
-}
-
-.sleek-card:hover {
-  transform: translateY(-4px);
-  border-color: rgba(59, 130, 246, 0.25);
-  box-shadow:
-    0 0 0 1px rgba(59, 130, 246, 0.06),
-    0 2px 4px rgba(15, 23, 42, 0.06),
-    0 10px 20px -4px rgba(15, 23, 42, 0.10),
-    0 24px 48px -14px rgba(59, 130, 246, 0.18);
-}
-
-.dark .sleek-card {
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.4),
-    0 8px 24px -12px rgba(0, 0, 0, 0.6);
-}
-
-.dark .sleek-card:hover {
-  transform: translateY(-4px);
-  border-color: rgba(96, 165, 250, 0.3);
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.4),
-    0 12px 32px -10px rgba(0, 0, 0, 0.7),
-    0 0 32px -8px rgba(59, 130, 246, 0.25);
-}
-
-/* Gradient accent line that appears along the top edge on hover */
-.card-topline {
-  position: absolute;
-  top: 0;
-  left: 1.5rem;
-  right: 1.5rem;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(59, 130, 246, 0.6), rgba(139, 92, 246, 0.6), transparent);
-  opacity: 0;
-  transition: opacity 0.3s ease;
-}
-
-.sleek-card:hover .card-topline {
-  opacity: 1;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .sleek-card:hover {
-    transform: none;
-  }
 }
 </style>

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/HeroSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/HeroSection.vue
@@ -1,40 +1,24 @@
 <!-- Hero Section - Clean Apple/Cursor-inspired design -->
 <template>
-  <section class="relative py-32 sm:py-40 md:py-48 px-6 sm:px-8 lg:px-12 bg-white dark:bg-[#0a0a0a] transition-colors duration-500 overflow-hidden">
-
-    <!-- Ambient gradient orbs for depth -->
-    <div class="absolute inset-0 pointer-events-none overflow-hidden">
-      <div class="absolute -top-32 left-1/2 -translate-x-1/2 w-[760px] h-[520px] bg-gradient-radial from-blue-400/10 dark:from-blue-500/[0.12] via-transparent to-transparent rounded-full blur-3xl"></div>
-      <div class="absolute top-1/3 -left-20 w-[420px] h-[420px] bg-gradient-radial from-violet-400/[0.07] dark:from-violet-500/[0.08] via-transparent to-transparent rounded-full blur-3xl animate-pulse-slow"></div>
-      <div class="absolute top-1/4 -right-20 w-[420px] h-[420px] bg-gradient-radial from-cyan-400/[0.06] dark:from-cyan-500/[0.07] via-transparent to-transparent rounded-full blur-3xl animate-pulse-slow"></div>
-    </div>
+  <section class="relative py-32 sm:py-40 md:py-48 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-orange-600 transition-colors duration-500 overflow-hidden">
 
     <div class="relative max-w-4xl mx-auto text-center">
 
-      <!-- Eyebrow badge -->
-      <div class="reveal flex justify-center mb-8" style="animation-delay: 0ms">
-        <span class="group inline-flex items-center gap-2 pl-2 pr-4 py-1.5 rounded-full border border-gray-200/80 dark:border-white/10 bg-white/70 dark:bg-white/[0.04] backdrop-blur-md text-xs font-medium text-gray-700 dark:text-white/70 shadow-sm transition-colors duration-300">
-          <span class="inline-flex items-center justify-center px-2 py-0.5 rounded-full bg-gradient-to-r from-blue-500 to-violet-500 text-white text-[10px] font-semibold tracking-wide">NEW</span>
-          <span>Build web apps with AI</span>
-        </span>
-      </div>
-
       <!-- Hero title -->
-      <h1 class="reveal text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-semibold text-gray-900 dark:text-white mb-6 tracking-tight leading-[1.05] transition-colors duration-300" style="animation-delay: 80ms">
-        Turn ideas into
-        <span class="bg-gradient-to-r from-blue-600 via-violet-500 to-cyan-500 dark:from-blue-400 dark:via-violet-400 dark:to-cyan-300 bg-clip-text text-transparent">web apps</span>
+      <h1 class="text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-semibold mb-6 tracking-[-0.025em] leading-[1.08] text-balance text-blue-950 dark:text-white">
+        Turn ideas into web apps
       </h1>
 
       <!-- Subtitle -->
-      <p class="reveal text-lg sm:text-xl text-gray-600 dark:text-white/70 tracking-wide font-medium mb-10 max-w-2xl mx-auto leading-relaxed transition-colors duration-300" style="animation-delay: 160ms">
+      <p class="text-lg sm:text-xl text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty mb-10 max-w-3xl mx-auto transition-colors duration-300">
         Imagi is a suite of AI tools that empowers non-technical developers to build web applications. Design visually, chat with AI, and launch to the web—fast, affordable, and approachable.
       </p>
 
       <!-- CTA buttons -->
-      <div class="reveal flex flex-col sm:flex-row gap-4 justify-center mb-14" style="animation-delay: 240ms">
+      <div class="flex flex-col sm:flex-row gap-4 justify-center mb-12">
         <router-link
           :to="startBuildingRoute"
-          class="btn-3d group relative inline-flex items-center justify-center gap-3 px-8 py-4 bg-gradient-to-b from-gray-800 via-gray-900 to-gray-950 dark:from-white dark:via-gray-50 dark:to-gray-100 text-white dark:text-gray-900 rounded-full font-medium text-lg transition-all duration-300 overflow-hidden border border-gray-700/50 dark:border-gray-300/50 hover:-translate-y-0.5"
+          class="btn-3d btn-accent group relative inline-flex items-center justify-center gap-3 px-8 py-4 text-blue-950 rounded-full font-medium text-lg overflow-hidden border border-white/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
         >
           <!-- Top edge highlight for 3D effect -->
           <span class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/70 to-transparent"></span>
@@ -48,16 +32,16 @@
       </div>
 
       <!-- Value props - centered and minimal -->
-      <div class="reveal flex flex-wrap items-center justify-center gap-3 text-xs transition-colors duration-300" style="animation-delay: 320ms">
+      <div class="flex flex-wrap items-center justify-center gap-3 text-xs transition-colors duration-300">
         <span
           v-for="(prop, index) in valueProps"
           :key="index"
-          class="flex items-center gap-2 px-3.5 py-2 rounded-full bg-white/70 dark:bg-white/[0.04] border border-gray-200/70 dark:border-white/10 backdrop-blur-md transition-all duration-300 whitespace-nowrap hover:border-gray-300 dark:hover:border-white/20"
+          class="value-pill flex items-center gap-2 px-3.5 py-2 rounded-full bg-white dark:bg-white border border-gray-200/90 dark:border-white/20 transition-all duration-300 whitespace-nowrap"
         >
-          <span class="w-4 h-4 rounded-full bg-emerald-100 dark:bg-emerald-500/15 flex items-center justify-center transition-all duration-300">
-            <i class="fas fa-check text-[9px] text-emerald-600 dark:text-emerald-400"></i>
+          <span class="w-4 h-4 rounded-full bg-orange-100 ring-1 ring-orange-200/80 flex items-center justify-center transition-all duration-300">
+            <i class="fas fa-check text-[9px] text-orange-600"></i>
           </span>
-          <span class="text-gray-700 dark:text-white/80 font-medium">{{ prop }}</span>
+          <span class="text-gray-800 dark:text-gray-900 font-medium">{{ prop }}</span>
         </span>
       </div>
 
@@ -92,83 +76,36 @@ export default defineComponent({
 </script>
 
 <style scoped>
-/* Staggered entrance */
-.reveal {
-  opacity: 0;
-  animation: hero-reveal 0.7s cubic-bezier(0.22, 1, 0.36, 1) forwards;
-}
-
-@keyframes hero-reveal {
-  0% {
-    opacity: 0;
-    transform: translateY(16px);
-  }
-  100% {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .reveal {
-    opacity: 1;
-    animation: none;
-  }
-}
-
-/* 3D Printed Button Effect */
+/* Soft 3D button effect - tight, layered, crisp. Blue-tinted shadows to suit the light baby-blue fill. */
 .btn-3d {
-  transform: translateZ(0);
+  transform: translateY(0) translateZ(0);
+  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
   box-shadow:
-    /* Tight shadow for immediate depth */
-    0 2px 3px -1px rgba(0, 0, 0, 0.4),
-    /* Medium shadow for body lift */
-    0 6px 12px -3px rgba(0, 0, 0, 0.35),
-    /* Large diffuse shadow */
-    0 16px 32px -8px rgba(0, 0, 0, 0.3),
-    0 24px 48px -12px rgba(0, 0, 0, 0.2),
-    /* Bottom edge thickness */
-    0 3px 0 -1px rgba(0, 0, 0, 0.5),
-    /* Inset highlights */
-    inset 0 2px 4px 0 rgba(255, 255, 255, 0.2),
-    inset 0 -4px 8px -2px rgba(0, 0, 0, 0.3);
+    0 1px 2px rgba(30, 58, 138, 0.14),
+    0 4px 10px -2px rgba(30, 58, 138, 0.16),
+    0 10px 20px -6px rgba(30, 58, 138, 0.18),
+    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
+    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.12);
 }
 
-.btn-3d:hover {
-  box-shadow:
-    0 4px 6px -1px rgba(0, 0, 0, 0.4),
-    0 10px 20px -4px rgba(0, 0, 0, 0.38),
-    0 22px 42px -10px rgba(0, 0, 0, 0.32),
-    0 32px 60px -14px rgba(0, 0, 0, 0.24),
-    0 3px 0 -1px rgba(0, 0, 0, 0.5),
-    inset 0 2px 4px 0 rgba(255, 255, 255, 0.25),
-    inset 0 -4px 8px -2px rgba(0, 0, 0, 0.3);
+.btn-3d:active {
+  transform: translateY(0) translateZ(0);
+  transition-duration: 0.1s;
 }
 
-.dark .btn-3d {
-  box-shadow:
-    /* Tight shadow for immediate depth */
-    0 2px 3px -1px rgba(0, 0, 0, 0.1),
-    /* Medium shadow for body lift */
-    0 6px 12px -3px rgba(0, 0, 0, 0.1),
-    /* Large diffuse shadow */
-    0 16px 32px -8px rgba(0, 0, 0, 0.1),
-    0 24px 48px -12px rgba(0, 0, 0, 0.08),
-    /* Bottom edge thickness */
-    0 3px 0 -1px rgba(0, 0, 0, 0.15),
-    /* Inset highlights */
-    inset 0 3px 6px 0 rgba(255, 255, 255, 0.9),
-    inset 0 -4px 8px -2px rgba(0, 0, 0, 0.08);
+/* Soft baby-blue gradient fill */
+.btn-accent {
+  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
 }
 
-.dark .btn-3d:hover {
+.dark .btn-accent {
+  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
+}
+
+/* Hairline-edged pills with a whisper of depth */
+.value-pill {
   box-shadow:
-    0 4px 6px -1px rgba(0, 0, 0, 0.12),
-    0 10px 20px -4px rgba(0, 0, 0, 0.12),
-    0 22px 42px -10px rgba(0, 0, 0, 0.12),
-    0 32px 60px -14px rgba(0, 0, 0, 0.1),
-    0 3px 0 -1px rgba(0, 0, 0, 0.15),
-    inset 0 3px 6px 0 rgba(255, 255, 255, 0.95),
-    inset 0 -4px 8px -2px rgba(0, 0, 0, 0.08);
+    0 1px 2px rgba(15, 23, 42, 0.05),
+    0 2px 6px -2px rgba(15, 23, 42, 0.06);
 }
 </style>

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/KeyFeaturesSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/KeyFeaturesSection.vue
@@ -1,25 +1,16 @@
 <!-- Key Features Section - Clean Apple/Cursor-inspired design -->
 <template>
-  <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-gray-50 dark:bg-[#0d0d0d] transition-colors duration-500 overflow-hidden">
-
-    <!-- Subtle ambient glow -->
-    <div class="absolute inset-0 pointer-events-none">
-      <div class="absolute top-0 right-1/4 w-[500px] h-[500px] bg-gradient-radial from-blue-500/[0.05] via-transparent to-transparent rounded-full blur-3xl"></div>
-      <div class="absolute bottom-0 left-1/4 w-[500px] h-[500px] bg-gradient-radial from-violet-500/[0.05] via-transparent to-transparent rounded-full blur-3xl"></div>
-    </div>
+  <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-blue-50 dark:bg-blue-400/[0.16] border-t border-blue-200/60 dark:border-blue-500/[0.12] transition-colors duration-500 overflow-hidden">
 
     <div class="relative max-w-6xl mx-auto">
 
       <!-- Section header -->
       <div class="text-center mb-16 md:mb-20">
-        <span class="inline-flex items-center gap-2 px-3 py-1 mb-5 rounded-full border border-gray-200/80 dark:border-white/10 bg-white/70 dark:bg-white/[0.04] backdrop-blur-md text-xs font-semibold uppercase tracking-widest text-gray-600 dark:text-white/60 transition-colors duration-300">
-          <span class="w-1.5 h-1.5 rounded-full bg-gradient-to-r from-blue-500 to-violet-500"></span>
-          Key Features
-        </span>
-        <h2 class="text-4xl sm:text-5xl md:text-6xl font-semibold text-gray-900 dark:text-white mb-6 tracking-tight transition-colors duration-300">
+        <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-orange-200/70 dark:border-orange-400/30 bg-orange-50/80 dark:bg-orange-600 text-xs font-semibold text-orange-700 dark:text-white uppercase tracking-[0.18em] mb-5 transition-colors duration-300">Key Features</p>
+        <h2 class="text-4xl sm:text-5xl md:text-6xl font-semibold text-blue-950 dark:text-white mb-6 tracking-tight text-balance transition-colors duration-300">
           Built for everyone
         </h2>
-        <p class="text-xl text-gray-600 dark:text-white/70 max-w-2xl mx-auto transition-colors duration-300">
+        <p class="text-xl text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty max-w-2xl mx-auto transition-colors duration-300">
           Everything you need to turn ideas into working web applications, without the complexity.
         </p>
       </div>
@@ -30,41 +21,46 @@
         <div
           v-for="(feature, index) in features"
           :key="index"
-          class="sleek-card group relative h-full overflow-hidden p-8 rounded-2xl bg-white dark:bg-white/[0.03] border border-gray-200/80 dark:border-white/10 transition-all duration-300"
+          class="relative"
         >
-          <span class="card-topline"></span>
+          <!-- Card with tinted background alternating blue / orange -->
+          <div
+            class="relative h-full p-8 rounded-2xl border crisp-card transition-colors duration-300"
+            :class="index % 2 === 1 ? 'bg-white border-blue-200/70' : 'bg-white border-orange-200/70'"
+          >
 
-          <!-- Icon -->
-          <div class="relative mb-6">
-            <div class="flex items-center justify-center w-12 h-12 rounded-xl bg-gradient-to-br from-blue-500/10 to-violet-500/10 dark:from-blue-500/20 dark:to-violet-500/20 border border-blue-500/10 dark:border-white/10 transition-all duration-300 group-hover:scale-105">
-              <i :class="[feature.icon, 'text-xl text-blue-600 dark:text-blue-300']"></i>
+            <!-- Title -->
+            <h3 class="relative text-xl font-semibold tracking-tight text-blue-950 transition-colors duration-300 mb-4 text-center">
+              {{ feature.title }}
+            </h3>
+
+            <!-- Description -->
+            <p class="relative text-blue-950/70 leading-relaxed text-pretty mb-6 transition-colors duration-300 text-center">
+              {{ feature.description }}
+            </p>
+
+            <!-- Feature highlights with accent-colored checkmarks -->
+            <div class="relative flex justify-center">
+              <ul class="space-y-3 inline-flex flex-col">
+                <li
+                  v-for="(highlight, hIndex) in feature.highlights"
+                  :key="hIndex"
+                  class="flex items-start gap-3"
+                >
+                  <div class="flex-shrink-0 mt-0.5">
+                    <div
+                      class="w-5 h-5 rounded-full ring-1 flex items-center justify-center transition-all duration-300"
+                      :class="index % 2 === 1 ? 'bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] ring-blue-200/80' : 'bg-orange-100 ring-orange-200/80'"
+                    >
+                      <i class="fas fa-check text-[10px]" :class="index % 2 === 1 ? 'text-blue-600' : 'text-orange-600'"></i>
+                    </div>
+                  </div>
+                  <span class="text-blue-950/70 text-sm leading-relaxed transition-colors duration-300">{{ highlight }}</span>
+                </li>
+              </ul>
             </div>
+
           </div>
-
-          <!-- Title -->
-          <h3 class="relative text-xl font-semibold text-gray-900 dark:text-white transition-colors duration-300 mb-3">
-            {{ feature.title }}
-          </h3>
-
-          <!-- Description -->
-          <p class="relative text-gray-600 dark:text-white/60 leading-relaxed mb-6 transition-colors duration-300">
-            {{ feature.description }}
-          </p>
-
-          <!-- Feature highlights with green checkmarks -->
-          <ul class="relative space-y-3 pt-5 border-t border-gray-100 dark:border-white/[0.06]">
-            <li
-              v-for="(highlight, hIndex) in feature.highlights"
-              :key="hIndex"
-              class="flex items-center gap-3"
-            >
-              <span class="flex-shrink-0 w-5 h-5 rounded-full bg-emerald-100 dark:bg-emerald-500/15 flex items-center justify-center transition-all duration-300">
-                <i class="fas fa-check text-[10px] text-emerald-600 dark:text-emerald-400"></i>
-              </span>
-              <span class="text-gray-600 dark:text-white/60 text-sm transition-colors duration-300">{{ highlight }}</span>
-            </li>
-          </ul>
-
         </div>
 
       </div>
@@ -118,59 +114,12 @@ export default defineComponent({
 </script>
 
 <style scoped>
-/* Crisp, sharply-defined cards: hairline edge + tight layered shadow, with subtle hover lift */
-.sleek-card {
+/* Crisp, sharply-defined cards: hairline edge + tight layered shadow */
+.crisp-card {
   box-shadow:
     0 0 0 1px rgba(15, 23, 42, 0.03),
     0 1px 2px rgba(15, 23, 42, 0.06),
     0 4px 10px -2px rgba(15, 23, 42, 0.07),
     0 12px 28px -10px rgba(15, 23, 42, 0.10);
-}
-
-.sleek-card:hover {
-  transform: translateY(-4px);
-  border-color: rgba(59, 130, 246, 0.25);
-  box-shadow:
-    0 0 0 1px rgba(59, 130, 246, 0.06),
-    0 2px 4px rgba(15, 23, 42, 0.06),
-    0 10px 20px -4px rgba(15, 23, 42, 0.10),
-    0 24px 48px -14px rgba(59, 130, 246, 0.18);
-}
-
-.dark .sleek-card {
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.4),
-    0 8px 24px -12px rgba(0, 0, 0, 0.6);
-}
-
-.dark .sleek-card:hover {
-  transform: translateY(-4px);
-  border-color: rgba(96, 165, 250, 0.3);
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.4),
-    0 12px 32px -10px rgba(0, 0, 0, 0.7),
-    0 0 32px -8px rgba(59, 130, 246, 0.25);
-}
-
-/* Gradient accent line that appears along the top edge on hover */
-.card-topline {
-  position: absolute;
-  top: 0;
-  left: 1.5rem;
-  right: 1.5rem;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(59, 130, 246, 0.6), rgba(139, 92, 246, 0.6), transparent);
-  opacity: 0;
-  transition: opacity 0.3s ease;
-}
-
-.sleek-card:hover .card-topline {
-  opacity: 1;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .sleek-card:hover {
-    transform: none;
-  }
 }
 </style>

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/StatsSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/StatsSection.vue
@@ -1,18 +1,15 @@
 <!-- Stats Section - Clean Apple/Cursor-inspired design -->
 <template>
-  <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-gray-50 dark:bg-[#0d0d0d] transition-colors duration-500">
+  <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-blue-50 dark:bg-blue-400/[0.16] border-t border-blue-200/60 dark:border-blue-500/[0.12] transition-colors duration-500">
     <div class="max-w-6xl mx-auto">
 
       <!-- Section header -->
       <div class="text-center mb-16">
-        <span class="inline-flex items-center gap-2 px-3 py-1 mb-5 rounded-full border border-gray-200/80 dark:border-white/10 bg-white/70 dark:bg-white/[0.04] backdrop-blur-md text-xs font-semibold uppercase tracking-widest text-gray-600 dark:text-white/60 transition-colors duration-300">
-          <span class="w-1.5 h-1.5 rounded-full bg-gradient-to-r from-blue-500 to-violet-500"></span>
-          Why Imagi
-        </span>
-        <h2 class="text-4xl sm:text-5xl md:text-6xl font-semibold text-gray-900 dark:text-white mb-6 tracking-tight transition-colors duration-300">
+        <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-orange-200/70 dark:border-orange-400/30 bg-orange-50/80 dark:bg-orange-600 text-xs font-semibold text-orange-700 dark:text-white uppercase tracking-[0.18em] mb-5 transition-colors duration-300">Why Imagi</p>
+        <h2 class="text-4xl sm:text-5xl md:text-6xl font-semibold text-blue-950 dark:text-white mb-6 tracking-tight text-balance transition-colors duration-300">
           Fast, affordable, approachable
         </h2>
-        <p class="text-xl text-gray-600 dark:text-white/70 max-w-2xl mx-auto transition-colors duration-300">
+        <p class="text-xl text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty max-w-2xl mx-auto transition-colors duration-300">
           Your practical partner for building web applications. We handle the technical complexity while you focus on your ideas.
         </p>
       </div>
@@ -22,30 +19,39 @@
         <div
           v-for="(stat, index) in stats"
           :key="index"
-          class="sleek-card group relative overflow-hidden text-center p-10 rounded-2xl bg-white dark:bg-white/[0.03] border border-gray-200/80 dark:border-white/10 transition-all duration-300"
+          class="relative text-center p-10 rounded-2xl bg-white border border-blue-200/70 crisp-card"
         >
-          <span class="card-topline"></span>
-          <p class="relative text-lg text-gray-500 dark:text-white/50 mb-3 transition-colors duration-300">{{ stat.label }}</p>
-          <div class="relative text-5xl md:text-6xl font-semibold tracking-tight bg-gradient-to-br from-gray-900 to-gray-600 dark:from-white dark:to-white/70 bg-clip-text text-transparent transition-colors duration-300">
-            {{ stat.value }}<span v-if="stat.unit" class="text-3xl text-gray-400 dark:text-white/40 ml-1">{{ stat.unit }}</span>
+          <p class="relative text-sm font-medium uppercase tracking-widest text-blue-700/70 mb-4 transition-colors duration-300">{{ stat.label }}</p>
+          <div class="relative text-5xl md:text-6xl font-semibold tracking-tight tabular-nums text-blue-950 transition-colors duration-300">
+            {{ stat.value }}<span v-if="stat.unit" class="text-3xl text-blue-950/70 ml-1.5 font-medium">{{ stat.unit }}</span>
           </div>
         </div>
       </div>
 
       <!-- Use case cards -->
       <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+
         <div
           v-for="(metric, index) in metrics"
           :key="index"
-          class="sleek-card group relative overflow-hidden p-8 rounded-2xl bg-white dark:bg-white/[0.03] border border-gray-200/80 dark:border-white/10 transition-all duration-300"
+          class="relative"
         >
-          <span class="card-topline"></span>
-          <!-- Icon and Title (side by side) -->
-          <div class="relative flex items-center gap-3 mb-4">
-            <div class="flex items-center justify-center w-12 h-12 rounded-xl bg-gradient-to-br from-blue-500/10 to-violet-500/10 dark:from-blue-500/20 dark:to-violet-500/20 border border-blue-500/10 dark:border-white/10 flex-shrink-0 transition-all duration-300 group-hover:scale-105">
-              <i :class="[metric.icon, 'text-xl text-blue-600 dark:text-blue-300']"></i>
+          <!-- Card with tinted background matching its accent color -->
+          <div
+            class="relative h-full p-8 rounded-2xl border crisp-card transition-colors duration-300"
+            :class="index % 2 === 1 ? 'bg-white border-orange-200/70' : 'bg-white border-blue-200/70'"
+          >
+
+            <!-- Icon -->
+            <div
+              class="relative flex items-center justify-center w-12 h-12 rounded-xl mx-auto mb-5 ring-1 transition-colors duration-300"
+              :class="index % 2 === 1 ? 'bg-orange-100 ring-orange-900/[0.08]' : 'bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] ring-blue-900/[0.08]'"
+            >
+              <i :class="[metric.icon, 'text-lg', index % 2 === 1 ? 'text-orange-600' : 'text-blue-600']"></i>
             </div>
-            <h3 class="text-lg font-semibold text-gray-900 dark:text-white transition-colors duration-300">
+
+            <!-- Title -->
+            <h3 class="relative text-xl font-semibold tracking-tight text-blue-950 transition-colors duration-300 mb-4 text-center">
               {{ metric.title }}
             </h3>
 
@@ -54,11 +60,6 @@
               {{ metric.description }}
             </p>
           </div>
-
-          <!-- Description -->
-          <p class="relative text-gray-600 dark:text-white/60 text-base leading-relaxed transition-colors duration-300">
-            {{ metric.description }}
-          </p>
         </div>
 
       </div>
@@ -112,59 +113,12 @@ export default defineComponent({
 </script>
 
 <style scoped>
-/* Crisp, sharply-defined cards: hairline edge + tight layered shadow, with subtle hover lift */
-.sleek-card {
+/* Crisp, sharply-defined cards: hairline edge + tight layered shadow */
+.crisp-card {
   box-shadow:
     0 0 0 1px rgba(15, 23, 42, 0.03),
     0 1px 2px rgba(15, 23, 42, 0.06),
     0 4px 10px -2px rgba(15, 23, 42, 0.07),
     0 12px 28px -10px rgba(15, 23, 42, 0.10);
-}
-
-.sleek-card:hover {
-  transform: translateY(-4px);
-  border-color: rgba(59, 130, 246, 0.25);
-  box-shadow:
-    0 0 0 1px rgba(59, 130, 246, 0.06),
-    0 2px 4px rgba(15, 23, 42, 0.06),
-    0 10px 20px -4px rgba(15, 23, 42, 0.10),
-    0 24px 48px -14px rgba(59, 130, 246, 0.18);
-}
-
-.dark .sleek-card {
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.4),
-    0 8px 24px -12px rgba(0, 0, 0, 0.6);
-}
-
-.dark .sleek-card:hover {
-  transform: translateY(-4px);
-  border-color: rgba(96, 165, 250, 0.3);
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.4),
-    0 12px 32px -10px rgba(0, 0, 0, 0.7),
-    0 0 32px -8px rgba(59, 130, 246, 0.25);
-}
-
-/* Gradient accent line that appears along the top edge on hover */
-.card-topline {
-  position: absolute;
-  top: 0;
-  left: 1.5rem;
-  right: 1.5rem;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(59, 130, 246, 0.6), rgba(139, 92, 246, 0.6), transparent);
-  opacity: 0;
-  transition: opacity 0.3s ease;
-}
-
-.sleek-card:hover .card-topline {
-  opacity: 1;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .sleek-card:hover {
-    transform: none;
-  }
 }
 </style>


### PR DESCRIPTION
## Why

`main` currently carries the **"sleeker" homepage redesign** (from PR #5) — gray/gradient buttons, gradient hero text, "NEW · Build web apps with AI" badge, etc. Our session's homepage design was intended to be the one merged via PR #6, but when `main` was merged into that branch the homepage got resolved in favor of the sleeker design, so our work was effectively overwritten on `main`.

This PR restores the session's design and applies the latest requested tweak (removing the CTA hover glow). It replaces the sleeker homepage with our design cleanly, branched off current `main`.

## What this restores

- **Baby-blue gradient CTA buttons** ("Start Building" / "Get Started") with dark navy text and a soft 3D edge. **Hover glow removed** — the buttons are static on hover; the `:active` press feedback is kept.
- **Solid, gradient-free section bands** alternating **orange** and **blue** (Hero, Features, CTA = orange; Stats, Key Features = blue), with **solid white cards**.
- **Dark-theme tuning**: cleaner `blue-400` blue bands and a true `orange-600` orange fill (derived from the card checkmark color) instead of muddy browns.
- **Readable stat values**: `$10-20` / `30 min` stay dark navy so they're legible on the always-white stat cards in both themes.
- **Contrasting header pills**: each section pill is the opposite color of its band (blue band → orange pill, orange band → blue pill), with solid fills in dark mode so they read clearly against the vivid orange band.

## Scope / reviewer notes

- Touches only the 5 home section components (`HeroSection`, `StatsSection`, `FeaturesSection`, `KeyFeaturesSection`, `CTASection`). `Home.vue` already matches.
- This is a design swap — it removes the sleeker redesign's homepage styling in favor of this one. Please confirm that's the intended direction before merging.
- Verified visually in the Vite preview in both light and dark themes across all sections during the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)