### PR TITLE
Fix dark-mode text contrast on orange homepage sections

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,7 +6,8 @@
       "runtimeExecutable": "bash",
       "runtimeArgs": ["-c", "bash ../../.claude/hooks/dev-setup.sh frontend; npm run dev"],
       "cwd": "frontend/vuejs",
-      "port": 5173
+      "port": 5173,
+      "autoPort": true
     },
     {
       "name": "backend-django",

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/CTASection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/CTASection.vue
@@ -1,6 +1,6 @@
 <!-- CTA Section - Clean Apple/Cursor-inspired design -->
 <template>
-  <section class="relative py-24 sm:py-32 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-orange-600 border-t border-orange-200/60 dark:border-orange-500/[0.12] transition-colors duration-500 overflow-hidden">
+  <section class="relative py-24 sm:py-32 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-orange-700 border-t border-orange-200/60 dark:border-orange-500/[0.12] transition-colors duration-500 overflow-hidden">
 
     <div class="relative max-w-4xl mx-auto text-center">
 
@@ -9,7 +9,7 @@
         {{ title }}
       </h2>
 
-      <p class="text-xl text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty mb-10 max-w-2xl mx-auto transition-colors duration-300">
+      <p class="text-xl text-blue-950/70 dark:text-orange-50 leading-relaxed text-pretty mb-10 max-w-2xl mx-auto transition-colors duration-300">
         {{ description }}
       </p>
       

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/FeaturesSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/FeaturesSection.vue
@@ -1,6 +1,6 @@
 <!-- Features Section - Clean Apple/Cursor-inspired design -->
 <template>
-  <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-orange-600 border-t border-orange-200/60 dark:border-orange-500/[0.12] transition-colors duration-500 overflow-hidden">
+  <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-orange-700 border-t border-orange-200/60 dark:border-orange-500/[0.12] transition-colors duration-500 overflow-hidden">
 
     <div class="relative max-w-6xl mx-auto">
 
@@ -10,7 +10,7 @@
         <h2 class="text-4xl sm:text-5xl md:text-6xl font-semibold text-blue-950 dark:text-white mb-6 tracking-tight text-balance transition-colors duration-300">
           Your product-building partner
         </h2>
-        <p class="text-xl text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty max-w-2xl mx-auto transition-colors duration-300">
+        <p class="text-xl text-blue-950/70 dark:text-orange-50 leading-relaxed text-pretty max-w-2xl mx-auto transition-colors duration-300">
           Three simple tools that work together to help you build, test, and launch web applications.
         </p>
       </div>

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/HeroSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/HeroSection.vue
@@ -1,6 +1,6 @@
 <!-- Hero Section - Clean Apple/Cursor-inspired design -->
 <template>
-  <section class="relative py-32 sm:py-40 md:py-48 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-orange-600 transition-colors duration-500 overflow-hidden">
+  <section class="relative py-32 sm:py-40 md:py-48 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-orange-700 transition-colors duration-500 overflow-hidden">
 
     <div class="relative max-w-4xl mx-auto text-center">
 
@@ -10,7 +10,7 @@
       </h1>
 
       <!-- Subtitle -->
-      <p class="text-lg sm:text-xl text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty mb-10 max-w-3xl mx-auto transition-colors duration-300">
+      <p class="text-lg sm:text-xl text-blue-950/70 dark:text-orange-50 leading-relaxed text-pretty mb-10 max-w-3xl mx-auto transition-colors duration-300">
         Imagi is a suite of AI tools that empowers non-technical developers to build web applications. Design visually, chat with AI, and launch to the web—fast, affordable, and approachable.
       </p>
 

--- a/frontend/vuejs/vite.config.ts
+++ b/frontend/vuejs/vite.config.ts
@@ -7,8 +7,11 @@ export default defineConfig({
     vue(),
   ],
   server: {
-    port: 5173,
-    strictPort: true,
+    // Honor a harness/CI-assigned PORT, else default to 5173.
+    // strictPort is false so Vite auto-increments (5174, 5175, …) when the
+    // port is taken — lets multiple dev servers run side by side.
+    port: Number(process.env.PORT) || 5173,
+    strictPort: false,
     hmr: {
       overlay: false,
     },


### PR DESCRIPTION
## What changed

### Dark-mode readability (Hero, Features, CTA sections)
In dark theme, three homepage sections rendered body copy as light-blue text at 70% opacity (`text-blue-100/70`) on a `bg-orange-600` background — a low-contrast combination that failed WCAG AA and was hard to read.

- Deepened the dark-mode background `orange-600` → `orange-700` (still clearly orange)
- Switched the subtitles to full-opacity `orange-50` (warm white)

Result clears WCAG AA: **~4.9:1** for body copy, **~5.2:1** for headings. Light mode is untouched (those sections use `bg-orange-50` with dark `blue-950` text, already fine).

Affected files:
- `HeroSection.vue` — "Imagi is a suite of AI tools…"
- `FeaturesSection.vue` — "Three simple tools that work together…"
- `CTASection.vue` — "Turn your ideas into web applications…"

### Dev server: allow parallel preview servers
- Removed Vite's `strictPort` so it auto-increments (5174, 5175, …) when 5173 is taken
- `port` now honors a harness/CI-assigned `PORT`, falling back to 5173
- Enabled `autoPort` in `.claude/launch.json`

This lets multiple sessions run preview dev servers side by side instead of colliding on 5173.

## Verification
Confirmed in the dark-mode browser preview via inspected color values and screenshots — all three orange sections now render crisp warm-white text on the deeper orange background. Dev server verified starting on an auto-assigned port with the homepage rendering correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)