### PR TITLE
Add business workspace hub template for projects

### DIFF
--- a/frontend/vuejs/src/apps/products/imagi/components/molecules/cards/ProjectCard.vue
+++ b/frontend/vuejs/src/apps/products/imagi/components/molecules/cards/ProjectCard.vue
@@ -1,7 +1,7 @@
 <template>
   <router-link
     v-if="project"
-    :to="{ name: 'builder-workspace', params: { projectName: toSlug(project.name) }}"
+    :to="{ name: 'project-hub', params: { projectName: toSlug(project.name) }}"
     class="crisp-card group relative block px-5 py-3 rounded-2xl bg-white dark:bg-white/[0.05] border border-blue-200/70 dark:border-blue-300/[0.16] hover:border-blue-300 dark:hover:border-blue-300/30 transition-colors duration-300"
     :title="`Open ${project.name}`"
   >
@@ -23,7 +23,7 @@
         {{ project.description }}
       </p>
       <div class="flex items-center justify-center gap-1.5 text-xs font-medium text-blue-700 dark:text-blue-300 group-hover:text-blue-800 dark:group-hover:text-blue-200 transition-colors duration-200 mt-2.5 pt-2.5 border-t border-blue-200/60 dark:border-white/[0.1]">
-        <span>Open workspace</span>
+        <span>Open project</span>
         <i class="fas fa-arrow-right text-xs group-hover:translate-x-1 transition-transform duration-200"></i>
       </div>
     </div>

--- a/frontend/vuejs/src/apps/products/imagi/components/organisms/hub/ToolCategoryCard.vue
+++ b/frontend/vuejs/src/apps/products/imagi/components/organisms/hub/ToolCategoryCard.vue
@@ -1,0 +1,107 @@
+<!--
+  ToolCategoryCard.vue - A single workspace category on the project hub.
+
+  Renders one BusinessTool (Build / Sell / Market / Operate) as a card that
+  links either to the app builder or to the generic coming-soon tool page.
+-->
+<template>
+  <router-link
+    :to="target"
+    class="crisp-card group relative flex flex-col h-full p-6 rounded-2xl bg-white dark:bg-white/[0.05] border transition-colors duration-300"
+    :class="accent.cardBorder"
+    :title="tool.name"
+  >
+    <!-- Soft accent glow on hover -->
+    <div
+      class="pointer-events-none absolute -top-px -right-px w-40 h-40 rounded-full blur-3xl opacity-0 group-hover:opacity-100 bg-gradient-to-br to-transparent transition-opacity duration-500"
+      :class="accent.glow"
+    ></div>
+
+    <!-- Icon + status -->
+    <div class="relative flex items-start justify-between mb-4">
+      <div
+        class="w-12 h-12 rounded-xl flex items-center justify-center border transition-colors duration-300"
+        :class="[accent.iconWrap]"
+      >
+        <i :class="['fas', tool.icon, accent.iconText]" class="text-xl"></i>
+      </div>
+      <span
+        v-if="tool.status === 'available'"
+        class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-[11px] font-semibold uppercase tracking-[0.14em] transition-colors duration-300"
+        :class="accent.badge"
+      >
+        <span class="w-1.5 h-1.5 rounded-full bg-current"></span>
+        Ready
+      </span>
+      <span
+        v-else
+        class="inline-flex items-center px-2.5 py-1 rounded-full border border-blue-950/10 dark:border-white/15 bg-blue-950/[0.03] dark:bg-white/[0.04] text-[11px] font-semibold uppercase tracking-[0.14em] text-blue-950/50 dark:text-white/50 transition-colors duration-300"
+      >
+        Coming soon
+      </span>
+    </div>
+
+    <!-- Name + tagline -->
+    <div class="relative flex-1">
+      <h3 class="text-lg font-semibold text-blue-950 dark:text-white mb-1 transition-colors duration-300">
+        {{ tool.name }}
+      </h3>
+      <p class="text-sm text-blue-950/70 dark:text-blue-100/70 leading-snug transition-colors duration-300">
+        {{ tool.tagline }}
+      </p>
+    </div>
+
+    <!-- CTA -->
+    <div
+      class="relative flex items-center gap-1.5 text-sm font-medium mt-5 pt-4 border-t border-blue-200/60 dark:border-white/[0.1] transition-colors duration-300"
+      :class="accent.link"
+    >
+      <span>{{ tool.status === 'available' ? 'Open workspace' : 'Preview' }}</span>
+      <i class="fas fa-arrow-right text-xs group-hover:translate-x-1 transition-transform duration-200"></i>
+    </div>
+  </router-link>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { RouteLocationRaw } from 'vue-router'
+import { accentClasses, type BusinessTool } from '../../../utils/businessTools'
+
+const props = defineProps<{
+  tool: BusinessTool
+  projectSlug: string
+}>()
+
+const accent = computed(() => accentClasses[props.tool.accent])
+
+const target = computed<RouteLocationRaw>(() => {
+  // "Build" points at the real workspace; everything else uses the generic
+  // coming-soon tool route keyed by the tool's slug.
+  if (props.tool.status === 'available') {
+    return { name: props.tool.routeName, params: { projectName: props.projectSlug } }
+  }
+  return {
+    name: props.tool.routeName,
+    params: { projectName: props.projectSlug, category: props.tool.slug },
+  }
+})
+</script>
+
+<style scoped>
+/* Crisp, sharply-defined card matching Home/About - hairline edge + tight layered shadow */
+.crisp-card {
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.03),
+    0 1px 2px rgba(15, 23, 42, 0.06),
+    0 4px 10px -2px rgba(15, 23, 42, 0.07),
+    0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
+
+:global(.dark) .crisp-card {
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 12px 28px -10px rgba(0, 0, 0, 0.55);
+}
+</style>

--- a/frontend/vuejs/src/apps/products/imagi/components/organisms/hub/index.ts
+++ b/frontend/vuejs/src/apps/products/imagi/components/organisms/hub/index.ts
@@ -1,0 +1,1 @@
+export { default as ToolCategoryCard } from './ToolCategoryCard.vue'

--- a/frontend/vuejs/src/apps/products/imagi/components/organisms/index.ts
+++ b/frontend/vuejs/src/apps/products/imagi/components/organisms/index.ts
@@ -2,4 +2,5 @@
 export * from "./chat";
 export * from "./workspace";
 export * from "./projects";
-export * from "./modals"; 
+export * from "./modals";
+export * from "./hub";

--- a/frontend/vuejs/src/apps/products/imagi/router/index.ts
+++ b/frontend/vuejs/src/apps/products/imagi/router/index.ts
@@ -1,5 +1,7 @@
 import type { RouteRecordRaw } from 'vue-router'
 import Projects from '../views/Projects.vue'
+import ProjectHub from '../views/ProjectHub.vue'
+import ToolCategory from '../views/ToolCategory.vue'
 import Workspace from '../views/Workspace.vue'
 
 const routes: RouteRecordRaw[] = [
@@ -18,15 +20,40 @@ const routes: RouteRecordRaw[] = [
     }
   },
   {
-    path: '/products/imagi/workspace/:projectName',
-    name: 'builder-workspace',
-    component: Workspace,
-    props: route => ({ 
+    path: '/products/imagi/project/:projectName',
+    name: 'project-hub',
+    component: ProjectHub,
+    props: route => ({
       projectName: String(route.params.projectName)
     }),
     meta: {
       requiresAuth: true,
       title: 'Project Workspace'
+    }
+  },
+  {
+    path: '/products/imagi/project/:projectName/:category',
+    name: 'project-tool',
+    component: ToolCategory,
+    props: route => ({
+      projectName: String(route.params.projectName),
+      category: String(route.params.category)
+    }),
+    meta: {
+      requiresAuth: true,
+      title: 'Business Tools'
+    }
+  },
+  {
+    path: '/products/imagi/workspace/:projectName',
+    name: 'builder-workspace',
+    component: Workspace,
+    props: route => ({
+      projectName: String(route.params.projectName)
+    }),
+    meta: {
+      requiresAuth: true,
+      title: 'App Builder'
     }
   }
 ]

--- a/frontend/vuejs/src/apps/products/imagi/utils/businessTools.ts
+++ b/frontend/vuejs/src/apps/products/imagi/utils/businessTools.ts
@@ -1,0 +1,185 @@
+/**
+ * businessTools.ts - Configuration for the Imagi business workspace.
+ *
+ * Imagi lets users BUILD a business (create a web app with AI agents) and RUN
+ * that business (tools for selling, marketing, and operations). This file is the
+ * single source of truth for the categories shown on a project's hub page.
+ *
+ * To add or change a workspace tool, edit the `businessTools` array below. The
+ * hub cards, the coming-soon template pages, and routing all read from here.
+ *
+ * NOTE: Accent color classes are written as full, static Tailwind strings inside
+ * `accentClasses` so the Tailwind JIT compiler can see them. Do not build these
+ * class names dynamically or they will be purged from the production build.
+ */
+
+export type ToolAccent = 'blue' | 'emerald' | 'violet' | 'amber'
+export type ToolStatus = 'available' | 'coming-soon'
+
+/** A single capability listed on a tool category's page. */
+export interface ToolFeature {
+  /** Font Awesome icon class, e.g. "fa-cart-shopping". */
+  icon: string
+  name: string
+  description: string
+}
+
+/** A workspace category shown on the project hub. */
+export interface BusinessTool {
+  /** Stable identifier. */
+  id: string
+  /**
+   * URL segment used for coming-soon tools, e.g. /project/:name/sales.
+   * `null` for tools that route to a dedicated view instead (e.g. Build).
+   */
+  slug: string | null
+  /** Short label, e.g. "Build". */
+  name: string
+  /** One-line summary shown under the name. */
+  tagline: string
+  /** Longer description shown on the tool's own page. */
+  description: string
+  /** Font Awesome icon class, e.g. "fa-wand-magic-sparkles". */
+  icon: string
+  accent: ToolAccent
+  status: ToolStatus
+  /**
+   * Named route to navigate to when the card is clicked. Available tools point
+   * at a real view; coming-soon tools reuse the generic 'project-tool' route.
+   */
+  routeName: string
+  /** Planned capabilities, rendered as a preview on the tool's page. */
+  features: ToolFeature[]
+}
+
+/**
+ * The four pillars of the Imagi workspace. "Build" is live today (the AI app
+ * builder); the rest are general templates that will be filled in later.
+ */
+export const businessTools: BusinessTool[] = [
+  {
+    id: 'build',
+    slug: null,
+    name: 'Build',
+    tagline: 'Create your product with AI',
+    description:
+      'Design and build your web application with AI agents. Describe what you want in plain language and Imagi generates the pages, styling, and logic for your product.',
+    icon: 'fa-wand-magic-sparkles',
+    accent: 'blue',
+    status: 'available',
+    routeName: 'builder-workspace',
+    features: [
+      { icon: 'fa-comments', name: 'AI agents', description: 'Chat with agents that build and edit your app.' },
+      { icon: 'fa-code', name: 'Live workspace', description: 'Generate and refine pages in real time.' },
+      { icon: 'fa-eye', name: 'Instant preview', description: 'See your product update as you build.' },
+    ],
+  },
+  {
+    id: 'sell',
+    slug: 'sales',
+    name: 'Sell',
+    tagline: 'Turn visitors into customers',
+    description:
+      'Everything you need to sell your product or service — storefronts, checkout, orders, and customer relationships, all connected to the app you build.',
+    icon: 'fa-hand-holding-dollar',
+    accent: 'emerald',
+    status: 'coming-soon',
+    routeName: 'project-tool',
+    features: [
+      { icon: 'fa-cart-shopping', name: 'Storefront & checkout', description: 'Sell products and take payments.' },
+      { icon: 'fa-receipt', name: 'Orders', description: 'Track and fulfill customer orders.' },
+      { icon: 'fa-address-book', name: 'CRM', description: 'Manage leads and customer relationships.' },
+    ],
+  },
+  {
+    id: 'market',
+    slug: 'marketing',
+    name: 'Market',
+    tagline: 'Grow your audience',
+    description:
+      'Reach and engage your customers with campaigns, email, social, and content tools — plus the analytics to see what is working.',
+    icon: 'fa-bullhorn',
+    accent: 'violet',
+    status: 'coming-soon',
+    routeName: 'project-tool',
+    features: [
+      { icon: 'fa-envelope-open-text', name: 'Email campaigns', description: 'Design and send email to your audience.' },
+      { icon: 'fa-hashtag', name: 'Social & content', description: 'Plan and publish across channels.' },
+      { icon: 'fa-chart-line', name: 'Marketing analytics', description: 'Measure reach, traffic, and conversion.' },
+    ],
+  },
+  {
+    id: 'operate',
+    slug: 'operations',
+    name: 'Operate',
+    tagline: 'Run the business',
+    description:
+      'Manage the day-to-day of your business — finance, invoicing, and operations — with dashboards that give you a clear view of how things are going.',
+    icon: 'fa-briefcase',
+    accent: 'amber',
+    status: 'coming-soon',
+    routeName: 'project-tool',
+    features: [
+      { icon: 'fa-file-invoice-dollar', name: 'Finance & invoicing', description: 'Track revenue, expenses, and invoices.' },
+      { icon: 'fa-gauge-high', name: 'Operations dashboard', description: 'Monitor the health of your business.' },
+      { icon: 'fa-users-gear', name: 'Team & workflows', description: 'Organize people and recurring work.' },
+    ],
+  },
+]
+
+/** Look up a tool by its URL slug (for coming-soon routes). */
+export function getToolBySlug(slug: string): BusinessTool | undefined {
+  return businessTools.find(tool => tool.slug === slug)
+}
+
+/** Look up a tool by its id. */
+export function getToolById(id: string): BusinessTool | undefined {
+  return businessTools.find(tool => tool.id === id)
+}
+
+/**
+ * Full, static Tailwind class strings per accent. Keep these literal so the JIT
+ * compiler keeps them in the build. Each entry styles the icon tile, badges,
+ * borders, and hover affordances used by the hub card and tool pages.
+ */
+export const accentClasses: Record<ToolAccent, {
+  cardBorder: string
+  iconWrap: string
+  iconText: string
+  badge: string
+  link: string
+  glow: string
+}> = {
+  blue: {
+    cardBorder: 'border-blue-200/70 dark:border-blue-300/[0.16] hover:border-blue-300 dark:hover:border-blue-300/40',
+    iconWrap: 'bg-blue-50 dark:bg-blue-400/10 border-blue-200/60 dark:border-blue-400/25',
+    iconText: 'text-blue-600 dark:text-blue-300',
+    badge: 'border-blue-200/70 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 text-blue-700 dark:text-blue-300',
+    link: 'text-blue-700 dark:text-blue-300 group-hover:text-blue-800 dark:group-hover:text-blue-200',
+    glow: 'from-blue-400/20',
+  },
+  emerald: {
+    cardBorder: 'border-emerald-200/70 dark:border-emerald-300/[0.16] hover:border-emerald-300 dark:hover:border-emerald-300/40',
+    iconWrap: 'bg-emerald-50 dark:bg-emerald-400/10 border-emerald-200/60 dark:border-emerald-400/25',
+    iconText: 'text-emerald-600 dark:text-emerald-300',
+    badge: 'border-emerald-200/70 dark:border-emerald-400/25 bg-emerald-50/80 dark:bg-emerald-400/10 text-emerald-700 dark:text-emerald-300',
+    link: 'text-emerald-700 dark:text-emerald-300 group-hover:text-emerald-800 dark:group-hover:text-emerald-200',
+    glow: 'from-emerald-400/20',
+  },
+  violet: {
+    cardBorder: 'border-violet-200/70 dark:border-violet-300/[0.16] hover:border-violet-300 dark:hover:border-violet-300/40',
+    iconWrap: 'bg-violet-50 dark:bg-violet-400/10 border-violet-200/60 dark:border-violet-400/25',
+    iconText: 'text-violet-600 dark:text-violet-300',
+    badge: 'border-violet-200/70 dark:border-violet-400/25 bg-violet-50/80 dark:bg-violet-400/10 text-violet-700 dark:text-violet-300',
+    link: 'text-violet-700 dark:text-violet-300 group-hover:text-violet-800 dark:group-hover:text-violet-200',
+    glow: 'from-violet-400/20',
+  },
+  amber: {
+    cardBorder: 'border-amber-200/70 dark:border-amber-300/[0.16] hover:border-amber-300 dark:hover:border-amber-300/40',
+    iconWrap: 'bg-amber-50 dark:bg-amber-400/10 border-amber-200/60 dark:border-amber-400/25',
+    iconText: 'text-amber-600 dark:text-amber-300',
+    badge: 'border-amber-200/70 dark:border-amber-400/25 bg-amber-50/80 dark:bg-amber-400/10 text-amber-700 dark:text-amber-300',
+    link: 'text-amber-700 dark:text-amber-300 group-hover:text-amber-800 dark:group-hover:text-amber-200',
+    glow: 'from-amber-400/20',
+  },
+}

--- a/frontend/vuejs/src/apps/products/imagi/views/ProjectHub.vue
+++ b/frontend/vuejs/src/apps/products/imagi/views/ProjectHub.vue
@@ -1,0 +1,138 @@
+<!--
+  ProjectHub.vue - Project Overview / Workspace Hub
+
+  This is the landing page for a single project (business). From here the user
+  chooses how to work on it:
+    - Build   -> the AI app builder (real, existing workspace)
+    - Sell    -> sales tools (general template, coming soon)
+    - Market  -> marketing tools (general template, coming soon)
+    - Operate -> finance & operations tools (general template, coming soon)
+
+  The categories are driven by utils/businessTools.ts. This view is a template
+  shell — it does not implement any of the specific tools.
+-->
+<template>
+  <DefaultLayout :isHomeNav="true">
+    <div class="bg-orange-50 dark:bg-[#16120e] relative transition-colors duration-500 min-h-screen overflow-hidden">
+      <!-- Subtle background matching home page -->
+      <div class="absolute inset-0 pointer-events-none">
+        <div class="absolute inset-0 opacity-[0.015] dark:opacity-[0.02]"
+             style="background-image: linear-gradient(rgba(128,128,128,0.1) 1px, transparent 1px), linear-gradient(90deg, rgba(128,128,128,0.1) 1px, transparent 1px); background-size: 64px 64px;"></div>
+      </div>
+
+      <main class="relative z-10 flex flex-col px-6 sm:px-8 lg:px-12 pt-20 pb-12 min-h-screen">
+        <div class="max-w-6xl mx-auto w-full">
+
+          <!-- Back link -->
+          <router-link
+            :to="{ name: 'projects' }"
+            class="inline-flex items-center gap-2 text-sm font-medium text-blue-950/60 dark:text-blue-100/60 hover:text-blue-950 dark:hover:text-white transition-colors duration-200 mb-6"
+          >
+            <i class="fas fa-arrow-left text-xs"></i>
+            <span>All projects</span>
+          </router-link>
+
+          <!-- Loading -->
+          <div v-if="isLoading" class="flex flex-col items-center justify-center py-24">
+            <div class="w-12 h-12 bg-blue-50 dark:bg-white/[0.06] border border-blue-200/60 dark:border-white/[0.12] rounded-full flex items-center justify-center mb-4">
+              <div class="w-6 h-6 border-2 border-blue-200 dark:border-blue-300/30 border-t-blue-600 dark:border-t-blue-300 rounded-full animate-spin"></div>
+            </div>
+            <p class="text-blue-950/70 dark:text-blue-100/70 text-sm transition-colors duration-300">Loading project...</p>
+          </div>
+
+          <!-- Not found -->
+          <div v-else-if="!project" class="flex flex-col items-center justify-center py-24 text-center">
+            <div class="w-16 h-16 bg-blue-50 dark:bg-white/[0.06] border border-blue-200/60 dark:border-white/[0.12] rounded-full flex items-center justify-center mb-6">
+              <i class="fas fa-folder-open text-2xl text-blue-950/40 dark:text-white/40"></i>
+            </div>
+            <h2 class="text-2xl font-semibold text-blue-950 dark:text-white mb-3 transition-colors duration-300">Project not found</h2>
+            <p class="text-blue-950/70 dark:text-blue-100/70 mb-8 max-w-md transition-colors duration-300">We couldn't find this project. It may have been deleted.</p>
+            <router-link
+              :to="{ name: 'projects' }"
+              class="inline-flex items-center gap-2 px-5 py-2.5 bg-white dark:bg-white/[0.06] hover:bg-blue-50 dark:hover:bg-white/[0.1] border border-blue-200/70 dark:border-white/[0.12] rounded-xl text-blue-950 dark:text-white font-medium text-sm transition-all duration-300"
+            >
+              <i class="fas fa-arrow-left text-sm"></i>
+              <span>Back to projects</span>
+            </router-link>
+          </div>
+
+          <!-- Hub -->
+          <template v-else>
+            <!-- Project header -->
+            <section class="mb-8 md:mb-10">
+              <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-blue-200/70 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 text-xs font-semibold text-blue-700 dark:text-blue-300 uppercase tracking-[0.18em] mb-4 transition-colors duration-300">Project workspace</p>
+              <h1 class="text-3xl sm:text-4xl font-semibold text-blue-950 dark:text-white mb-2 tracking-tight transition-colors duration-300">
+                {{ project.name }}
+              </h1>
+              <p class="text-base text-blue-950/70 dark:text-blue-100/70 max-w-2xl transition-colors duration-300">
+                {{ project.description || 'Build your product and run your business — all in one place. Choose a workspace to get started.' }}
+              </p>
+            </section>
+
+            <!-- Category grid -->
+            <section>
+              <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5">
+                <ToolCategoryCard
+                  v-for="tool in businessTools"
+                  :key="tool.id"
+                  :tool="tool"
+                  :project-slug="projectSlug"
+                />
+              </div>
+            </section>
+          </template>
+        </div>
+      </main>
+    </div>
+  </DefaultLayout>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, watch } from 'vue'
+import { DefaultLayout } from '@/shared/layouts'
+import { useProjectStore } from '../stores/projectStore'
+import { useAuthStore } from '@/shared/stores/auth'
+import { ToolCategoryCard } from '../components/organisms/hub'
+import { businessTools } from '../utils/businessTools'
+import { matchesSlug } from '../utils/slug'
+import type { Project } from '../types/components'
+
+const props = defineProps<{
+  projectName: string
+}>()
+
+const projectStore = useProjectStore()
+const authStore = useAuthStore()
+
+const isInitializing = ref(true)
+
+const projectSlug = computed(() => props.projectName)
+const isLoading = computed(() => projectStore.loading || isInitializing.value)
+
+const project = computed<Project | null>(() => {
+  return projectStore.projects.find(p => matchesSlug(p.name, props.projectName)) || null
+})
+
+async function loadProject() {
+  isInitializing.value = true
+  try {
+    if (!authStore.isAuthenticated) return
+    if (projectStore.isAuthenticated !== authStore.isAuthenticated) {
+      projectStore.setAuthenticated(authStore.isAuthenticated)
+    }
+    // Ensure the projects list is loaded so we can resolve the slug.
+    if (!projectStore.projects.length) {
+      await projectStore.fetchProjects()
+    }
+  } catch (error) {
+    console.error('Failed to load project for hub:', error)
+  } finally {
+    isInitializing.value = false
+  }
+}
+
+onMounted(loadProject)
+
+// Reload if the route param changes (navigating between projects).
+watch(() => props.projectName, loadProject)
+</script>

--- a/frontend/vuejs/src/apps/products/imagi/views/Projects.vue
+++ b/frontend/vuejs/src/apps/products/imagi/views/Projects.vue
@@ -37,7 +37,7 @@
             Your Projects
           </h1>
           <p class="text-base text-blue-950/70 dark:text-blue-100/70 transition-colors duration-300">
-            Create new web applications or continue working on existing projects.
+            Start a new business or keep building and running an existing one.
           </p>
         </section>
 
@@ -75,7 +75,7 @@
                 <div class="mb-5 flex-shrink-0">
                   <p class="inline-flex items-center px-3 py-1 rounded-full border border-blue-200/70 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 text-xs font-semibold text-blue-700 dark:text-blue-300 uppercase tracking-[0.18em] mb-3 transition-colors duration-300">New Project</p>
                   <h2 class="text-2xl font-semibold text-blue-950 dark:text-white mb-2 transition-colors duration-300">Create a Project</h2>
-                  <p class="text-sm text-blue-950/70 dark:text-blue-100/70 transition-colors duration-300">Start building a new web application with AI assistance.</p>
+                  <p class="text-sm text-blue-950/70 dark:text-blue-100/70 transition-colors duration-300">Start a new business — build your product, then sell, market, and run it.</p>
                 </div>
 
                 <!-- Create Form -->
@@ -408,10 +408,10 @@ async function createProject() {
       idType: typeof newProject.id
     })
     
-    // Navigate immediately to the workspace for the newly created project
-    router.push({ 
-      name: 'builder-workspace', 
-      params: { projectName: toSlug(newProject.name) } 
+    // Navigate immediately to the project hub for the newly created project
+    router.push({
+      name: 'project-hub',
+      params: { projectName: toSlug(newProject.name) }
     })
     
   } catch (error: any) {

--- a/frontend/vuejs/src/apps/products/imagi/views/ToolCategory.vue
+++ b/frontend/vuejs/src/apps/products/imagi/views/ToolCategory.vue
@@ -1,0 +1,174 @@
+<!--
+  ToolCategory.vue - Generic "coming soon" template for a business tool.
+
+  Drives the Sell / Market / Operate pages from utils/businessTools.ts. It shows
+  the category's purpose and a preview of the planned capabilities. No specific
+  tool is implemented yet — this is intentionally a template shell.
+
+  Route: /products/imagi/project/:projectName/:category
+-->
+<template>
+  <DefaultLayout :isHomeNav="true">
+    <div class="bg-orange-50 dark:bg-[#16120e] relative transition-colors duration-500 min-h-screen overflow-hidden">
+      <!-- Subtle background matching home page -->
+      <div class="absolute inset-0 pointer-events-none">
+        <div class="absolute inset-0 opacity-[0.015] dark:opacity-[0.02]"
+             style="background-image: linear-gradient(rgba(128,128,128,0.1) 1px, transparent 1px), linear-gradient(90deg, rgba(128,128,128,0.1) 1px, transparent 1px); background-size: 64px 64px;"></div>
+      </div>
+
+      <main class="relative z-10 flex flex-col px-6 sm:px-8 lg:px-12 pt-20 pb-12 min-h-screen">
+        <div class="max-w-5xl mx-auto w-full">
+
+          <!-- Back link -->
+          <router-link
+            :to="{ name: 'project-hub', params: { projectName } }"
+            class="inline-flex items-center gap-2 text-sm font-medium text-blue-950/60 dark:text-blue-100/60 hover:text-blue-950 dark:hover:text-white transition-colors duration-200 mb-6"
+          >
+            <i class="fas fa-arrow-left text-xs"></i>
+            <span>Project workspace</span>
+          </router-link>
+
+          <!-- Unknown category -->
+          <div v-if="!tool" class="flex flex-col items-center justify-center py-24 text-center">
+            <div class="w-16 h-16 bg-blue-50 dark:bg-white/[0.06] border border-blue-200/60 dark:border-white/[0.12] rounded-full flex items-center justify-center mb-6">
+              <i class="fas fa-circle-question text-2xl text-blue-950/40 dark:text-white/40"></i>
+            </div>
+            <h2 class="text-2xl font-semibold text-blue-950 dark:text-white mb-3 transition-colors duration-300">Tool not found</h2>
+            <router-link
+              :to="{ name: 'project-hub', params: { projectName } }"
+              class="inline-flex items-center gap-2 px-5 py-2.5 bg-white dark:bg-white/[0.06] hover:bg-blue-50 dark:hover:bg-white/[0.1] border border-blue-200/70 dark:border-white/[0.12] rounded-xl text-blue-950 dark:text-white font-medium text-sm transition-all duration-300"
+            >
+              <i class="fas fa-arrow-left text-sm"></i>
+              <span>Back to workspace</span>
+            </router-link>
+          </div>
+
+          <template v-else>
+            <!-- Header -->
+            <section class="flex flex-col sm:flex-row sm:items-center gap-5 mb-8">
+              <div
+                class="w-16 h-16 rounded-2xl flex items-center justify-center border flex-shrink-0 transition-colors duration-300"
+                :class="accent.iconWrap"
+              >
+                <i :class="['fas', tool.icon, accent.iconText]" class="text-2xl"></i>
+              </div>
+              <div>
+                <div class="flex items-center gap-3 mb-1.5">
+                  <h1 class="text-3xl font-semibold text-blue-950 dark:text-white tracking-tight transition-colors duration-300">{{ tool.name }}</h1>
+                  <span class="inline-flex items-center px-2.5 py-1 rounded-full border border-blue-950/10 dark:border-white/15 bg-blue-950/[0.03] dark:bg-white/[0.04] text-[11px] font-semibold uppercase tracking-[0.14em] text-blue-950/50 dark:text-white/50 transition-colors duration-300">Coming soon</span>
+                </div>
+                <p class="text-base text-blue-950/70 dark:text-blue-100/70 max-w-2xl transition-colors duration-300">{{ tool.description }}</p>
+              </div>
+            </section>
+
+            <!-- Planned capabilities -->
+            <section class="mb-8">
+              <p class="inline-flex items-center px-3 py-1 rounded-full border text-xs font-semibold uppercase tracking-[0.18em] mb-4 transition-colors duration-300" :class="accent.badge">What's coming</p>
+              <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                <div
+                  v-for="feature in tool.features"
+                  :key="feature.name"
+                  class="crisp-card p-5 rounded-2xl bg-white dark:bg-white/[0.05] border border-blue-200/70 dark:border-blue-300/[0.16] transition-colors duration-300"
+                >
+                  <div class="w-10 h-10 rounded-xl flex items-center justify-center border mb-3 transition-colors duration-300" :class="accent.iconWrap">
+                    <i :class="['fas', feature.icon, accent.iconText]"></i>
+                  </div>
+                  <h3 class="text-base font-semibold text-blue-950 dark:text-white mb-1 transition-colors duration-300">{{ feature.name }}</h3>
+                  <p class="text-sm text-blue-950/70 dark:text-blue-100/70 leading-snug transition-colors duration-300">{{ feature.description }}</p>
+                </div>
+              </div>
+            </section>
+
+            <!-- Placeholder notice -->
+            <section>
+              <div class="crisp-card p-6 md:p-8 rounded-2xl bg-white dark:bg-white/[0.05] border border-blue-200/70 dark:border-blue-300/[0.16] text-center transition-colors duration-300">
+                <div class="w-12 h-12 bg-blue-50 dark:bg-white/[0.06] border border-blue-200/60 dark:border-white/[0.12] rounded-full flex items-center justify-center mx-auto mb-4">
+                  <i class="fas fa-screwdriver-wrench text-xl text-blue-950/40 dark:text-white/40"></i>
+                </div>
+                <h3 class="text-lg font-semibold text-blue-950 dark:text-white mb-2 transition-colors duration-300">We're building this workspace</h3>
+                <p class="text-sm text-blue-950/70 dark:text-blue-100/70 max-w-md mx-auto mb-6 transition-colors duration-300">
+                  {{ tool.name }} tools aren't available yet. In the meantime, you can start building your product with the app builder.
+                </p>
+                <router-link
+                  :to="{ name: 'builder-workspace', params: { projectName } }"
+                  class="btn-3d btn-accent group relative inline-flex items-center justify-center gap-3 px-7 py-3 text-blue-950 rounded-full font-medium text-base overflow-hidden border border-white/60 dark:border-white/30"
+                >
+                  <span class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/70 to-transparent"></span>
+                  <span class="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-blue-900/15 to-transparent"></span>
+                  <i class="fas fa-wand-magic-sparkles relative"></i>
+                  <span class="relative">Open the app builder</span>
+                </router-link>
+              </div>
+            </section>
+          </template>
+        </div>
+      </main>
+    </div>
+  </DefaultLayout>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { DefaultLayout } from '@/shared/layouts'
+import { getToolBySlug, accentClasses } from '../utils/businessTools'
+
+const props = defineProps<{
+  projectName: string
+  category: string
+}>()
+
+const tool = computed(() => getToolBySlug(props.category))
+const accent = computed(() => accentClasses[tool.value?.accent ?? 'blue'])
+</script>
+
+<style scoped>
+/* Crisp, sharply-defined card matching Home/About - hairline edge + tight layered shadow */
+.crisp-card {
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.03),
+    0 1px 2px rgba(15, 23, 42, 0.06),
+    0 4px 10px -2px rgba(15, 23, 42, 0.07),
+    0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
+
+:global(.dark) .crisp-card {
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 12px 28px -10px rgba(0, 0, 0, 0.55);
+}
+
+.btn-3d {
+  transform: translateY(0) translateZ(0);
+  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+  box-shadow:
+    0 1px 2px rgba(30, 58, 138, 0.14),
+    0 4px 10px -2px rgba(30, 58, 138, 0.16),
+    0 10px 20px -6px rgba(30, 58, 138, 0.18),
+    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
+    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.12);
+}
+
+.btn-3d:active {
+  transform: translateY(0) translateZ(0);
+  transition-duration: 0.1s;
+}
+
+.btn-accent {
+  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
+}
+
+:global(.dark) .btn-accent {
+  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
+}
+
+:global(.dark) .btn-3d {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 10px 20px -6px rgba(0, 0, 0, 0.5),
+    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
+    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.18);
+}
+</style>


### PR DESCRIPTION
Restructure the Imagi product workspace around its new purpose: building a
business and running it. Selecting a project now opens a hub where users
choose how to work on it, rather than dropping straight into the app builder.

- Add utils/businessTools.ts as the single source of truth for the four
  workspace categories (Build, Sell, Market, Operate), including accent
  styling and placeholder feature lists.
- Add ProjectHub view: a project overview page presenting the categories.
- Add ToolCategory view: a generic "coming soon" template driving the Sell,
  Market, and Operate pages (no specific tools implemented yet).
- Add ToolCategoryCard organism for the hub grid.
- "Build" links to the existing AI app builder (Workspace) unchanged.
- Route project cards and new-project creation to the hub; add hub and tool
  routes; refresh Projects page copy for the business purpose.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015dDDUZxFtbr1rqKvVB6R7f