### PR TITLE
Restore cohesive dark theme on Hero, Features, and CTA sections

### DIFF
--- a/frontend/vuejs/src/apps/home/components/organisms/sections/CTASection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/CTASection.vue
@@ -1,6 +1,6 @@
 <!-- CTA Section - Clean Apple/Cursor-inspired design -->
 <template>
-  <section class="relative py-24 sm:py-32 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-orange-700 border-t border-orange-200/60 dark:border-orange-500/[0.12] transition-colors duration-500 overflow-hidden">
+  <section class="relative py-24 sm:py-32 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-[#16120e] border-t border-orange-200/60 dark:border-orange-400/[0.14] transition-colors duration-500 overflow-hidden">
 
     <div class="relative max-w-4xl mx-auto text-center">
 
@@ -9,7 +9,7 @@
         {{ title }}
       </h2>
 
-      <p class="text-xl text-blue-950/70 dark:text-orange-50 leading-relaxed text-pretty mb-10 max-w-2xl mx-auto transition-colors duration-300">
+      <p class="text-xl text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty mb-10 max-w-2xl mx-auto transition-colors duration-300">
         {{ description }}
       </p>
       

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/FeaturesSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/FeaturesSection.vue
@@ -1,6 +1,6 @@
 <!-- Features Section - Clean Apple/Cursor-inspired design -->
 <template>
-  <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-orange-700 border-t border-orange-200/60 dark:border-orange-500/[0.12] transition-colors duration-500 overflow-hidden">
+  <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-[#16120e] border-t border-orange-200/60 dark:border-orange-400/[0.14] transition-colors duration-500 overflow-hidden">
 
     <div class="relative max-w-6xl mx-auto">
 
@@ -10,7 +10,7 @@
         <h2 class="text-4xl sm:text-5xl md:text-6xl font-semibold text-blue-950 dark:text-white mb-6 tracking-tight text-balance transition-colors duration-300">
           Your product-building partner
         </h2>
-        <p class="text-xl text-blue-950/70 dark:text-orange-50 leading-relaxed text-pretty max-w-2xl mx-auto transition-colors duration-300">
+        <p class="text-xl text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty max-w-2xl mx-auto transition-colors duration-300">
           Three simple tools that work together to help you build, test, and launch web applications.
         </p>
       </div>

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/HeroSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/HeroSection.vue
@@ -1,6 +1,6 @@
 <!-- Hero Section - Clean Apple/Cursor-inspired design -->
 <template>
-  <section class="relative py-32 sm:py-40 md:py-48 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-orange-700 transition-colors duration-500 overflow-hidden">
+  <section class="relative py-32 sm:py-40 md:py-48 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-[#16120e] transition-colors duration-500 overflow-hidden">
 
     <div class="relative max-w-4xl mx-auto text-center">
 
@@ -10,7 +10,7 @@
       </h1>
 
       <!-- Subtitle -->
-      <p class="text-lg sm:text-xl text-blue-950/70 dark:text-orange-50 leading-relaxed text-pretty mb-10 max-w-3xl mx-auto transition-colors duration-300">
+      <p class="text-lg sm:text-xl text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty mb-10 max-w-3xl mx-auto transition-colors duration-300">
         Imagi is a suite of AI tools that empowers non-technical developers to build web applications. Design visually, chat with AI, and launch to the web—fast, affordable, and approachable.
       </p>
 


### PR DESCRIPTION
## Summary

The Hero, Features, and CTA sections were reverted to the old saturated-orange dark treatment during a merge conflict resolution on the dark-theme PR (#12), leaving them visually inconsistent with the rest of the landing page. This restores the cohesive dark styling to those three sections. All other pages (Stats, Key Features, About, Privacy, Terms, docs, auth) were unaffected and remain correct.

## Changes (3 files, 6 lines)

Per section, in dark mode only:
- Section background `dark:bg-orange-700` → `dark:bg-[#16120e]` (warm charcoal, matching the charcoal/navy section-alternation used across the page)
- Border `dark:border-orange-500/[0.12]` → `dark:border-orange-400/[0.14]`
- Subtitle/description text `dark:text-orange-50` → `dark:text-blue-100/70` (the consistent body-text color used on every other dark section)

Light mode is untouched.

## Testing
- Verified in the browser (dark mode): the Hero now renders warm charcoal matching the navy section below it, with legible subtitle text.
- Branched off latest `main`; merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)