### PR TITLE
Apply baby-blue design system to login and register pages

### DIFF
--- a/frontend/vuejs/src/apps/auth/components/atoms/buttons/GradientButton.vue
+++ b/frontend/vuejs/src/apps/auth/components/atoms/buttons/GradientButton.vue
@@ -2,16 +2,20 @@
   <button
     :type="type"
     :disabled="disabled || loading"
-    class="group relative w-full inline-flex items-center justify-center gap-2 px-8 py-4 
-           bg-black dark:bg-white 
-           rounded-xl 
-           text-white dark:text-gray-900 
-           font-medium 
-           shadow-sm 
-           transition-all duration-200
+    class="btn-3d btn-accent group relative w-full inline-flex items-center justify-center gap-2 px-8 py-4
+           text-blue-950
+           rounded-full
+           font-medium
+           border border-white/60
+           focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]
+           transition-all duration-300
            disabled:opacity-50 disabled:cursor-not-allowed
            overflow-hidden"
   >
+    <!-- Top edge highlight for 3D effect -->
+    <span class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/70 to-transparent"></span>
+    <!-- Bottom edge shadow for depth -->
+    <span class="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-blue-900/15 to-transparent"></span>
     <!-- Content -->
     <span v-if="loading" class="relative z-10 flex items-center justify-center">
       <i class="fas fa-circle-notch fa-spin mr-2"></i>
@@ -19,7 +23,7 @@
     </span>
     <span v-else class="relative z-10 flex items-center justify-center gap-2">
       <span class="font-medium"><slot></slot></span>
-      <i class="fas fa-arrow-right text-sm"></i>
+      <i class="fas fa-arrow-right text-sm transition-transform duration-300 group-hover:translate-x-1"></i>
     </span>
   </button>
 </template>
@@ -44,3 +48,31 @@ defineProps({
   }
 })
 </script>
+
+<style scoped>
+/* Soft 3D button effect - tight, layered, crisp. Blue-tinted shadows to suit the light baby-blue fill. */
+.btn-3d {
+  transform: translateY(0) translateZ(0);
+  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+  box-shadow:
+    0 1px 2px rgba(30, 58, 138, 0.14),
+    0 4px 10px -2px rgba(30, 58, 138, 0.16),
+    0 10px 20px -6px rgba(30, 58, 138, 0.18),
+    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
+    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.12);
+}
+
+.btn-3d:active {
+  transform: translateY(0) translateZ(0);
+  transition-duration: 0.1s;
+}
+
+/* Soft baby-blue gradient fill */
+.btn-accent {
+  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
+}
+
+.dark .btn-accent {
+  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
+}
+</style>

--- a/frontend/vuejs/src/apps/auth/components/atoms/inputs/PasswordInput.vue
+++ b/frontend/vuejs/src/apps/auth/components/atoms/inputs/PasswordInput.vue
@@ -3,7 +3,7 @@
     <label v-if="label" :for="id" class="sr-only">{{ label }}</label>
     <div class="relative group">
       <span class="absolute inset-y-0 left-0 flex items-center pl-4 z-10">
-        <i class="fas fa-lock text-black dark:text-white transition-colors duration-200"></i>
+        <i class="fas fa-lock text-blue-950/40 dark:text-blue-100/40 transition-colors duration-200"></i>
       </span>
       <input
         :id="id"
@@ -16,25 +16,25 @@
         :placeholder="placeholder"
         :required="required"
         :disabled="disabled"
-        class="w-full py-4 pl-12 pr-12 rounded-xl 
-               text-black dark:text-white 
-               placeholder-gray-400 dark:placeholder-white/30 
+        class="w-full py-4 pl-12 pr-12 rounded-xl
+               text-blue-950 dark:text-white
+               placeholder-blue-950/40 dark:placeholder-white/30
                outline-none focus:outline-none
-               disabled:opacity-50 disabled:cursor-not-allowed 
+               disabled:opacity-50 disabled:cursor-not-allowed
                transition-all duration-200
-               border bg-gray-50 dark:bg-white/[0.03] backdrop-blur-sm
+               border bg-blue-50/50 dark:bg-white/[0.03] backdrop-blur-sm
                focus:ring-0"
-        :class="{ 
+        :class="{
           'border-red-500/50 bg-red-50 dark:bg-red-500/5': hasError,
-          'border-gray-200 dark:border-white/[0.08]': !hasError
+          'border-blue-200/70 dark:border-white/[0.08]': !hasError
         }"
       >
       <button
         type="button"
         @click="togglePassword"
-        class="absolute inset-y-0 right-0 flex items-center pr-4 
-               text-black dark:text-white 
-               hover:text-black/70 dark:hover:text-white/80 
+        class="absolute inset-y-0 right-0 flex items-center pr-4
+               text-blue-950/40 dark:text-blue-100/40
+               hover:text-blue-950 dark:hover:text-white
                transition-colors duration-200 z-10"
       >
         <i :class="['fas', isVisible ? 'fa-eye-slash' : 'fa-eye']"></i>
@@ -145,10 +145,10 @@ button:focus-visible {
 input:-webkit-autofill,
 input:-webkit-autofill:hover,
 input:-webkit-autofill:focus {
-  -webkit-text-fill-color: black;
-  -webkit-box-shadow: 0 0 0px 1000px rgba(249, 250, 251, 1) inset;
+  -webkit-text-fill-color: #172554;
+  -webkit-box-shadow: 0 0 0px 1000px rgba(239, 246, 255, 1) inset;
   transition: background-color 5000s ease-in-out 0s;
-  border-color: rgb(229, 231, 235) !important;
+  border-color: rgb(191, 219, 254) !important;
 }
 
 /* Autofill styling for dark mode */

--- a/frontend/vuejs/src/apps/auth/components/atoms/items/RequirementItem.vue
+++ b/frontend/vuejs/src/apps/auth/components/atoms/items/RequirementItem.vue
@@ -2,20 +2,20 @@
   <div class="flex items-center gap-2.5">
     <div 
       class="w-5 h-5 rounded-md flex items-center justify-center transition-all duration-300"
-      :class="checked 
-        ? 'bg-emerald-500/20 border border-emerald-500/40' 
-        : 'bg-black/[0.03] dark:bg-white/[0.03] border border-black/[0.08] dark:border-white/[0.08]'"
+      :class="checked
+        ? 'bg-emerald-500/20 border border-emerald-500/40'
+        : 'bg-blue-100/60 dark:bg-white/[0.03] border border-blue-200/70 dark:border-white/[0.08]'"
     >
-      <i 
+      <i
         class="fas text-[10px] transition-all duration-300"
-        :class="checked 
-          ? 'fa-check text-emerald-500 dark:text-emerald-400' 
-          : 'fa-circle text-black/20 dark:text-white/20'"
+        :class="checked
+          ? 'fa-check text-emerald-500 dark:text-emerald-400'
+          : 'fa-circle text-blue-950/20 dark:text-white/20'"
       ></i>
     </div>
-    <span 
+    <span
       class="text-sm transition-colors duration-300"
-      :class="checked ? 'text-black/80 dark:text-white/80' : 'text-black/40 dark:text-white/40'"
+      :class="checked ? 'text-blue-950/80 dark:text-white/80' : 'text-blue-950/40 dark:text-white/40'"
     >
       {{ text }}
     </span>

--- a/frontend/vuejs/src/apps/auth/components/molecules/forms/FormCheckbox.vue
+++ b/frontend/vuejs/src/apps/auth/components/molecules/forms/FormCheckbox.vue
@@ -11,18 +11,19 @@
           type="checkbox"
           v-bind="field"
           :disabled="disabled"
-          class="w-4 h-4 rounded 
-                 border-black/20 dark:border-white/20 
-                 bg-black/[0.05] dark:bg-white/[0.05] 
-                 text-violet-500 focus:ring-violet-500/50 focus:ring-offset-0 focus:ring-2
+          class="w-4 h-4 rounded
+                 accent-blue-600
+                 border-blue-300 dark:border-white/20
+                 bg-blue-50 dark:bg-white/[0.05]
+                 text-blue-600 focus:ring-blue-500/40 focus:ring-offset-0 focus:ring-2
                  disabled:opacity-50 disabled:cursor-not-allowed
                  transition-all duration-300
-                 checked:bg-violet-500 checked:border-violet-500"
+                 checked:bg-blue-600 checked:border-blue-600"
         >
       </Field>
     </div>
     <div class="ml-3">
-      <label class="text-sm text-black/60 dark:text-white/60 leading-relaxed">
+      <label class="text-sm text-blue-950/60 dark:text-white/60 leading-relaxed">
         <slot></slot>
       </label>
       <ErrorMessage v-if="showError && false" :name="name" class="block mt-1 text-sm text-red-400" />

--- a/frontend/vuejs/src/apps/auth/components/molecules/forms/FormInput.vue
+++ b/frontend/vuejs/src/apps/auth/components/molecules/forms/FormInput.vue
@@ -3,7 +3,7 @@
     <label class="relative block group">
       <span class="sr-only">{{ label }}</span>
       <span class="absolute inset-y-0 left-0 flex items-center pl-4 z-10">
-        <i :class="[icon, 'text-black dark:text-white transition-colors duration-200']"></i>
+        <i :class="[icon, 'text-blue-950/40 dark:text-blue-100/40 transition-colors duration-200']"></i>
       </span>
       <input
         :value="modelValue"
@@ -14,17 +14,17 @@
         :type="inputType"
         :disabled="disabled"
         :placeholder="placeholder"
-        class="w-full py-4 pl-12 pr-4 rounded-xl 
-               text-black dark:text-white 
-               placeholder-gray-400 dark:placeholder-white/30 
+        class="w-full py-4 pl-12 pr-4 rounded-xl
+               text-blue-950 dark:text-white
+               placeholder-blue-950/40 dark:placeholder-white/30
                outline-none focus:outline-none
-               disabled:opacity-50 disabled:cursor-not-allowed 
+               disabled:opacity-50 disabled:cursor-not-allowed
                transition-all duration-200
-               border bg-gray-50 dark:bg-white/[0.03] backdrop-blur-sm
+               border bg-blue-50/50 dark:bg-white/[0.03] backdrop-blur-sm
                focus:ring-0"
-        :class="{ 
-          'border-red-500/50 bg-red-50 dark:bg-red-500/5': hasError, 
-          'border-gray-200 dark:border-white/[0.08]': !hasError
+        :class="{
+          'border-red-500/50 bg-red-50 dark:bg-red-500/5': hasError,
+          'border-blue-200/70 dark:border-white/[0.08]': !hasError
         }"
       >
     </label>
@@ -127,10 +127,10 @@ input::-moz-focus-inner {
 input:-webkit-autofill,
 input:-webkit-autofill:hover,
 input:-webkit-autofill:focus {
-  -webkit-text-fill-color: black;
-  -webkit-box-shadow: 0 0 0px 1000px rgba(249, 250, 251, 1) inset;
+  -webkit-text-fill-color: #172554;
+  -webkit-box-shadow: 0 0 0px 1000px rgba(239, 246, 255, 1) inset;
   transition: background-color 5000s ease-in-out 0s;
-  border-color: rgb(229, 231, 235) !important;
+  border-color: rgb(191, 219, 254) !important;
 }
 
 /* Autofill styling for dark mode */

--- a/frontend/vuejs/src/apps/auth/components/molecules/links/AuthLinks.vue
+++ b/frontend/vuejs/src/apps/auth/components/molecules/links/AuthLinks.vue
@@ -3,21 +3,21 @@
     <!-- Enhanced Links Section -->
     <div class="text-center">
       <!-- Alternate Auth Action -->
-      <p class="text-black dark:text-white text-sm transition-colors duration-300">
+      <p class="text-blue-950/70 dark:text-blue-100/70 text-sm transition-colors duration-300">
         <template v-if="isLoginPage">
           New to Imagi?
-          <router-link 
-            to="/auth/register" 
-            class="text-black dark:text-white font-medium ml-1"
+          <router-link
+            to="/auth/register"
+            class="text-blue-700 dark:text-blue-300 hover:text-blue-800 dark:hover:text-blue-200 font-medium transition-colors duration-200 ml-1"
           >
             Create an account
           </router-link>
         </template>
         <template v-else>
           Already have an account?
-          <router-link 
-            to="/auth/signin" 
-            class="text-black dark:text-white hover:text-gray-600 dark:hover:text-white/70 font-medium transition-colors duration-200 ml-1"
+          <router-link
+            to="/auth/signin"
+            class="text-blue-700 dark:text-blue-300 hover:text-blue-800 dark:hover:text-blue-200 font-medium transition-colors duration-200 ml-1"
           >
             Sign in here
           </router-link>

--- a/frontend/vuejs/src/apps/auth/layouts/AuthLayout.vue
+++ b/frontend/vuejs/src/apps/auth/layouts/AuthLayout.vue
@@ -2,11 +2,11 @@
 <template>
   <DefaultLayout>
     <!-- Clean full-screen layout matching Home page design -->
-    <div class="min-h-screen bg-gray-50 dark:bg-[#0f0f0f] relative overflow-hidden transition-colors duration-500">
-      <!-- Minimal background with subtle texture - matching Home page -->
+    <div class="min-h-screen bg-white dark:bg-[#0a0a0a] relative overflow-hidden transition-colors duration-500">
+      <!-- Minimal background with subtle baby-blue wash - matching Home/About/Docs -->
       <div class="fixed inset-0 pointer-events-none">
-        <!-- Subtle gradient - very minimal -->
-        <div class="absolute inset-0 bg-gradient-to-b from-gray-50/50 via-gray-50 to-gray-50 dark:from-[#0f0f0f] dark:via-[#0f0f0f] dark:to-[#0f0f0f] transition-colors duration-500"></div>
+        <!-- Soft baby-blue gradient fade from the top -->
+        <div class="absolute inset-x-0 top-0 h-[480px] bg-gradient-to-b from-blue-50/70 via-white to-white dark:from-blue-400/[0.06] dark:via-[#0a0a0a] dark:to-[#0a0a0a] transition-colors duration-500"></div>
         
         <!-- Very subtle grid pattern for texture (dark mode only) -->
         <div class="absolute inset-0 opacity-[0.015] dark:opacity-[0.02]" 
@@ -20,7 +20,7 @@
           <div class="w-full max-w-[520px] mx-auto">
             <!-- Clean card with subtle shadow -->
             <div class="relative animate-fade-in">
-              <div class="relative rounded-2xl border border-gray-200/80 dark:border-white/[0.08] bg-white dark:bg-[#0a0a0f]/50 shadow-sm dark:shadow-none backdrop-blur-xl overflow-hidden transition-all duration-300">
+              <div class="relative rounded-2xl border border-blue-200/70 dark:border-blue-500/[0.12] bg-white dark:bg-[#0d0d0d] crisp-card dark:shadow-none backdrop-blur-xl overflow-hidden transition-all duration-300">
                 <!-- Card content -->
                 <div class="relative z-10 p-8 sm:p-10">
                   <!-- Logo and Title Section -->
@@ -30,10 +30,10 @@
                     </div>
                     
                     <!-- Title -->
-                    <h2 class="text-xl sm:text-2xl font-medium tracking-tight mb-3 leading-[1.2] text-black dark:text-white transition-colors duration-300">
+                    <h2 class="text-xl sm:text-2xl font-semibold tracking-tight mb-3 leading-[1.2] text-blue-950 dark:text-white transition-colors duration-300">
                       {{ route.meta.title }}
                     </h2>
-                    <p class="text-base text-gray-500 dark:text-white/80 leading-relaxed transition-colors duration-300">
+                    <p class="text-base text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty transition-colors duration-300">
                       {{ route.meta.subtitle }}
                     </p>
                   </div>
@@ -63,6 +63,15 @@ const route = useRoute()
 </script>
 
 <style scoped>
+/* Crisp, sharply-defined card: hairline edge + tight layered shadow (matches marketing pages) */
+.crisp-card {
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.03),
+    0 1px 2px rgba(15, 23, 42, 0.06),
+    0 4px 10px -2px rgba(15, 23, 42, 0.07),
+    0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
+
 /* Fade transition */
 .fade-enter-active,
 .fade-leave-active {

--- a/frontend/vuejs/src/apps/auth/views/Login.vue
+++ b/frontend/vuejs/src/apps/auth/views/Login.vue
@@ -65,9 +65,9 @@
     <!-- Separator -->
     <div class="relative py-4">
       <div class="relative flex items-center justify-center">
-        <div class="flex-1 h-px bg-gradient-to-r from-transparent via-gray-300/50 dark:via-white/[0.08] to-transparent transition-colors duration-300"></div>
-        <div class="mx-4 text-xs text-gray-400 dark:text-white uppercase tracking-wider transition-colors duration-300">or</div>
-        <div class="flex-1 h-px bg-gradient-to-r from-transparent via-gray-300/50 dark:via-white/[0.08] to-transparent transition-colors duration-300"></div>
+        <div class="flex-1 h-px bg-gradient-to-r from-transparent via-blue-200/70 dark:via-white/[0.08] to-transparent transition-colors duration-300"></div>
+        <div class="mx-4 text-xs text-blue-950/40 dark:text-blue-100/40 uppercase tracking-wider transition-colors duration-300">or</div>
+        <div class="flex-1 h-px bg-gradient-to-r from-transparent via-blue-200/70 dark:via-white/[0.08] to-transparent transition-colors duration-300"></div>
       </div>
     </div>
 

--- a/frontend/vuejs/src/apps/auth/views/Register.vue
+++ b/frontend/vuejs/src/apps/auth/views/Register.vue
@@ -62,10 +62,10 @@
               :hasError="!!errorMessage && formSubmitCount > 0"
             />
             <!-- Password requirements with premium glass styling -->
-            <div class="mt-4 p-4 rounded-xl 
-                        border border-black/[0.08] dark:border-white/[0.08] 
-                        bg-black/[0.02] dark:bg-white/[0.02] 
-                        backdrop-blur-sm 
+            <div class="mt-4 p-4 rounded-xl
+                        border border-blue-200/70 dark:border-white/[0.08]
+                        bg-blue-50/50 dark:bg-white/[0.02]
+                        backdrop-blur-sm
                         transition-all duration-300">
               <PasswordRequirements 
                 :password="value || ''"
@@ -101,12 +101,12 @@
       <!-- Bottom section -->
       <div class="space-y-5 pt-2">
         <!-- Terms checkbox with premium styling -->
-        <div class="p-4 rounded-xl 
-                    border border-black/[0.08] dark:border-white/[0.08] 
-                    bg-black/[0.02] dark:bg-white/[0.02] 
-                    backdrop-blur-sm 
-                    hover:bg-black/[0.04] dark:hover:bg-white/[0.04] 
-                    hover:border-black/[0.12] dark:hover:border-white/[0.12] 
+        <div class="p-4 rounded-xl
+                    border border-blue-200/70 dark:border-white/[0.08]
+                    bg-blue-50/50 dark:bg-white/[0.02]
+                    backdrop-blur-sm
+                    hover:bg-blue-50 dark:hover:bg-white/[0.04]
+                    hover:border-blue-300/70 dark:hover:border-white/[0.12]
                     transition-all duration-300">
           <Field name="agreeToTerms" :rules="{ required: { allowFalse: false } }" :validateOnBlur="false" v-slot="{ errorMessage }">
             <FormCheckbox 
@@ -114,12 +114,12 @@
               :disabled="authStore.loading || isSubmitting"
               :showError="false"
             >
-              I agree to the 
-              <router-link to="/terms" class="text-black dark:text-white hover:text-black/70 dark:hover:text-white/70 transition-colors duration-300 font-medium">
+              I agree to the
+              <router-link to="/terms" class="text-blue-700 dark:text-blue-300 hover:text-blue-800 dark:hover:text-blue-200 transition-colors duration-300 font-medium">
                 Terms of Service
               </router-link>
               and
-              <router-link to="/privacy" class="text-black dark:text-white hover:text-black/70 dark:hover:text-white/70 transition-colors duration-300 font-medium">
+              <router-link to="/privacy" class="text-blue-700 dark:text-blue-300 hover:text-blue-800 dark:hover:text-blue-200 transition-colors duration-300 font-medium">
                 Privacy Policy
               </router-link>
             </FormCheckbox>
@@ -132,13 +132,13 @@
 
         <!-- Error message with premium styling -->
         <transition name="fade-up">
-          <div v-if="serverError" 
-               class="p-4 rounded-xl border border-red-500/20 bg-red-500/10 backdrop-blur-sm">
+          <div v-if="serverError"
+               class="p-4 rounded-xl border border-red-500/20 bg-red-50 dark:bg-red-500/10 backdrop-blur-sm transition-colors duration-300">
             <div class="flex items-center gap-3">
-              <div class="w-8 h-8 rounded-lg bg-red-500/20 border border-red-500/30 flex items-center justify-center flex-shrink-0">
-                <i class="fas fa-exclamation-triangle text-red-400 text-sm"></i>
+              <div class="w-8 h-8 rounded-lg bg-red-100 dark:bg-red-500/20 border border-red-200 dark:border-red-500/30 flex items-center justify-center flex-shrink-0 transition-colors duration-300">
+                <i class="fas fa-exclamation-triangle text-red-600 dark:text-red-400 text-sm transition-colors duration-300"></i>
               </div>
-              <p class="text-sm font-medium text-red-400 whitespace-pre-line">{{ serverError }}</p>
+              <p class="text-sm font-medium text-red-600 dark:text-red-400 whitespace-pre-line transition-colors duration-300">{{ serverError }}</p>
             </div>
           </div>
         </transition>
@@ -159,17 +159,17 @@
     <!-- Separator -->
     <div class="relative py-4">
       <div class="relative flex items-center justify-center">
-        <div class="flex-1 h-px bg-gradient-to-r from-transparent via-black/[0.08] dark:via-white/[0.08] to-transparent"></div>
-        <div class="mx-4 text-xs text-gray-400 dark:text-white uppercase tracking-wider transition-colors duration-300">or</div>
-        <div class="flex-1 h-px bg-gradient-to-r from-transparent via-black/[0.08] dark:via-white/[0.08] to-transparent"></div>
+        <div class="flex-1 h-px bg-gradient-to-r from-transparent via-blue-200/70 dark:via-white/[0.08] to-transparent"></div>
+        <div class="mx-4 text-xs text-blue-950/40 dark:text-blue-100/40 uppercase tracking-wider transition-colors duration-300">or</div>
+        <div class="flex-1 h-px bg-gradient-to-r from-transparent via-blue-200/70 dark:via-white/[0.08] to-transparent"></div>
       </div>
     </div>
 
     <!-- Auth Links -->
     <div class="text-center">
-      <p class="text-black dark:text-white text-sm transition-colors duration-300">
+      <p class="text-blue-950/70 dark:text-blue-100/70 text-sm transition-colors duration-300">
         Already have an account?
-        <router-link to="/auth/signin" class="text-black dark:text-white hover:text-gray-600 dark:hover:text-white/70 font-medium transition-colors duration-200 ml-1">
+        <router-link to="/auth/signin" class="text-blue-700 dark:text-blue-300 hover:text-blue-800 dark:hover:text-blue-200 font-medium transition-colors duration-200 ml-1">
           Sign in
         </router-link>
       </p>


### PR DESCRIPTION
## What

Restyles the login and register pages — and the shared auth components they use — to match the **baby-blue design system** already used across the homepage, About, and Docs. The auth flow was still on an older monochrome black/white/gray (plus off-brand violet) scheme, so it looked disconnected from the rest of the marketing site.

## Changes

- **AuthLayout** — page background moves from `gray-50/#0f0f0f` to `white/#0a0a0a` with a soft baby-blue top wash; the card gets a blue hairline border and the shared `crisp-card` shadow; navy (`blue-950`) title and blue-tinted subtitle.
- **GradientButton** — the flat black `rounded-xl` button becomes the signature baby-blue **`btn-accent` pill** (`rounded-full`, navy text, edge highlights, blue-tinted 3D shadow), identical to the hero "Start Building" CTA.
- **FormInput / PasswordInput** — blue-tinted fields (`bg-blue-50/50`, `border-blue-200/70`), navy text, muted blue icons, and recolored autofill styling.
- **FormCheckbox** — off-brand violet accent replaced with blue.
- **RequirementItem** — unmet items use a blue tint (emerald retained for the satisfied check).
- **AuthLinks / Login / Register** — blue links, blue separators, blue-tinted glass panels, and a light-mode red error box on Register (so it matches Login).

## Testing

Verified live in the Vite preview on both `/auth/signin` and `/auth/register`, in light and dark mode. Confirmed the submit button renders the exact hero gradient (`#dbeeff → #b7ddf7 → #9ecdf3`) with `blue-950` text and `rounded-full`. No new console/build errors (only pre-existing backend health-check warnings from the dev server).

## Notes for reviewer

- Purely presentational — no template structure, props, validation, or auth logic changed.
- The satisfied-state emerald check on the password requirements was kept intentionally (green = valid is a strong UX convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)