### PR TITLE
Add cohesive dark theme and fix theme initialization

### DIFF
--- a/frontend/vuejs/index.html
+++ b/frontend/vuejs/index.html
@@ -7,8 +7,22 @@
     <link rel="icon" href="/favicon.ico">
     <title>Imagi - Transform Text to Web Apps</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" />
+    <script>
+      // Apply the saved theme before first paint to avoid a flash of the wrong theme.
+      // Mirrors the logic in src/shared/stores/theme.ts, which takes over after mount.
+      ;(function () {
+        var theme = localStorage.getItem('theme')
+        var dark =
+          theme === 'dark' ||
+          ((!theme || theme === 'system') &&
+            window.matchMedia('(prefers-color-scheme: dark)').matches)
+        var root = document.documentElement
+        root.classList.add(dark ? 'dark' : 'light')
+        root.style.colorScheme = dark ? 'dark' : 'light'
+      })()
+    </script>
   </head>
-  <body class="bg-gray-900 text-white">
+  <body>
     <noscript>
       <strong>We're sorry but Imagi doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>

--- a/frontend/vuejs/src/App.vue
+++ b/frontend/vuejs/src/App.vue
@@ -10,11 +10,10 @@
 
 <script setup lang="ts">
 import { useThemeStore } from '@/shared/stores/theme'
-import { onMounted } from 'vue'
 
 const themeStore = useThemeStore()
 
-onMounted(() => {
-  themeStore.initializeTheme()
-})
+// Initialize synchronously (before mount) so the store takes over from the
+// pre-paint inline script in index.html without a repaint in between.
+themeStore.initializeTheme()
 </script>

--- a/frontend/vuejs/src/apps/auth/components/atoms/buttons/GradientButton.vue
+++ b/frontend/vuejs/src/apps/auth/components/atoms/buttons/GradientButton.vue
@@ -6,7 +6,7 @@
            text-blue-950
            rounded-full
            font-medium
-           border border-white/60
+           border border-white/60 dark:border-white/30
            focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]
            transition-all duration-300
            disabled:opacity-50 disabled:cursor-not-allowed
@@ -74,5 +74,15 @@ defineProps({
 
 .dark .btn-accent {
   background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
+}
+
+/* On dark, ground the light button with deep neutral shadows; keep the inner sheen */
+.dark .btn-3d {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 10px 20px -6px rgba(0, 0, 0, 0.5),
+    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
+    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.18);
 }
 </style>

--- a/frontend/vuejs/src/apps/auth/layouts/AuthLayout.vue
+++ b/frontend/vuejs/src/apps/auth/layouts/AuthLayout.vue
@@ -20,7 +20,7 @@
           <div class="w-full max-w-[520px] mx-auto">
             <!-- Clean card with subtle shadow -->
             <div class="relative animate-fade-in">
-              <div class="relative rounded-2xl border border-blue-200/70 dark:border-blue-500/[0.12] bg-white dark:bg-[#0d0d0d] crisp-card dark:shadow-none backdrop-blur-xl overflow-hidden transition-all duration-300">
+              <div class="relative rounded-2xl border border-blue-200/70 dark:border-blue-300/[0.16] bg-white dark:bg-white/[0.05] crisp-card backdrop-blur-xl overflow-hidden transition-all duration-300">
                 <!-- Card content -->
                 <div class="relative z-10 p-8 sm:p-10">
                   <!-- Logo and Title Section -->
@@ -70,6 +70,14 @@ const route = useRoute()
     0 1px 2px rgba(15, 23, 42, 0.06),
     0 4px 10px -2px rgba(15, 23, 42, 0.07),
     0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
+
+:root.dark .crisp-card {
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 12px 28px -10px rgba(0, 0, 0, 0.55);
 }
 
 /* Fade transition */

--- a/frontend/vuejs/src/apps/docs/components/molecules/cards/DocsCard.vue
+++ b/frontend/vuejs/src/apps/docs/components/molecules/cards/DocsCard.vue
@@ -1,13 +1,13 @@
 <template>
-  <div class="crisp-card group relative h-full p-8 rounded-2xl border border-blue-200/70 bg-white transition-all duration-300">
+  <div class="crisp-card group relative h-full p-8 rounded-2xl border border-blue-200/70 dark:border-blue-300/[0.16] bg-white dark:bg-white/[0.05] transition-all duration-300">
     <h3
       v-if="title"
-      class="text-xl font-semibold text-blue-950 mb-3 transition-colors duration-300"
+      class="text-xl font-semibold text-blue-950 dark:text-white mb-3 transition-colors duration-300"
     >
       {{ title }}
     </h3>
 
-    <div class="text-blue-950/70 leading-relaxed transition-colors duration-300">
+    <div class="text-blue-950/70 dark:text-blue-100/70 leading-relaxed transition-colors duration-300">
       <slot></slot>
     </div>
   </div>

--- a/frontend/vuejs/src/apps/docs/components/molecules/cards/DocsNavigationCard.vue
+++ b/frontend/vuejs/src/apps/docs/components/molecules/cards/DocsNavigationCard.vue
@@ -1,19 +1,19 @@
 <template>
   <router-link
     :to="to"
-    class="crisp-card group relative block h-full p-8 rounded-2xl border border-blue-200/70 bg-white transition-all duration-300 hover:-translate-y-0.5"
+    class="crisp-card group relative block h-full p-8 rounded-2xl border border-blue-200/70 dark:border-blue-300/[0.16] bg-white dark:bg-white/[0.05] transition-all duration-300 hover:-translate-y-0.5"
   >
     <div class="flex items-start gap-4">
       <div class="flex-1">
-        <h3 class="text-xl font-semibold text-blue-950 mb-2 transition-colors duration-300">
+        <h3 class="text-xl font-semibold text-blue-950 dark:text-white mb-2 transition-colors duration-300">
           {{ title }}
         </h3>
-        <p class="text-blue-950/70 leading-relaxed transition-colors duration-300">
+        <p class="text-blue-950/70 dark:text-blue-100/70 leading-relaxed transition-colors duration-300">
           {{ description }}
         </p>
       </div>
       <svg
-        class="w-5 h-5 text-blue-500 transition-transform duration-300 group-hover:translate-x-1 flex-shrink-0 mt-1"
+        class="w-5 h-5 text-blue-500 dark:text-blue-300 transition-transform duration-300 group-hover:translate-x-1 flex-shrink-0 mt-1"
         fill="none"
         stroke="currentColor"
         viewBox="0 0 24 24"

--- a/frontend/vuejs/src/apps/docs/components/molecules/cards/DocsStepCard.vue
+++ b/frontend/vuejs/src/apps/docs/components/molecules/cards/DocsStepCard.vue
@@ -1,14 +1,14 @@
 <template>
-  <div class="crisp-card relative p-8 rounded-2xl border border-blue-200/70 bg-white transition-all duration-300 my-8">
+  <div class="crisp-card relative p-8 rounded-2xl border border-blue-200/70 dark:border-blue-300/[0.16] bg-white dark:bg-white/[0.05] transition-all duration-300 my-8">
     <div class="flex items-start gap-6">
-      <div class="text-4xl font-bold text-blue-600 flex-shrink-0 leading-none w-10">
+      <div class="text-4xl font-bold text-blue-600 dark:text-blue-300 flex-shrink-0 leading-none w-10">
         {{ number }}
       </div>
       <div class="flex-1">
-        <h3 class="text-2xl font-semibold text-blue-950 mb-4 transition-colors duration-300">
+        <h3 class="text-2xl font-semibold text-blue-950 dark:text-white mb-4 transition-colors duration-300">
           {{ title }}
         </h3>
-        <div class="text-blue-950/70 leading-relaxed transition-colors duration-300">
+        <div class="text-blue-950/70 dark:text-blue-100/70 leading-relaxed transition-colors duration-300">
           <slot></slot>
         </div>
       </div>

--- a/frontend/vuejs/src/apps/docs/components/molecules/headers/DocsPageHeader.vue
+++ b/frontend/vuejs/src/apps/docs/components/molecules/headers/DocsPageHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="mb-12 md:mb-16 text-center">
-    <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-blue-200/70 dark:border-blue-400/30 bg-blue-50/80 dark:bg-blue-600 text-xs font-semibold text-blue-700 dark:text-white uppercase tracking-[0.18em] mb-5 transition-colors duration-300">
+    <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-blue-200/70 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 text-xs font-semibold text-blue-700 dark:text-blue-300 uppercase tracking-[0.18em] mb-5 transition-colors duration-300">
       {{ badgeText }}
     </p>
     <h1 class="text-4xl sm:text-5xl md:text-6xl font-semibold tracking-[-0.025em] text-blue-950 dark:text-white mb-6 leading-[1.08] text-balance transition-colors duration-300">

--- a/frontend/vuejs/src/apps/docs/layouts/DocsLayout.vue
+++ b/frontend/vuejs/src/apps/docs/layouts/DocsLayout.vue
@@ -68,9 +68,21 @@ const isActive = (path) => route.path === path
     0 12px 28px -10px rgba(15, 23, 42, 0.10);
 }
 
+:root.dark .docs-content :deep(.crisp-card) {
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 12px 28px -10px rgba(0, 0, 0, 0.55);
+}
+
 /* Alternating blue / orange accent borders for cards in a grid, echoing the home page */
 .docs-content :deep(.grid > .crisp-card:nth-child(2n)) {
   border-color: rgba(254, 215, 170, 0.7);
+}
+
+:root.dark .docs-content :deep(.grid > .crisp-card:nth-child(2n)) {
+  border-color: rgba(253, 186, 116, 0.16);
 }
 </style>
 

--- a/frontend/vuejs/src/apps/docs/views/DocsCreatingProjects.vue
+++ b/frontend/vuejs/src/apps/docs/views/DocsCreatingProjects.vue
@@ -23,26 +23,26 @@
           <li class="flex items-start gap-4">
             <div class="w-8 h-8 rounded-full bg-blue-600 text-white font-bold text-sm flex items-center justify-center flex-shrink-0 shadow-md">1</div>
             <div class="text-lg leading-relaxed">
-              <strong class="text-blue-950 font-semibold">Click the "New Project" button</strong> on your dashboard homepage or from the projects list.
+              <strong class="text-blue-950 dark:text-white font-semibold">Click the "New Project" button</strong> on your dashboard homepage or from the projects list.
             </div>
           </li>
           <li class="flex items-start gap-4">
             <div class="w-8 h-8 rounded-full bg-blue-600 text-white font-bold text-sm flex items-center justify-center flex-shrink-0 shadow-md">2</div>
             <div class="text-lg leading-relaxed">
-              <strong class="text-blue-950 font-semibold">Enter a project name</strong> — choose something descriptive that reflects the purpose of your application.
+              <strong class="text-blue-950 dark:text-white font-semibold">Enter a project name</strong> — choose something descriptive that reflects the purpose of your application.
             </div>
           </li>
           <li class="flex items-start gap-4">
             <div class="w-8 h-8 rounded-full bg-blue-600 text-white font-bold text-sm flex items-center justify-center flex-shrink-0 shadow-md">3</div>
             <div class="text-lg leading-relaxed">
-              <strong class="text-blue-950 font-semibold">Select a project template</strong> (optional) — start from scratch or choose from pre-configured templates.
+              <strong class="text-blue-950 dark:text-white font-semibold">Select a project template</strong> (optional) — start from scratch or choose from pre-configured templates.
             </div>
           </li>
         </ol>
 
-        <div class="bg-blue-50/70 border border-blue-200/70 rounded-xl p-6 transition-colors duration-300">
-          <h4 class="text-blue-950 mt-0 mb-3 text-lg font-semibold">Pro Tip</h4>
-          <p class="text-lg text-blue-950/70 mb-0 leading-relaxed">
+        <div class="bg-blue-50/70 dark:bg-blue-400/[0.08] border border-blue-200/70 dark:border-blue-300/[0.16] rounded-xl p-6 transition-colors duration-300">
+          <h4 class="text-blue-950 dark:text-white mt-0 mb-3 text-lg font-semibold">Pro Tip</h4>
+          <p class="text-lg text-blue-950/70 dark:text-blue-100/70 mb-0 leading-relaxed">
             Starting with a template can save time, but creating from scratch gives you more control over the architecture.
             Choose based on your specific needs and timeline.
           </p>

--- a/frontend/vuejs/src/apps/docs/views/DocsQuickStart.vue
+++ b/frontend/vuejs/src/apps/docs/views/DocsQuickStart.vue
@@ -12,10 +12,10 @@
           Navigate to the Builder Dashboard to get started. Click the "New Project" button to create your first project.
           Give it a name and description that reflects what you want to build.
         </p>
-        <div class="w-full h-px bg-blue-200/70 mb-6"></div>
+        <div class="w-full h-px bg-blue-200/70 dark:bg-blue-300/[0.16] mb-6"></div>
         <router-link
           to="/products/imagi/projects"
-          class="btn-3d btn-accent group relative inline-flex items-center justify-center gap-3 px-8 py-4 text-blue-950 rounded-full font-medium text-lg transition-all duration-300 overflow-hidden border border-white/60"
+          class="btn-3d btn-accent group relative inline-flex items-center justify-center gap-3 px-8 py-4 text-blue-950 rounded-full font-medium text-lg transition-all duration-300 overflow-hidden border border-white/60 dark:border-white/30"
         >
           <span class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/70 to-transparent"></span>
           <span class="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-blue-900/15 to-transparent"></span>
@@ -40,27 +40,27 @@
         <ul class="space-y-3 mb-6">
           <li class="flex items-start gap-3">
             <div class="w-1.5 h-1.5 rounded-full bg-blue-500 mt-2 flex-shrink-0"></div>
-            <span class="text-lg leading-relaxed">Describe the <strong class="font-semibold text-blue-950">purpose</strong> and functionality you need</span>
+            <span class="text-lg leading-relaxed">Describe the <strong class="font-semibold text-blue-950 dark:text-white">purpose</strong> and functionality you need</span>
           </li>
           <li class="flex items-start gap-3">
             <div class="w-1.5 h-1.5 rounded-full bg-blue-500 mt-2 flex-shrink-0"></div>
-            <span class="text-lg leading-relaxed">Specify key <strong class="font-semibold text-blue-950">features</strong> and user interactions</span>
+            <span class="text-lg leading-relaxed">Specify key <strong class="font-semibold text-blue-950 dark:text-white">features</strong> and user interactions</span>
           </li>
           <li class="flex items-start gap-3">
             <div class="w-1.5 h-1.5 rounded-full bg-blue-500 mt-2 flex-shrink-0"></div>
-            <span class="text-lg leading-relaxed">Mention any <strong class="font-semibold text-blue-950">data models</strong> or structure requirements</span>
+            <span class="text-lg leading-relaxed">Mention any <strong class="font-semibold text-blue-950 dark:text-white">data models</strong> or structure requirements</span>
           </li>
           <li class="flex items-start gap-3">
             <div class="w-1.5 h-1.5 rounded-full bg-blue-500 mt-2 flex-shrink-0"></div>
-            <span class="text-lg leading-relaxed">Share <strong class="font-semibold text-blue-950">design preferences</strong> or style inspiration</span>
+            <span class="text-lg leading-relaxed">Share <strong class="font-semibold text-blue-950 dark:text-white">design preferences</strong> or style inspiration</span>
           </li>
         </ul>
 
-        <div class="bg-blue-50/70 border border-blue-200/70 rounded-xl p-6 transition-colors duration-300">
-          <h4 class="text-blue-950 mt-0 mb-3 text-lg font-semibold">
+        <div class="bg-blue-50/70 dark:bg-blue-400/[0.08] border border-blue-200/70 dark:border-blue-300/[0.16] rounded-xl p-6 transition-colors duration-300">
+          <h4 class="text-blue-950 dark:text-white mt-0 mb-3 text-lg font-semibold">
             Example Prompt
           </h4>
-          <p class="text-lg text-blue-950/70 mb-0 leading-relaxed">
+          <p class="text-lg text-blue-950/70 dark:text-blue-100/70 mb-0 leading-relaxed">
             "I need a task management application with user authentication. Users should be able to create projects,
             add tasks to projects, and mark tasks as complete. Each task should have a title, description, due date,
             and priority level. The app should have a dashboard showing task statistics and upcoming deadlines.
@@ -87,7 +87,7 @@
           </li>
           <li class="flex items-start gap-3">
             <div class="w-1.5 h-1.5 rounded-full bg-blue-500 mt-2 flex-shrink-0"></div>
-            <span class="text-lg leading-relaxed">Click the <strong class="font-semibold text-blue-950">"Deploy"</strong> button in your project dashboard</span>
+            <span class="text-lg leading-relaxed">Click the <strong class="font-semibold text-blue-950 dark:text-white">"Deploy"</strong> button in your project dashboard</span>
           </li>
           <li class="flex items-start gap-3">
             <div class="w-1.5 h-1.5 rounded-full bg-blue-500 mt-2 flex-shrink-0"></div>
@@ -145,5 +145,15 @@ import { DocsPageHeader, DocsStepCard, DocsNavigationCard } from '../components'
 /* Soft baby-blue gradient fill */
 .btn-accent {
   background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
+}
+
+/* On dark, ground the light button with deep neutral shadows; keep the inner sheen */
+.dark .btn-3d {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 10px 20px -6px rgba(0, 0, 0, 0.5),
+    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
+    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.18);
 }
 </style>

--- a/frontend/vuejs/src/apps/home/components/organisms/navigation/HomeNavbar.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/navigation/HomeNavbar.vue
@@ -177,4 +177,14 @@ export default defineComponent({
 .dark .btn-accent {
   background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
 }
+
+/* On dark, ground the light button with deep neutral shadows; keep the inner sheen */
+.dark .btn-3d {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 10px 20px -6px rgba(0, 0, 0, 0.5),
+    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
+    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.18);
+}
 </style>

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/CTASection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/CTASection.vue
@@ -1,6 +1,6 @@
 <!-- CTA Section - Clean Apple/Cursor-inspired design -->
 <template>
-  <section class="relative py-24 sm:py-32 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-orange-600 border-t border-orange-200/60 dark:border-orange-500/[0.12] transition-colors duration-500 overflow-hidden">
+  <section class="relative py-24 sm:py-32 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-[#16120e] border-t border-orange-200/60 dark:border-orange-400/[0.14] transition-colors duration-500 overflow-hidden">
 
     <div class="relative max-w-4xl mx-auto text-center">
 
@@ -17,7 +17,7 @@
       <div class="flex flex-col sm:flex-row gap-4 justify-center">
         <router-link
           :to="getAuthenticatedRedirect"
-          class="btn-3d btn-accent group relative inline-flex items-center justify-center gap-3 px-8 py-4 text-blue-950 rounded-full font-medium text-lg overflow-hidden border border-white/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
+          class="btn-3d btn-accent group relative inline-flex items-center justify-center gap-3 px-8 py-4 text-blue-950 rounded-full font-medium text-lg overflow-hidden border border-white/60 dark:border-white/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#16120e]"
         >
           <!-- Top edge highlight for 3D effect -->
           <span class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/70 to-transparent"></span>
@@ -32,7 +32,7 @@
         <router-link 
           v-if="showSecondaryButton"
           :to="secondaryButtonTo"
-          class="group relative inline-flex items-center justify-center gap-2 px-8 py-4 bg-transparent text-orange-700 dark:text-orange-300 rounded-full font-medium text-lg overflow-hidden border-2 border-orange-500/60 dark:border-orange-400/50 hover:bg-orange-50 dark:hover:bg-orange-500/10 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500/40 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
+          class="group relative inline-flex items-center justify-center gap-2 px-8 py-4 bg-transparent text-orange-700 dark:text-orange-300 rounded-full font-medium text-lg overflow-hidden border-2 border-orange-500/60 dark:border-orange-400/50 hover:bg-orange-50 dark:hover:bg-orange-500/10 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500/40 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#16120e]"
         >
           <span class="relative">{{ secondaryButtonText }}</span>
         </router-link>
@@ -120,5 +120,15 @@ export default defineComponent({
 
 .dark .btn-accent {
   background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
+}
+
+/* On dark, ground the light button with deep neutral shadows; keep the inner sheen */
+.dark .btn-3d {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 10px 20px -6px rgba(0, 0, 0, 0.5),
+    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
+    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.18);
 }
 </style>

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/FeaturesSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/FeaturesSection.vue
@@ -1,12 +1,12 @@
 <!-- Features Section - Clean Apple/Cursor-inspired design -->
 <template>
-  <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-orange-600 border-t border-orange-200/60 dark:border-orange-500/[0.12] transition-colors duration-500 overflow-hidden">
+  <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-[#16120e] border-t border-orange-200/60 dark:border-orange-400/[0.14] transition-colors duration-500 overflow-hidden">
 
     <div class="relative max-w-6xl mx-auto">
 
       <!-- Section header -->
       <div class="text-center mb-16 md:mb-20">
-        <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-blue-200/70 dark:border-blue-400/30 bg-blue-50/80 dark:bg-blue-600 text-xs font-semibold text-blue-700 dark:text-white uppercase tracking-[0.18em] mb-5 transition-colors duration-300">How it works</p>
+        <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-blue-200/70 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 text-xs font-semibold text-blue-700 dark:text-blue-300 uppercase tracking-[0.18em] mb-5 transition-colors duration-300">How it works</p>
         <h2 class="text-4xl sm:text-5xl md:text-6xl font-semibold text-blue-950 dark:text-white mb-6 tracking-tight text-balance transition-colors duration-300">
           Your product-building partner
         </h2>
@@ -26,24 +26,24 @@
           <!-- Card with tinted background matching its accent color -->
           <div
             class="relative h-full p-8 rounded-2xl border crisp-card transition-colors duration-300"
-            :class="index % 2 === 1 ? 'bg-white border-orange-200/70' : 'bg-white border-blue-200/70'"
+            :class="index % 2 === 1 ? 'bg-white dark:bg-white/[0.05] border-orange-200/70 dark:border-orange-300/[0.16]' : 'bg-white dark:bg-white/[0.05] border-blue-200/70 dark:border-blue-300/[0.16]'"
           >
 
             <!-- Icon -->
             <div
               class="relative flex items-center justify-center w-12 h-12 rounded-xl mx-auto mb-5 ring-1 transition-colors duration-300"
-              :class="index % 2 === 1 ? 'bg-orange-100 ring-orange-900/[0.08]' : 'bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] ring-blue-900/[0.08]'"
+              :class="index % 2 === 1 ? 'bg-orange-100 dark:bg-orange-400/[0.14] ring-orange-900/[0.08] dark:ring-orange-300/[0.18]' : 'bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] dark:from-blue-400/[0.18] dark:to-blue-500/[0.22] ring-blue-900/[0.08] dark:ring-blue-300/[0.18]'"
             >
-              <i :class="[feature.icon, 'text-lg', index % 2 === 1 ? 'text-orange-600' : 'text-blue-600']"></i>
+              <i :class="[feature.icon, 'text-lg', index % 2 === 1 ? 'text-orange-600 dark:text-orange-300' : 'text-blue-600 dark:text-blue-300']"></i>
             </div>
 
             <!-- Title -->
-            <h3 class="relative text-xl font-semibold tracking-tight text-blue-950 transition-colors duration-300 mb-4 text-center">
+            <h3 class="relative text-xl font-semibold tracking-tight text-blue-950 dark:text-white transition-colors duration-300 mb-4 text-center">
               {{ feature.title }}
             </h3>
 
             <!-- Description -->
-            <p class="relative text-blue-950/70 leading-relaxed text-pretty transition-colors duration-300 text-center">
+            <p class="relative text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty transition-colors duration-300 text-center">
               {{ feature.description }}
             </p>
 
@@ -108,5 +108,13 @@ export default defineComponent({
     0 1px 2px rgba(15, 23, 42, 0.06),
     0 4px 10px -2px rgba(15, 23, 42, 0.07),
     0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
+
+.dark .crisp-card {
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 12px 28px -10px rgba(0, 0, 0, 0.55);
 }
 </style>

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/HeroSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/HeroSection.vue
@@ -1,6 +1,6 @@
 <!-- Hero Section - Clean Apple/Cursor-inspired design -->
 <template>
-  <section class="relative py-32 sm:py-40 md:py-48 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-orange-600 transition-colors duration-500 overflow-hidden">
+  <section class="relative py-32 sm:py-40 md:py-48 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-[#16120e] transition-colors duration-500 overflow-hidden">
 
     <div class="relative max-w-4xl mx-auto text-center">
 
@@ -18,7 +18,7 @@
       <div class="flex flex-col sm:flex-row gap-4 justify-center mb-12">
         <router-link
           :to="startBuildingRoute"
-          class="btn-3d btn-accent group relative inline-flex items-center justify-center gap-3 px-8 py-4 text-blue-950 rounded-full font-medium text-lg overflow-hidden border border-white/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
+          class="btn-3d btn-accent group relative inline-flex items-center justify-center gap-3 px-8 py-4 text-blue-950 rounded-full font-medium text-lg overflow-hidden border border-white/60 dark:border-white/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#16120e]"
         >
           <!-- Top edge highlight for 3D effect -->
           <span class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/70 to-transparent"></span>
@@ -36,12 +36,12 @@
         <span
           v-for="(prop, index) in valueProps"
           :key="index"
-          class="value-pill flex items-center gap-2 px-3.5 py-2 rounded-full bg-white dark:bg-white border border-gray-200/90 dark:border-white/20 transition-all duration-300 whitespace-nowrap"
+          class="value-pill flex items-center gap-2 px-3.5 py-2 rounded-full bg-white dark:bg-white/[0.07] border border-gray-200/90 dark:border-white/[0.14] transition-all duration-300 whitespace-nowrap"
         >
-          <span class="w-4 h-4 rounded-full bg-orange-100 ring-1 ring-orange-200/80 flex items-center justify-center transition-all duration-300">
-            <i class="fas fa-check text-[9px] text-orange-600"></i>
+          <span class="w-4 h-4 rounded-full bg-orange-100 dark:bg-orange-400/[0.16] ring-1 ring-orange-200/80 dark:ring-orange-400/30 flex items-center justify-center transition-all duration-300">
+            <i class="fas fa-check text-[9px] text-orange-600 dark:text-orange-300"></i>
           </span>
-          <span class="text-gray-800 dark:text-gray-900 font-medium">{{ prop }}</span>
+          <span class="text-gray-800 dark:text-blue-100/85 font-medium">{{ prop }}</span>
         </span>
       </div>
 
@@ -102,10 +102,26 @@ export default defineComponent({
   background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
 }
 
+/* On dark, ground the light button with deep neutral shadows; keep the inner sheen */
+.dark .btn-3d {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 10px 20px -6px rgba(0, 0, 0, 0.5),
+    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
+    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.18);
+}
+
 /* Hairline-edged pills with a whisper of depth */
 .value-pill {
   box-shadow:
     0 1px 2px rgba(15, 23, 42, 0.05),
     0 2px 6px -2px rgba(15, 23, 42, 0.06);
+}
+
+.dark .value-pill {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.4),
+    0 2px 6px -2px rgba(0, 0, 0, 0.35);
 }
 </style>

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/KeyFeaturesSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/KeyFeaturesSection.vue
@@ -1,12 +1,12 @@
 <!-- Key Features Section - Clean Apple/Cursor-inspired design -->
 <template>
-  <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-blue-50 dark:bg-blue-400/[0.16] border-t border-blue-200/60 dark:border-blue-500/[0.12] transition-colors duration-500 overflow-hidden">
+  <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-blue-50 dark:bg-[#0e141f] border-t border-blue-200/60 dark:border-blue-400/[0.14] transition-colors duration-500 overflow-hidden">
 
     <div class="relative max-w-6xl mx-auto">
 
       <!-- Section header -->
       <div class="text-center mb-16 md:mb-20">
-        <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-orange-200/70 dark:border-orange-400/30 bg-orange-50/80 dark:bg-orange-600 text-xs font-semibold text-orange-700 dark:text-white uppercase tracking-[0.18em] mb-5 transition-colors duration-300">Key Features</p>
+        <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-orange-200/70 dark:border-orange-400/25 bg-orange-50/80 dark:bg-orange-400/10 text-xs font-semibold text-orange-700 dark:text-orange-300 uppercase tracking-[0.18em] mb-5 transition-colors duration-300">Key Features</p>
         <h2 class="text-4xl sm:text-5xl md:text-6xl font-semibold text-blue-950 dark:text-white mb-6 tracking-tight text-balance transition-colors duration-300">
           Built for everyone
         </h2>
@@ -26,16 +26,16 @@
           <!-- Card with tinted background alternating blue / orange -->
           <div
             class="relative h-full p-8 rounded-2xl border crisp-card transition-colors duration-300"
-            :class="index % 2 === 1 ? 'bg-white border-blue-200/70' : 'bg-white border-orange-200/70'"
+            :class="index % 2 === 1 ? 'bg-white dark:bg-white/[0.05] border-blue-200/70 dark:border-blue-300/[0.16]' : 'bg-white dark:bg-white/[0.05] border-orange-200/70 dark:border-orange-300/[0.16]'"
           >
 
             <!-- Title -->
-            <h3 class="relative text-xl font-semibold tracking-tight text-blue-950 transition-colors duration-300 mb-4 text-center">
+            <h3 class="relative text-xl font-semibold tracking-tight text-blue-950 dark:text-white transition-colors duration-300 mb-4 text-center">
               {{ feature.title }}
             </h3>
 
             <!-- Description -->
-            <p class="relative text-blue-950/70 leading-relaxed text-pretty mb-6 transition-colors duration-300 text-center">
+            <p class="relative text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty mb-6 transition-colors duration-300 text-center">
               {{ feature.description }}
             </p>
 
@@ -50,12 +50,12 @@
                   <div class="flex-shrink-0 mt-0.5">
                     <div
                       class="w-5 h-5 rounded-full ring-1 flex items-center justify-center transition-all duration-300"
-                      :class="index % 2 === 1 ? 'bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] ring-blue-200/80' : 'bg-orange-100 ring-orange-200/80'"
+                      :class="index % 2 === 1 ? 'bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] dark:from-blue-400/[0.18] dark:to-blue-500/[0.22] ring-blue-200/80 dark:ring-blue-300/[0.18]' : 'bg-orange-100 dark:bg-orange-400/[0.14] ring-orange-200/80 dark:ring-orange-300/[0.18]'"
                     >
-                      <i class="fas fa-check text-[10px]" :class="index % 2 === 1 ? 'text-blue-600' : 'text-orange-600'"></i>
+                      <i class="fas fa-check text-[10px]" :class="index % 2 === 1 ? 'text-blue-600 dark:text-blue-300' : 'text-orange-600 dark:text-orange-300'"></i>
                     </div>
                   </div>
-                  <span class="text-blue-950/70 text-sm leading-relaxed transition-colors duration-300">{{ highlight }}</span>
+                  <span class="text-blue-950/70 dark:text-blue-100/70 text-sm leading-relaxed transition-colors duration-300">{{ highlight }}</span>
                 </li>
               </ul>
             </div>
@@ -121,5 +121,13 @@ export default defineComponent({
     0 1px 2px rgba(15, 23, 42, 0.06),
     0 4px 10px -2px rgba(15, 23, 42, 0.07),
     0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
+
+.dark .crisp-card {
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 12px 28px -10px rgba(0, 0, 0, 0.55);
 }
 </style>

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/StatsSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/StatsSection.vue
@@ -1,11 +1,11 @@
 <!-- Stats Section - Clean Apple/Cursor-inspired design -->
 <template>
-  <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-blue-50 dark:bg-blue-400/[0.16] border-t border-blue-200/60 dark:border-blue-500/[0.12] transition-colors duration-500">
+  <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-blue-50 dark:bg-[#0e141f] border-t border-blue-200/60 dark:border-blue-400/[0.14] transition-colors duration-500">
     <div class="max-w-6xl mx-auto">
 
       <!-- Section header -->
       <div class="text-center mb-16">
-        <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-orange-200/70 dark:border-orange-400/30 bg-orange-50/80 dark:bg-orange-600 text-xs font-semibold text-orange-700 dark:text-white uppercase tracking-[0.18em] mb-5 transition-colors duration-300">Why Imagi</p>
+        <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-orange-200/70 dark:border-orange-400/25 bg-orange-50/80 dark:bg-orange-400/10 text-xs font-semibold text-orange-700 dark:text-orange-300 uppercase tracking-[0.18em] mb-5 transition-colors duration-300">Why Imagi</p>
         <h2 class="text-4xl sm:text-5xl md:text-6xl font-semibold text-blue-950 dark:text-white mb-6 tracking-tight text-balance transition-colors duration-300">
           Fast, affordable, approachable
         </h2>
@@ -19,11 +19,11 @@
         <div
           v-for="(stat, index) in stats"
           :key="index"
-          class="relative text-center p-10 rounded-2xl bg-white border border-blue-200/70 crisp-card"
+          class="relative text-center p-10 rounded-2xl bg-white dark:bg-white/[0.05] border border-blue-200/70 dark:border-blue-300/[0.16] crisp-card transition-colors duration-300"
         >
-          <p class="relative text-sm font-medium uppercase tracking-widest text-blue-700/70 mb-4 transition-colors duration-300">{{ stat.label }}</p>
-          <div class="relative text-5xl md:text-6xl font-semibold tracking-tight tabular-nums text-blue-950 transition-colors duration-300">
-            {{ stat.value }}<span v-if="stat.unit" class="text-3xl text-blue-950/70 ml-1.5 font-medium">{{ stat.unit }}</span>
+          <p class="relative text-sm font-medium uppercase tracking-widest text-blue-700/70 dark:text-blue-300/70 mb-4 transition-colors duration-300">{{ stat.label }}</p>
+          <div class="relative text-5xl md:text-6xl font-semibold tracking-tight tabular-nums text-blue-950 dark:text-white transition-colors duration-300">
+            {{ stat.value }}<span v-if="stat.unit" class="text-3xl text-blue-950/70 dark:text-blue-100/70 ml-1.5 font-medium">{{ stat.unit }}</span>
           </div>
         </div>
       </div>
@@ -39,24 +39,24 @@
           <!-- Card with tinted background matching its accent color -->
           <div
             class="relative h-full p-8 rounded-2xl border crisp-card transition-colors duration-300"
-            :class="index % 2 === 1 ? 'bg-white border-orange-200/70' : 'bg-white border-blue-200/70'"
+            :class="index % 2 === 1 ? 'bg-white dark:bg-white/[0.05] border-orange-200/70 dark:border-orange-300/[0.16]' : 'bg-white dark:bg-white/[0.05] border-blue-200/70 dark:border-blue-300/[0.16]'"
           >
 
             <!-- Icon -->
             <div
               class="relative flex items-center justify-center w-12 h-12 rounded-xl mx-auto mb-5 ring-1 transition-colors duration-300"
-              :class="index % 2 === 1 ? 'bg-orange-100 ring-orange-900/[0.08]' : 'bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] ring-blue-900/[0.08]'"
+              :class="index % 2 === 1 ? 'bg-orange-100 dark:bg-orange-400/[0.14] ring-orange-900/[0.08] dark:ring-orange-300/[0.18]' : 'bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] dark:from-blue-400/[0.18] dark:to-blue-500/[0.22] ring-blue-900/[0.08] dark:ring-blue-300/[0.18]'"
             >
-              <i :class="[metric.icon, 'text-lg', index % 2 === 1 ? 'text-orange-600' : 'text-blue-600']"></i>
+              <i :class="[metric.icon, 'text-lg', index % 2 === 1 ? 'text-orange-600 dark:text-orange-300' : 'text-blue-600 dark:text-blue-300']"></i>
             </div>
 
             <!-- Title -->
-            <h3 class="relative text-xl font-semibold tracking-tight text-blue-950 transition-colors duration-300 mb-4 text-center">
+            <h3 class="relative text-xl font-semibold tracking-tight text-blue-950 dark:text-white transition-colors duration-300 mb-4 text-center">
               {{ metric.title }}
             </h3>
 
             <!-- Description -->
-            <p class="relative text-blue-950/70 leading-relaxed text-pretty transition-colors duration-300 text-center">
+            <p class="relative text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty transition-colors duration-300 text-center">
               {{ metric.description }}
             </p>
           </div>
@@ -120,5 +120,13 @@ export default defineComponent({
     0 1px 2px rgba(15, 23, 42, 0.06),
     0 4px 10px -2px rgba(15, 23, 42, 0.07),
     0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
+
+.dark .crisp-card {
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 12px 28px -10px rgba(0, 0, 0, 0.55);
 }
 </style>

--- a/frontend/vuejs/src/apps/home/views/About.vue
+++ b/frontend/vuejs/src/apps/home/views/About.vue
@@ -6,7 +6,7 @@
       <!-- Main Content -->
       <main class="relative z-10">
         <!-- Hero Section -->
-        <section class="relative py-32 sm:py-40 md:py-48 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-orange-600 transition-colors duration-500 overflow-hidden">
+        <section class="relative py-32 sm:py-40 md:py-48 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-[#16120e] transition-colors duration-500 overflow-hidden">
           <div class="relative max-w-4xl mx-auto text-center">
 
             <!-- Hero title -->
@@ -22,11 +22,11 @@
         </section>
 
         <!-- Mission Section -->
-        <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-blue-50 dark:bg-blue-400/[0.16] border-t border-blue-200/60 dark:border-blue-500/[0.12] transition-colors duration-500 overflow-hidden">
+        <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-blue-50 dark:bg-[#0e141f] border-t border-blue-200/60 dark:border-blue-400/[0.14] transition-colors duration-500 overflow-hidden">
           <div class="relative max-w-6xl mx-auto">
             <!-- Section header -->
             <div class="text-center mb-16 md:mb-20">
-              <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-orange-200/70 dark:border-orange-400/30 bg-orange-50/80 dark:bg-orange-600 text-xs font-semibold text-orange-700 dark:text-white uppercase tracking-[0.18em] mb-5 transition-colors duration-300">Our Mission</p>
+              <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-orange-200/70 dark:border-orange-400/25 bg-orange-50/80 dark:bg-orange-400/10 text-xs font-semibold text-orange-700 dark:text-orange-300 uppercase tracking-[0.18em] mb-5 transition-colors duration-300">Our Mission</p>
               <h2 class="text-4xl sm:text-5xl md:text-6xl font-semibold text-blue-950 dark:text-white mb-6 tracking-tight text-balance transition-colors duration-300">
                 Removing barriers between ideas and reality
               </h2>
@@ -40,13 +40,13 @@
               <div v-for="(card, index) in missionCards" :key="index" class="relative">
                 <div
                   class="relative h-full p-8 rounded-2xl border crisp-card transition-colors duration-300"
-                  :class="index % 2 === 1 ? 'bg-white border-orange-200/70' : 'bg-white border-blue-200/70'"
+                  :class="index % 2 === 1 ? 'bg-white dark:bg-white/[0.05] border-orange-200/70 dark:border-orange-300/[0.16]' : 'bg-white dark:bg-white/[0.05] border-blue-200/70 dark:border-blue-300/[0.16]'"
                 >
                   <!-- Content -->
-                  <h3 class="text-xl font-semibold tracking-tight text-blue-950 transition-colors duration-300 mb-5">
+                  <h3 class="text-xl font-semibold tracking-tight text-blue-950 dark:text-white transition-colors duration-300 mb-5">
                     {{ card.title }}
                   </h3>
-                  <p class="text-blue-950/70 leading-relaxed text-pretty transition-colors duration-300">
+                  <p class="text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty transition-colors duration-300">
                     {{ card.description }}
                   </p>
                 </div>
@@ -56,11 +56,11 @@
         </section>
 
         <!-- What We Do Section -->
-        <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-orange-600 border-t border-orange-200/60 dark:border-orange-500/[0.12] transition-colors duration-500 overflow-hidden">
+        <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-[#16120e] border-t border-orange-200/60 dark:border-orange-400/[0.14] transition-colors duration-500 overflow-hidden">
           <div class="relative max-w-6xl mx-auto">
             <!-- Section header -->
             <div class="text-center mb-16 md:mb-20">
-              <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-blue-200/70 dark:border-blue-400/30 bg-blue-50/80 dark:bg-blue-600 text-xs font-semibold text-blue-700 dark:text-white uppercase tracking-[0.18em] mb-5 transition-colors duration-300">What We Do</p>
+              <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-blue-200/70 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 text-xs font-semibold text-blue-700 dark:text-blue-300 uppercase tracking-[0.18em] mb-5 transition-colors duration-300">What We Do</p>
               <h2 class="text-4xl sm:text-5xl md:text-6xl font-semibold text-blue-950 dark:text-white mb-6 tracking-tight text-balance transition-colors duration-300">
                 A complete AI-powered development platform
               </h2>
@@ -74,13 +74,13 @@
               <div v-for="(feature, index) in features" :key="index" class="relative">
                 <div
                   class="relative h-full p-8 rounded-2xl border crisp-card transition-colors duration-300"
-                  :class="index % 2 === 1 ? 'bg-white border-orange-200/70' : 'bg-white border-blue-200/70'"
+                  :class="index % 2 === 1 ? 'bg-white dark:bg-white/[0.05] border-orange-200/70 dark:border-orange-300/[0.16]' : 'bg-white dark:bg-white/[0.05] border-blue-200/70 dark:border-blue-300/[0.16]'"
                 >
                   <!-- Content -->
-                  <h3 class="text-xl font-semibold tracking-tight text-blue-950 transition-colors duration-300 mb-5 text-center">
+                  <h3 class="text-xl font-semibold tracking-tight text-blue-950 dark:text-white transition-colors duration-300 mb-5 text-center">
                     {{ feature.title }}
                   </h3>
-                  <p class="text-blue-950/70 leading-relaxed text-pretty transition-colors duration-300 text-center">
+                  <p class="text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty transition-colors duration-300 text-center">
                     {{ feature.description }}
                   </p>
                 </div>
@@ -90,11 +90,11 @@
         </section>
 
         <!-- Who We Serve Section -->
-        <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-blue-50 dark:bg-blue-400/[0.16] border-t border-blue-200/60 dark:border-blue-500/[0.12] transition-colors duration-500 overflow-hidden">
+        <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-blue-50 dark:bg-[#0e141f] border-t border-blue-200/60 dark:border-blue-400/[0.14] transition-colors duration-500 overflow-hidden">
           <div class="relative max-w-6xl mx-auto">
             <!-- Section header -->
             <div class="text-center mb-16 md:mb-20">
-              <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-orange-200/70 dark:border-orange-400/30 bg-orange-50/80 dark:bg-orange-600 text-xs font-semibold text-orange-700 dark:text-white uppercase tracking-[0.18em] mb-5 transition-colors duration-300">Who We Serve</p>
+              <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-orange-200/70 dark:border-orange-400/25 bg-orange-50/80 dark:bg-orange-400/10 text-xs font-semibold text-orange-700 dark:text-orange-300 uppercase tracking-[0.18em] mb-5 transition-colors duration-300">Who We Serve</p>
               <h2 class="text-4xl sm:text-5xl md:text-6xl font-semibold text-blue-950 dark:text-white mb-6 tracking-tight text-balance transition-colors duration-300">
                 Built for creators, entrepreneurs, and innovators
               </h2>
@@ -108,13 +108,13 @@
               <div v-for="(userType, index) in userTypes" :key="index" class="relative">
                 <div
                   class="relative h-full p-8 rounded-2xl border crisp-card transition-colors duration-300"
-                  :class="index % 2 === 1 ? 'bg-white border-orange-200/70' : 'bg-white border-blue-200/70'"
+                  :class="index % 2 === 1 ? 'bg-white dark:bg-white/[0.05] border-orange-200/70 dark:border-orange-300/[0.16]' : 'bg-white dark:bg-white/[0.05] border-blue-200/70 dark:border-blue-300/[0.16]'"
                 >
                   <!-- Content -->
-                  <h3 class="text-xl font-semibold tracking-tight text-blue-950 transition-colors duration-300 mb-5">
+                  <h3 class="text-xl font-semibold tracking-tight text-blue-950 dark:text-white transition-colors duration-300 mb-5">
                     {{ userType.title }}
                   </h3>
-                  <p class="text-blue-950/70 leading-relaxed text-pretty transition-colors duration-300">
+                  <p class="text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty transition-colors duration-300">
                     {{ userType.description }}
                   </p>
                 </div>
@@ -236,6 +236,14 @@ export default defineComponent({
     0 1px 2px rgba(15, 23, 42, 0.06),
     0 4px 10px -2px rgba(15, 23, 42, 0.07),
     0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
+
+.dark .crisp-card {
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 12px 28px -10px rgba(0, 0, 0, 0.55);
 }
 
 /* Minimal scrollbar matching Home page */

--- a/frontend/vuejs/src/apps/home/views/PrivacyPolicy.vue
+++ b/frontend/vuejs/src/apps/home/views/PrivacyPolicy.vue
@@ -6,10 +6,10 @@
       <!-- Main Content -->
       <main class="relative z-10">
         <!-- Hero Section -->
-        <section class="relative py-32 sm:py-40 md:py-48 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-orange-600 transition-colors duration-500 overflow-hidden">
+        <section class="relative py-32 sm:py-40 md:py-48 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-[#16120e] transition-colors duration-500 overflow-hidden">
           <div class="relative max-w-4xl mx-auto text-center">
             <!-- Eyebrow pill -->
-            <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-blue-200/70 dark:border-blue-400/30 bg-blue-50/80 dark:bg-blue-600 text-xs font-semibold text-blue-700 dark:text-white uppercase tracking-[0.18em] mb-6 transition-colors duration-300">Legal</p>
+            <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-blue-200/70 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 text-xs font-semibold text-blue-700 dark:text-blue-300 uppercase tracking-[0.18em] mb-6 transition-colors duration-300">Legal</p>
 
             <!-- Hero title -->
             <h1 class="text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-semibold text-blue-950 dark:text-white mb-6 tracking-[-0.025em] leading-[1.08] text-balance transition-colors duration-300">
@@ -32,8 +32,8 @@
                  :class="[
                    'relative py-20 md:py-24 px-6 sm:px-8 lg:px-12 border-t transition-colors duration-500 overflow-hidden',
                    index % 2 === 0
-                     ? 'bg-blue-50 dark:bg-blue-400/[0.16] border-blue-200/60 dark:border-blue-500/[0.12]'
-                     : 'bg-orange-50 dark:bg-orange-600 border-orange-200/60 dark:border-orange-500/[0.12]'
+                     ? 'bg-blue-50 dark:bg-[#0e141f] border-blue-200/60 dark:border-blue-400/[0.14]'
+                     : 'bg-orange-50 dark:bg-[#16120e] border-orange-200/60 dark:border-orange-400/[0.14]'
                  ]">
           <div class="relative max-w-3xl mx-auto">
             <!-- Section header -->
@@ -41,8 +41,8 @@
               <p
                 class="inline-flex items-center px-3.5 py-1.5 rounded-full border text-xs font-semibold uppercase tracking-[0.18em] mb-5 transition-colors duration-300"
                 :class="index % 2 === 0
-                  ? 'border-orange-200/70 dark:border-orange-400/30 bg-orange-50/80 dark:bg-orange-600 text-orange-700 dark:text-white'
-                  : 'border-blue-200/70 dark:border-blue-400/30 bg-blue-50/80 dark:bg-blue-600 text-blue-700 dark:text-white'"
+                  ? 'border-orange-200/70 dark:border-orange-400/25 bg-orange-50/80 dark:bg-orange-400/10 text-orange-700 dark:text-orange-300'
+                  : 'border-blue-200/70 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 text-blue-700 dark:text-blue-300'"
               >
                 {{ parseBadge(section.badge).eyebrow }}
               </p>
@@ -58,11 +58,11 @@
             <div v-if="section.items" class="space-y-4">
               <div v-for="(item, itemIndex) in section.items" :key="itemIndex"
                    class="relative p-6 sm:p-8 rounded-2xl border crisp-card transition-colors duration-300"
-                   :class="itemIndex % 2 === 1 ? 'bg-white border-orange-200/70' : 'bg-white border-blue-200/70'">
-                <h3 class="text-lg sm:text-xl font-semibold text-blue-950 transition-colors duration-300 mb-3">
+                   :class="itemIndex % 2 === 1 ? 'bg-white dark:bg-white/[0.05] border-orange-200/70 dark:border-orange-300/[0.16]' : 'bg-white dark:bg-white/[0.05] border-blue-200/70 dark:border-blue-300/[0.16]'">
+                <h3 class="text-lg sm:text-xl font-semibold text-blue-950 dark:text-white transition-colors duration-300 mb-3">
                   {{ item.title }}
                 </h3>
-                <p class="text-blue-950/70 leading-relaxed text-pretty transition-colors duration-300">
+                <p class="text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty transition-colors duration-300">
                   {{ item.text }}
                 </p>
               </div>
@@ -316,6 +316,14 @@ export default defineComponent({
     0 1px 2px rgba(15, 23, 42, 0.06),
     0 4px 10px -2px rgba(15, 23, 42, 0.07),
     0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
+
+.dark .crisp-card {
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 12px 28px -10px rgba(0, 0, 0, 0.55);
 }
 
 /* Refined minimal scrollbar */

--- a/frontend/vuejs/src/apps/home/views/TermsOfService.vue
+++ b/frontend/vuejs/src/apps/home/views/TermsOfService.vue
@@ -6,10 +6,10 @@
       <!-- Main Content -->
       <main class="relative z-10">
         <!-- Hero Section -->
-        <section class="relative py-32 sm:py-40 md:py-48 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-orange-600 transition-colors duration-500 overflow-hidden">
+        <section class="relative py-32 sm:py-40 md:py-48 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-[#16120e] transition-colors duration-500 overflow-hidden">
           <div class="relative max-w-4xl mx-auto text-center">
             <!-- Eyebrow pill -->
-            <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-blue-200/70 dark:border-blue-400/30 bg-blue-50/80 dark:bg-blue-600 text-xs font-semibold text-blue-700 dark:text-white uppercase tracking-[0.18em] mb-6 transition-colors duration-300">Legal</p>
+            <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-blue-200/70 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 text-xs font-semibold text-blue-700 dark:text-blue-300 uppercase tracking-[0.18em] mb-6 transition-colors duration-300">Legal</p>
 
             <!-- Hero title -->
             <h1 class="text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-semibold text-blue-950 dark:text-white mb-6 tracking-[-0.025em] leading-[1.08] text-balance transition-colors duration-300">
@@ -32,8 +32,8 @@
                  :class="[
                    'relative py-20 md:py-24 px-6 sm:px-8 lg:px-12 border-t transition-colors duration-500 overflow-hidden',
                    index % 2 === 0
-                     ? 'bg-blue-50 dark:bg-blue-400/[0.16] border-blue-200/60 dark:border-blue-500/[0.12]'
-                     : 'bg-orange-50 dark:bg-orange-600 border-orange-200/60 dark:border-orange-500/[0.12]'
+                     ? 'bg-blue-50 dark:bg-[#0e141f] border-blue-200/60 dark:border-blue-400/[0.14]'
+                     : 'bg-orange-50 dark:bg-[#16120e] border-orange-200/60 dark:border-orange-400/[0.14]'
                  ]">
           <div class="relative max-w-3xl mx-auto">
             <!-- Section header -->
@@ -41,8 +41,8 @@
               <p
                 class="inline-flex items-center px-3.5 py-1.5 rounded-full border text-xs font-semibold uppercase tracking-[0.18em] mb-5 transition-colors duration-300"
                 :class="index % 2 === 0
-                  ? 'border-orange-200/70 dark:border-orange-400/30 bg-orange-50/80 dark:bg-orange-600 text-orange-700 dark:text-white'
-                  : 'border-blue-200/70 dark:border-blue-400/30 bg-blue-50/80 dark:bg-blue-600 text-blue-700 dark:text-white'"
+                  ? 'border-orange-200/70 dark:border-orange-400/25 bg-orange-50/80 dark:bg-orange-400/10 text-orange-700 dark:text-orange-300'
+                  : 'border-blue-200/70 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 text-blue-700 dark:text-blue-300'"
               >
                 {{ parseBadge(section.badge).eyebrow }}
               </p>
@@ -58,11 +58,11 @@
             <div v-if="section.items" class="space-y-4">
               <div v-for="(item, itemIndex) in section.items" :key="itemIndex"
                    class="relative p-6 sm:p-8 rounded-2xl border crisp-card transition-colors duration-300"
-                   :class="itemIndex % 2 === 1 ? 'bg-white border-orange-200/70' : 'bg-white border-blue-200/70'">
-                <h3 class="text-lg sm:text-xl font-semibold text-blue-950 transition-colors duration-300 mb-3">
+                   :class="itemIndex % 2 === 1 ? 'bg-white dark:bg-white/[0.05] border-orange-200/70 dark:border-orange-300/[0.16]' : 'bg-white dark:bg-white/[0.05] border-blue-200/70 dark:border-blue-300/[0.16]'">
+                <h3 class="text-lg sm:text-xl font-semibold text-blue-950 dark:text-white transition-colors duration-300 mb-3">
                   {{ item.title }}
                 </h3>
-                <p class="text-blue-950/70 leading-relaxed text-pretty transition-colors duration-300">
+                <p class="text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty transition-colors duration-300">
                   {{ item.text }}
                 </p>
               </div>
@@ -314,6 +314,14 @@ export default defineComponent({
     0 1px 2px rgba(15, 23, 42, 0.06),
     0 4px 10px -2px rgba(15, 23, 42, 0.07),
     0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
+
+.dark .crisp-card {
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 12px 28px -10px rgba(0, 0, 0, 0.55);
 }
 
 /* Refined minimal scrollbar */

--- a/frontend/vuejs/src/shared/layouts/BaseLayout.vue
+++ b/frontend/vuejs/src/shared/layouts/BaseLayout.vue
@@ -1,14 +1,14 @@
 <!-- Base layout - Root wrapper for all layouts -->
 <template>
-  <div class="flex flex-col min-h-screen bg-dark-900">
+  <div class="flex flex-col min-h-screen bg-white dark:bg-[#0a0a0a] transition-colors duration-300">
     <!-- Custom scrollbar and focus styles using arbitrary values -->
     <div class="overflow-auto
-                [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar]:h-2 
-                [&::-webkit-scrollbar-track]:bg-dark-900
-                [&::-webkit-scrollbar-thumb]:bg-dark-700 [&::-webkit-scrollbar-thumb]:rounded
-                [&::-webkit-scrollbar-thumb:hover]:bg-dark-800
+                [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar]:h-2
+                [&::-webkit-scrollbar-track]:bg-transparent
+                [&::-webkit-scrollbar-thumb]:bg-gray-300 dark:[&::-webkit-scrollbar-thumb]:bg-dark-700 [&::-webkit-scrollbar-thumb]:rounded
+                [&::-webkit-scrollbar-thumb:hover]:bg-gray-400 dark:[&::-webkit-scrollbar-thumb:hover]:bg-dark-600
                 [&_*:focus-visible]:outline-2 [&_*:focus-visible]:outline-primary-500 [&_*:focus-visible]:outline-offset-2
-                [scrollbar-width]:thin [scrollbar-color]:dark-700_dark-900">
+                [scrollbar-width]:thin">
       <slot></slot>
     </div>
   </div>

--- a/frontend/vuejs/src/shared/stores/theme.ts
+++ b/frontend/vuejs/src/shared/stores/theme.ts
@@ -110,7 +110,10 @@ export const useThemeStore = defineStore('theme', {
         html.classList.add('light')
         html.classList.remove('dark')
       }
-      
+
+      // Keep native UI (scrollbars, form controls) in sync with the theme
+      html.style.colorScheme = this.effectiveTheme
+
       // Set data attribute for reference
       html.setAttribute('data-theme', this.currentTheme)
     },


### PR DESCRIPTION
## Summary

Studies the baby-blue light design system and translates it into a consistent dark theme across the site, plus fixes to the theme configuration so it conforms to best practices.

### Dark theme (landing, About, Privacy, Terms, docs, auth)

The previous dark styles were inconsistent placeholders (fully saturated `dark:bg-orange-600` heroes, white cards with no dark variants, shadows that vanished on dark). Each light-theme element now has a faithful dark translation:

- **Section alternation preserved**: warm charcoal `#16120e` (dark analogue of the peach `orange-50`) alternating with navy charcoal `#0e141f` (dark analogue of the baby-blue `blue-50`)
- **Cards**: white → translucent elevated surfaces (`white/[0.05]`) keeping tinted blue/orange hairline borders, with the layered "crisp" shadows re-cut in black plus a faint white edge ring
- **Accents**: the orange/blue duo shifts to dark-legible translucent tints (`orange-400/10` pills with `orange-300` text, tinted icon chips)
- **CTA buttons**: the signature baby-blue gradient stays as-is (brand accent) with its 3D shadow stack grounded in deep neutrals

### Theme configuration fixes

- **Eliminate flash of wrong theme**: an inline pre-paint script in `index.html` applies the saved theme before first render; the Pinia store now initializes before mount and takes over seamlessly
- **`color-scheme`** is set alongside the class so native scrollbars and form controls follow the theme
- Removed hardcoded dark backgrounds left over from the old dark-only design (`<body class="bg-gray-900">`, `BaseLayout`'s `bg-dark-900`)

## Testing

- `npm run type-check` passes
- Screenshot-verified in the browser: Home, About, Privacy, Docs (Welcome + Quick Start), Login, and Register in dark mode; Home, About, and Login in light mode (light is unchanged)
- Verified `html` class, `color-scheme`, and `data-theme` stay in sync through toggle changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)