### PR TITLE
Replace GPT 5.5 with GPT 5.6 suite (Sol, Terra, Luna) in build section

### DIFF
--- a/backend/django/apps/Products/Imagi/Agents/api/views.py
+++ b/backend/django/apps/Products/Imagi/Agents/api/views.py
@@ -19,6 +19,19 @@ from django.shortcuts import get_object_or_404
 
 from ..models import AgentConversation, AgentMessage
 from ..services import ImagiAgentService, DEFAULT_MODEL
+from apps.Products.Imagi.Builder.services.models_service import get_model_by_id
+
+
+def resolve_model(model):
+    """
+    Resolve a requested model id to a valid GPT 5.6 suite model.
+
+    Any of the available suite models (Sol, Terra, Luna) is accepted; anything
+    unrecognized falls back to the default model.
+    """
+    if model and get_model_by_id(model):
+        return model
+    return DEFAULT_MODEL
 
 # Re-export for URL imports
 __all__ = [
@@ -89,7 +102,8 @@ def chat(request):
     """
     Chat with an AI agent using the OpenAI Agents SDK.
     
-    This endpoint accepts a prompt and generates a response using GPT 5.5.
+    This endpoint accepts a prompt and generates a response using the selected
+    GPT 5.6 suite model (Sol, Terra, or Luna).
     The conversation is threaded if a conversation_id is provided.
     """
     try:
@@ -106,9 +120,8 @@ def chat(request):
         if not message:
             return create_error_response('Message is required', status.HTTP_400_BAD_REQUEST)
         
-        # Force GPT 5.5 for chat mode
-        if not model or model != DEFAULT_MODEL:
-            model = DEFAULT_MODEL
+        # Use the selected GPT 5.6 suite model (falls back to default if invalid)
+        model = resolve_model(model)
         
         # Ensure project_id is an integer if provided
         if project_id:
@@ -184,9 +197,8 @@ def agent(request):
         if not project_id:
             return create_error_response('Project ID is required for agent mode', status.HTTP_400_BAD_REQUEST)
 
-        # Force GPT 5.5 for agent mode
-        if not model or model != DEFAULT_MODEL:
-            model = DEFAULT_MODEL
+        # Use the selected GPT 5.6 suite model (falls back to default if invalid)
+        model = resolve_model(model)
 
         # Ensure project_id is an integer
         try:

--- a/backend/django/apps/Products/Imagi/Agents/migrations/0003_alter_agentconversation_model_name.py
+++ b/backend/django/apps/Products/Imagi/Agents/migrations/0003_alter_agentconversation_model_name.py
@@ -1,0 +1,25 @@
+# Generated for GPT 5.6 suite (Sol, Terra, Luna) model choices update.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('Agents', '0002_alter_agentconversation_options_and_more'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='agentconversation',
+            name='model_name',
+            field=models.CharField(
+                choices=[
+                    ('gpt-5.6-sol', 'GPT 5.6 Sol'),
+                    ('gpt-5.6-terra', 'GPT 5.6 Terra'),
+                    ('gpt-5.6-luna', 'GPT 5.6 Luna'),
+                ],
+                max_length=50,
+            ),
+        ),
+    ]

--- a/backend/django/apps/Products/Imagi/Agents/services/base_agent.py
+++ b/backend/django/apps/Products/Imagi/Agents/services/base_agent.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 OPENAI_API_KEY = os.getenv('OPENAI_KEY') or getattr(settings, 'OPENAI_KEY', None)
 
 # Default model for agents
-DEFAULT_MODEL = "gpt-5.5"
+DEFAULT_MODEL = "gpt-5.6-sol"
 
 
 @dataclass
@@ -60,7 +60,7 @@ class ImagiAgentService:
         Initialize the agent service.
         
         Args:
-            model: The OpenAI model to use (default: gpt-5.5)
+            model: The OpenAI model to use (default: gpt-5.6-sol)
         """
         self.model = model
         self._chat_agent = None

--- a/backend/django/apps/Products/Imagi/Agents/services/chat_agent.py
+++ b/backend/django/apps/Products/Imagi/Agents/services/chat_agent.py
@@ -14,7 +14,7 @@ from agents import Agent, RunContextWrapper
 logger = logging.getLogger(__name__)
 
 # Default model
-DEFAULT_MODEL = "gpt-5.5"
+DEFAULT_MODEL = "gpt-5.6-sol"
 
 # Chat agent system instructions
 CHAT_AGENT_INSTRUCTIONS = """You are an expert web designer and developer called Imagi, a powerful AI platform for building web applications. You assist users with understanding their project code, explaining concepts, and providing guidance on web development using Django, Vue.js, and modern frontend technologies.

--- a/backend/django/apps/Products/Imagi/Agents/services/coding_agent.py
+++ b/backend/django/apps/Products/Imagi/Agents/services/coding_agent.py
@@ -22,7 +22,7 @@ from apps.Products.Imagi.Builder.services.directory_service import DirectoryServ
 logger = logging.getLogger(__name__)
 
 # Default model
-DEFAULT_MODEL = "gpt-5.5"
+DEFAULT_MODEL = "gpt-5.6-sol"
 
 # Coding agent system instructions
 CODING_AGENT_INSTRUCTIONS = """You are Imagi, an expert AI coding assistant for building web applications. You can both chat with users AND directly edit files in their project.

--- a/backend/django/apps/Products/Imagi/Builder/services/models_service.py
+++ b/backend/django/apps/Products/Imagi/Builder/services/models_service.py
@@ -11,17 +11,47 @@ from typing import List, Tuple, Dict, Any
 logger = logging.getLogger(__name__)
 
 # Centralized Model Definitions
+# The GPT 5.6 suite: three tiers users can choose from when building.
+#   Sol   - flagship, most capable (default)
+#   Terra - balanced, general-purpose
+#   Luna  - light, fast and economical
 MODELS = {
-    'gpt-5.5': {
-        'id': 'gpt-5.5',
-        'name': 'GPT 5.5',
+    'gpt-5.6-sol': {
+        'id': 'gpt-5.6-sol',
+        'name': 'GPT 5.6 Sol',
         'provider': 'openai',
         'type': 'openai',
-        'description': 'OpenAI | GPT 5.5 for chat and building assistance',
+        'description': 'OpenAI | GPT 5.6 Sol — flagship model for the most demanding building tasks',
+        'capabilities': ['code_generation', 'chat', 'analysis'],
+        'maxTokens': 128000,
+        'input_price_per_m_tokens': 6,
+        'output_price_per_m_tokens': 30,
+        'api_version': 'responses',  # Uses OpenAI Responses API
+        'supports_temperature': False
+    },
+    'gpt-5.6-terra': {
+        'id': 'gpt-5.6-terra',
+        'name': 'GPT 5.6 Terra',
+        'provider': 'openai',
+        'type': 'openai',
+        'description': 'OpenAI | GPT 5.6 Terra — balanced model for everyday chat and building assistance',
         'capabilities': ['code_generation', 'chat', 'analysis'],
         'maxTokens': 128000,
         'input_price_per_m_tokens': 3,
         'output_price_per_m_tokens': 15,
+        'api_version': 'responses',  # Uses OpenAI Responses API
+        'supports_temperature': False
+    },
+    'gpt-5.6-luna': {
+        'id': 'gpt-5.6-luna',
+        'name': 'GPT 5.6 Luna',
+        'provider': 'openai',
+        'type': 'openai',
+        'description': 'OpenAI | GPT 5.6 Luna — light, fast and economical model for quick tasks',
+        'capabilities': ['code_generation', 'chat', 'analysis'],
+        'maxTokens': 128000,
+        'input_price_per_m_tokens': 1,
+        'output_price_per_m_tokens': 5,
         'api_version': 'responses',  # Uses OpenAI Responses API
         'supports_temperature': False
     }
@@ -43,7 +73,9 @@ MODEL_COSTS = {
 
 # Default model costs for unknown models (per million tokens)
 DEFAULT_MODEL_COSTS = {
-    'gpt-5.5': {'input': 3, 'output': 15},
+    'gpt-5.6-sol': {'input': 6, 'output': 30},
+    'gpt-5.6-terra': {'input': 3, 'output': 15},
+    'gpt-5.6-luna': {'input': 1, 'output': 5},
 }
 
 def get_model_choices() -> List[Tuple[str, str]]:
@@ -108,11 +140,8 @@ def get_model_cost(model_id: str) -> Dict[str, float]:
     amount = MODEL_COSTS.get(model_id)
 
     if amount is None:
-        model_lower = model_id.lower()
-        if model_lower.startswith('gpt-5'):
-            amount = {'input': 3, 'output': 15}
-        else:
-            amount = {'input': 3, 'output': 15}
+        # Fall back to the balanced (Terra) tier pricing for unknown GPT 5.6 ids
+        amount = {'input': 3, 'output': 15}
 
     return amount
 
@@ -132,7 +161,7 @@ def get_default_model_id() -> str:
     Returns:
         str: The default model ID
     """
-    return 'gpt-5.5'
+    return 'gpt-5.6-sol'
 
 def get_model_display_name(model_id: str) -> str:
     """

--- a/backend/django/apps/Products/Imagi/Builder/tests.py
+++ b/backend/django/apps/Products/Imagi/Builder/tests.py
@@ -155,7 +155,7 @@ class BuilderServiceTests(TestCase):
         
         response = process_builder_mode_input(
             user_input="Create a simple landing page",
-            model="gpt-5.5",
+            model="gpt-5.6-sol",
             file_name="index.html",
             user=self.user
         )
@@ -227,7 +227,7 @@ class BuilderIntegrationTests(TestCase):
             reverse('builder:process_input'),
             {
                 'user_input': 'Create a simple landing page',
-                'model': 'gpt-5.5',
+                'model': 'gpt-5.6-sol',
                 'file': 'index.html',
                 'mode': 'build'
             }

--- a/frontend/vuejs/src/apps/payments/components/organisms/sections/ModelPricingSection/ModelPricingSection.vue
+++ b/frontend/vuejs/src/apps/payments/components/organisms/sections/ModelPricingSection/ModelPricingSection.vue
@@ -82,11 +82,25 @@ const props = defineProps({
         description: 'Anthropic\'s advanced model for nuanced tasks'
       },
       {
-        id: 'gpt-5.5',
-        name: 'GPT 5.5',
+        id: 'gpt-5.6-sol',
+        name: 'GPT 5.6 Sol',
+        inputPrice: 6,
+        outputPrice: 30,
+        description: 'OpenAI | GPT 5.6 Sol — flagship model for the most demanding building tasks'
+      },
+      {
+        id: 'gpt-5.6-terra',
+        name: 'GPT 5.6 Terra',
         inputPrice: 3,
         outputPrice: 15,
-        description: 'OpenAI | GPT 5.5 for chat and building assistance'
+        description: 'OpenAI | GPT 5.6 Terra — balanced model for everyday chat and building assistance'
+      },
+      {
+        id: 'gpt-5.6-luna',
+        name: 'GPT 5.6 Luna',
+        inputPrice: 1,
+        outputPrice: 5,
+        description: 'OpenAI | GPT 5.6 Luna — light, fast and economical model for quick tasks'
       }
     ]
   },

--- a/frontend/vuejs/src/apps/products/imagi/components/organisms/sidebar/BuilderSidebarChat.vue
+++ b/frontend/vuejs/src/apps/products/imagi/components/organisms/sidebar/BuilderSidebarChat.vue
@@ -132,16 +132,14 @@ const prompt = ref('')
 const promptTextarea = ref<HTMLTextAreaElement | null>(null)
 
 const modelOptions = computed<AIModel[]>(() => {
-  const available = (store.availableModels || []).filter(model => model.id === 'gpt-5.5')
+  const available = (store.availableModels || []).filter(model => model.id.startsWith('gpt-5.6'))
   if (available.length > 0) {
     return available
   }
   return [
-    {
-      id: 'gpt-5.5',
-      name: 'GPT 5.5',
-      provider: 'openai'
-    } as AIModel
+    { id: 'gpt-5.6-sol', name: 'GPT 5.6 Sol', provider: 'openai' } as AIModel,
+    { id: 'gpt-5.6-terra', name: 'GPT 5.6 Terra', provider: 'openai' } as AIModel,
+    { id: 'gpt-5.6-luna', name: 'GPT 5.6 Luna', provider: 'openai' } as AIModel
   ]
 })
 

--- a/frontend/vuejs/src/apps/products/imagi/services/agentService.ts
+++ b/frontend/vuejs/src/apps/products/imagi/services/agentService.ts
@@ -562,8 +562,8 @@ export const AgentService = {
       throw new Error('Prompt, project ID, and file path are required');
     }
     
-    // Use the provided model or default to GPT 5.5
-    const modelId = model || 'gpt-5.5';
+    // Use the provided model or default to GPT 5.6 Sol
+    const modelId = model || 'gpt-5.6-sol';
     
     try {
       // Get conversation ID if available

--- a/frontend/vuejs/src/apps/products/imagi/stores/agentStore.ts
+++ b/frontend/vuejs/src/apps/products/imagi/stores/agentStore.ts
@@ -5,7 +5,7 @@ import type { BuilderMode, ProjectFile } from '../types/components'
 import { FileService } from '../services/fileService'
 import { AgentService } from '../services/agentService'
 
-const DEFAULT_MODEL_ID = 'gpt-5.5'
+const DEFAULT_MODEL_ID = 'gpt-5.6-sol'
 
 function newLocalId(): string {
   return `inst-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`

--- a/frontend/vuejs/src/apps/products/imagi/types/services.ts
+++ b/frontend/vuejs/src/apps/products/imagi/types/services.ts
@@ -56,7 +56,25 @@ export interface UndoResponse {
  * Map of model configurations by model ID
  */
 export const MODEL_CONFIGS: Record<string, ModelConfig> = {
-  'gpt-5.5': {
+  'gpt-5.6-sol': {
+    maxTokens: 128000,
+    rateLimits: {
+      tokensPerMinute: 60000,
+      requestsPerMinute: 250
+    },
+    contextWindow: 128000,
+    capabilities: ['code_generation', 'chat', 'analysis']
+  },
+  'gpt-5.6-terra': {
+    maxTokens: 128000,
+    rateLimits: {
+      tokensPerMinute: 60000,
+      requestsPerMinute: 250
+    },
+    contextWindow: 128000,
+    capabilities: ['code_generation', 'chat', 'analysis']
+  },
+  'gpt-5.6-luna': {
     maxTokens: 128000,
     rateLimits: {
       tokensPerMinute: 60000,
@@ -67,20 +85,48 @@ export const MODEL_CONFIGS: Record<string, ModelConfig> = {
   }
 };
 
-// List of standard models
+// List of standard models — the GPT 5.6 suite (Sol, Terra, Luna)
 export const AI_MODELS: AIModel[] = [
   {
-    id: 'gpt-5.5',
-    name: 'GPT 5.5',
+    id: 'gpt-5.6-sol',
+    name: 'GPT 5.6 Sol',
     provider: 'openai',
     type: 'openai',
     context_window: 128000,
     features: ['chat', 'code', 'analysis'],
-    description: 'OpenAI | GPT 5.5 for chat and building assistance',
+    description: 'OpenAI | GPT 5.6 Sol — flagship model for the most demanding building tasks',
+    capabilities: ['code_generation', 'chat', 'analysis'],
+    maxTokens: 128000,
+    inputPricePerMTokens: 6,
+    outputPricePerMTokens: 30,
+    api_version: 'responses'
+  },
+  {
+    id: 'gpt-5.6-terra',
+    name: 'GPT 5.6 Terra',
+    provider: 'openai',
+    type: 'openai',
+    context_window: 128000,
+    features: ['chat', 'code', 'analysis'],
+    description: 'OpenAI | GPT 5.6 Terra — balanced model for everyday chat and building assistance',
     capabilities: ['code_generation', 'chat', 'analysis'],
     maxTokens: 128000,
     inputPricePerMTokens: 3,
     outputPricePerMTokens: 15,
+    api_version: 'responses'
+  },
+  {
+    id: 'gpt-5.6-luna',
+    name: 'GPT 5.6 Luna',
+    provider: 'openai',
+    type: 'openai',
+    context_window: 128000,
+    features: ['chat', 'code', 'analysis'],
+    description: 'OpenAI | GPT 5.6 Luna — light, fast and economical model for quick tasks',
+    capabilities: ['code_generation', 'chat', 'analysis'],
+    maxTokens: 128000,
+    inputPricePerMTokens: 1,
+    outputPricePerMTokens: 5,
     api_version: 'responses'
   }
 ];

--- a/frontend/vuejs/src/apps/products/imagi/views/Workspace.vue
+++ b/frontend/vuejs/src/apps/products/imagi/views/Workspace.vue
@@ -544,7 +544,7 @@ async function retryProjectLoad() {
 
     const active = store.activeInstance
     if (active && !active.selectedModelId && store.availableModels && store.availableModels.length > 0) {
-      const defaultModel = store.availableModels.find(m => m.id === 'gpt-5.5')
+      const defaultModel = store.availableModels.find(m => m.id === 'gpt-5.6-sol')
         || store.availableModels[0];
       if (defaultModel) {
         store.setInstanceModel(active.id, defaultModel.id)
@@ -701,7 +701,7 @@ onMounted(async () => {
         // Ensure active instance has a model selected
         const active = store.activeInstance
         if (active && !active.selectedModelId && store.availableModels && store.availableModels.length > 0) {
-          const defaultModel = store.availableModels.find(m => m.id === 'gpt-5.5')
+          const defaultModel = store.availableModels.find(m => m.id === 'gpt-5.6-sol')
             || store.availableModels[0];
           if (defaultModel) {
             store.setInstanceModel(active.id, defaultModel.id)


### PR DESCRIPTION
Swap the single GPT 5.5 model used across the project build workspace for
the three-model GPT 5.6 suite, and let users choose among them:

- Sol (flagship, default) - $6/$30 per M tokens
- Terra (balanced)        - $3/$15 per M tokens
- Luna (light, economical)- $1/$5  per M tokens

Backend:
- Define the three models in the centralized Builder models_service, with
  tiered pricing and gpt-5.6-sol as the default.
- Point the base/chat/coding agent DEFAULT_MODEL at gpt-5.6-sol.
- Accept any suite model in the chat/agent endpoints instead of forcing a
  single model, falling back to the default when unrecognized.
- Add migration for the AgentConversation.model_name choices.

Frontend:
- Update AI_MODELS/MODEL_CONFIGS and the builder sidebar to offer all three
  suite models, defaulting to Sol.
- Refresh the payments model pricing section with the new tiers.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019M2o63E1ZYjSjxWjKiVQJ6