### PR TITLE
Harden payments auth and fail-closed Django settings

### DIFF
--- a/backend/django/apps/Payments/api/views.py
+++ b/backend/django/apps/Payments/api/views.py
@@ -6,7 +6,7 @@ import stripe
 import logging
 from rest_framework import generics, status
 from rest_framework.decorators import api_view, permission_classes
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from django.conf import settings
@@ -642,7 +642,16 @@ def get_session_status(request):
             
         # Retrieve session from Stripe
         session = stripe_service.get_session_status(session_id)
-        
+
+        # Enforce object-level ownership: the session must belong to the caller.
+        # Without this, any authenticated user who obtains another user's
+        # session_id (it is exposed in the success-page URL) could claim that
+        # user's purchased credits to their own balance.
+        if session.metadata.get('user_id') != str(request.user.id):
+            return Response({
+                'error': 'Session not found'
+            }, status=status.HTTP_404_NOT_FOUND)
+
         # Check if payment succeeded
         if session.payment_status == 'paid':
             # Subscription sessions are handled by webhooks, just confirm success
@@ -750,8 +759,16 @@ def verify_webhook(request):
         }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 @api_view(['POST'])
+@permission_classes([AllowAny])
 def webhook(request):
-    """Handle Stripe webhooks."""
+    """Handle Stripe webhooks.
+
+    Authenticated by Stripe's signature (verify_webhook_event) rather than a
+    logged-in session, so it must bypass the DRF default IsAuthenticated —
+    otherwise Stripe's unauthenticated POST is rejected and the webhook never
+    runs (which would leave the ownership-checked, idempotent crediting path
+    dead and force all crediting through the synchronous session-status call).
+    """
     try:
         payload = request.body
         sig_header = request.META.get('HTTP_STRIPE_SIGNATURE')

--- a/backend/django/imagi/settings.py
+++ b/backend/django/imagi/settings.py
@@ -13,6 +13,7 @@ https://docs.djangoproject.com/en/6.0/ref/settings/
 from pathlib import Path
 from urllib.parse import urlparse
 import os
+from django.core.exceptions import ImproperlyConfigured
 from dotenv import load_dotenv
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -25,11 +26,23 @@ load_dotenv(BASE_DIR / '.env')
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/6.0/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', 'django-insecure-=t%ber3f=v$=ldar^nf_=rap!t#%f6d0#+r!94ig5%g6ohjn&c')
-
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get('DJANGO_DEBUG', 'True').lower() in ('true', '1', 'yes')
+# Fail closed: default to False so a misconfigured/unset env never exposes
+# debug pages or stack traces in production.
+DEBUG = os.environ.get('DJANGO_DEBUG', 'False').lower() in ('true', '1', 'yes')
+
+# SECURITY WARNING: keep the secret key used in production secret!
+# No hardcoded fallback: a publicly-known key would allow session-cookie /
+# signed-token forgery. Require it in production; allow an ephemeral
+# dev-only key strictly when DEBUG is on so local commands still work.
+SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')
+if not SECRET_KEY:
+    if DEBUG:
+        SECRET_KEY = 'django-insecure-dev-only-key-do-not-use-in-production'
+    else:
+        raise ImproperlyConfigured(
+            'DJANGO_SECRET_KEY environment variable must be set when DEBUG is False.'
+        )
 
 ALLOWED_HOSTS = [
     h.strip()


### PR DESCRIPTION
## Summary

Backend security fixes surfaced by a security review of the payments module. These are independent of the dark-theme work (already merged in #12) and branch cleanly off the latest `main`.

## Fixes

### 1. Payments IDOR — credit theft (High)
`get_session_status` (`GET /api/v1/payments/session-status/`) credited **`request.user`** using a caller-supplied Stripe `session_id`, without verifying the session belonged to the caller. Since the `session_id` is exposed in the success-page URL (leakable via `Referer`, history, logs), an authenticated attacker could pass a victim's `session_id` and have the victim's purchased credits added to their **own** balance — made permanent by the `unique=True` constraint on `stripe_checkout_session_id`. Now returns 404 unless `session.metadata['user_id']` matches `request.user.id`, mirroring the webhook handler's existing scoping.

### 2. Stripe webhook was unreachable (High, enabler of #1)
The `webhook` view inherited DRF's default `IsAuthenticated`, so Stripe's signature-authenticated (but unauthenticated-session) POST was rejected — the webhook never ran, leaving the ownership-checked, idempotent crediting path dead and forcing all crediting through the vulnerable synchronous endpoint. Added `@permission_classes([AllowAny])`; it remains authenticated by Stripe signature verification.

### 3. Fail-closed Django settings (defense-in-depth)
- `DEBUG` now defaults to `False` (was `True`), so a misconfigured/unset env can't expose stack traces in production.
- `SECRET_KEY` no longer has a hardcoded fallback: production (`DEBUG=False`) requires `DJANGO_SECRET_KEY` or startup raises `ImproperlyConfigured`; a dev-only ephemeral key is used only when `DEBUG` is on. The existing `.env` already sets both, so local dev is unaffected.

## Testing
- `python manage.py check` passes (settings load, imports valid).
- Diff is limited to the two backend files; branched off latest `main` so it merges without conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)