### PR TITLE
Switch build section to GPT 5.6 suite (Sol/Terra/Luna) with reasoning effort

### DIFF
--- a/backend/django/apps/Products/Imagi/Agents/api/views.py
+++ b/backend/django/apps/Products/Imagi/Agents/api/views.py
@@ -110,38 +110,39 @@ def chat(request):
         # Extract request data
         message = request.data.get('message')
         model = request.data.get('model', DEFAULT_MODEL)
+        reasoning_effort = request.data.get('reasoning_effort')
         conversation_id = request.data.get('conversation_id')
         project_id = request.data.get('project_id')
         current_file = request.data.get('current_file')
-        
+
         logger.info(f"Chat API request - Model: {model}, Project ID: {project_id}")
-        
+
         # Validate required fields
         if not message:
             return create_error_response('Message is required', status.HTTP_400_BAD_REQUEST)
-        
+
         # Use the selected GPT 5.6 suite model (falls back to default if invalid)
         model = resolve_model(model)
-        
+
         # Ensure project_id is an integer if provided
         if project_id:
             try:
                 project_id = int(project_id)
             except (ValueError, TypeError):
                 project_id = None
-        
+
         # Ensure conversation_id is an integer if provided
         if conversation_id:
             try:
                 conversation_id = int(conversation_id)
             except (ValueError, TypeError):
                 conversation_id = None
-        
+
         # Create agent service instance
-        agent_service = ImagiAgentService(model=model)
-        
-        logger.info(f"Chat request: message length={len(message)}, model={model}, project_id={project_id}")
-        
+        agent_service = ImagiAgentService(model=model, reasoning_effort=reasoning_effort)
+
+        logger.info(f"Chat request: message length={len(message)}, model={model}, effort={reasoning_effort}, project_id={project_id}")
+
         # Process the chat message
         result = agent_service.process_chat(
             user_input=message,
@@ -150,6 +151,7 @@ def chat(request):
             project_id=project_id,
             current_file=current_file,
             conversation_id=conversation_id,
+            reasoning_effort=reasoning_effort,
         )
         
         # Check for success
@@ -185,6 +187,7 @@ def agent(request):
     try:
         message = request.data.get('message')
         model = request.data.get('model', DEFAULT_MODEL)
+        reasoning_effort = request.data.get('reasoning_effort')
         conversation_id = request.data.get('conversation_id')
         project_id = request.data.get('project_id')
         current_file = request.data.get('current_file')
@@ -214,9 +217,9 @@ def agent(request):
                 conversation_id = None
 
         # Create agent service instance
-        agent_service = ImagiAgentService(model=model)
+        agent_service = ImagiAgentService(model=model, reasoning_effort=reasoning_effort)
 
-        logger.info(f"Agent request: message length={len(message)}, model={model}, project_id={project_id}")
+        logger.info(f"Agent request: message length={len(message)}, model={model}, effort={reasoning_effort}, project_id={project_id}")
 
         # Process the message with the coding agent
         result = agent_service.process_agent(
@@ -226,6 +229,7 @@ def agent(request):
             project_id=project_id,
             current_file=current_file,
             conversation_id=conversation_id,
+            reasoning_effort=reasoning_effort,
         )
 
         if not result.get('success', False):

--- a/backend/django/apps/Products/Imagi/Agents/services/base_agent.py
+++ b/backend/django/apps/Products/Imagi/Agents/services/base_agent.py
@@ -13,6 +13,17 @@ from dataclasses import dataclass
 from dotenv import load_dotenv
 
 from agents import Agent, Runner, handoff, RunConfig
+
+try:  # ModelSettings location can vary across SDK versions
+    from agents import ModelSettings
+except ImportError:  # pragma: no cover - defensive fallback
+    ModelSettings = None
+
+try:  # Reasoning config for the OpenAI Responses API
+    from openai.types.shared import Reasoning
+except ImportError:  # pragma: no cover - defensive fallback
+    Reasoning = None
+
 from agents.extensions.handoff_prompt import RECOMMENDED_PROMPT_PREFIX
 
 from django.conf import settings
@@ -31,6 +42,24 @@ OPENAI_API_KEY = os.getenv('OPENAI_KEY') or getattr(settings, 'OPENAI_KEY', None
 
 # Default model for agents
 DEFAULT_MODEL = "gpt-5.6-sol"
+
+
+def build_model_settings(reasoning_effort: Optional[str] = None):
+    """
+    Build ModelSettings for an agent, applying a reasoning effort level when one
+    is provided (and supported by the installed SDK).
+
+    Returns None when ModelSettings is unavailable, so callers can omit the
+    argument entirely and fall back to SDK defaults.
+    """
+    if ModelSettings is None:
+        return None
+    if reasoning_effort and Reasoning is not None:
+        try:
+            return ModelSettings(reasoning=Reasoning(effort=reasoning_effort))
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning(f"Could not apply reasoning effort '{reasoning_effort}': {e}")
+    return ModelSettings()
 
 
 @dataclass
@@ -55,14 +84,17 @@ class ImagiAgentService:
     - Integration with Django models
     """
     
-    def __init__(self, model: str = DEFAULT_MODEL):
+    def __init__(self, model: str = DEFAULT_MODEL, reasoning_effort: Optional[str] = None):
         """
         Initialize the agent service.
-        
+
         Args:
             model: The OpenAI model to use (default: gpt-5.6-sol)
+            reasoning_effort: How much reasoning the model should use
+                ('low', 'medium', 'high'). None uses the model default.
         """
         self.model = model
+        self.reasoning_effort = reasoning_effort
         self._chat_agent = None
         self._coding_agent = None
         self._orchestrator_agent = None
@@ -74,12 +106,20 @@ class ImagiAgentService:
             # Set environment variable for the agents SDK
             os.environ['OPENAI_API_KEY'] = OPENAI_API_KEY
     
+    def _apply_reasoning_effort(self, reasoning_effort: Optional[str]) -> None:
+        """Update the reasoning effort, invalidating cached agents if it changed."""
+        if reasoning_effort is not None and reasoning_effort != self.reasoning_effort:
+            self.reasoning_effort = reasoning_effort
+            self._chat_agent = None
+            self._coding_agent = None
+            self._orchestrator_agent = None
+
     @property
     def coding_agent(self) -> Agent:
         """Lazy-load the coding agent."""
         if self._coding_agent is None:
             from .coding_agent import create_coding_agent
-            self._coding_agent = create_coding_agent(self.model)
+            self._coding_agent = create_coding_agent(self.model, self.reasoning_effort)
         return self._coding_agent
 
     @property
@@ -87,7 +127,7 @@ class ImagiAgentService:
         """Lazy-load the chat agent."""
         if self._chat_agent is None:
             from .chat_agent import create_chat_agent
-            self._chat_agent = create_chat_agent(self.model)
+            self._chat_agent = create_chat_agent(self.model, self.reasoning_effort)
         return self._chat_agent
     
     @property
@@ -128,17 +168,24 @@ Technology Stack:
 - HTTP client: Axios
 """
         
+        from apps.Products.Imagi.Builder.services.models_service import get_backend_model_id
+        backend_model = get_backend_model_id(self.model)
+        kwargs = {}
+        settings = build_model_settings(self.reasoning_effort)
+        if settings is not None:
+            kwargs['model_settings'] = settings
         return Agent[AgentContext](
             name="Imagi Orchestrator",
             instructions=instructions,
-            model=self.model,
+            model=backend_model,
             handoffs=[
                 handoff(
                     agent=self.chat_agent,
                     tool_description="Hand off to the chat agent for general conversations, "
                                      "questions, explanations, and guidance about web development."
                 )
-            ]
+            ],
+            **kwargs
         )
     
     # -------------------------------------------------------------------------
@@ -252,10 +299,11 @@ Technology Stack:
         project_id: Optional[int] = None,
         current_file: Optional[Dict[str, Any]] = None,
         conversation_id: Optional[int] = None,
+        reasoning_effort: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Process a chat message using the OpenAI Agents SDK.
-        
+
         Args:
             user_input: The user's message
             user: The Django user object
@@ -263,7 +311,8 @@ Technology Stack:
             project_id: Optional project ID
             current_file: Optional current file context
             conversation_id: Optional existing conversation ID
-            
+            reasoning_effort: How much reasoning to use ('low', 'medium', 'high')
+
         Returns:
             Dict containing the response and metadata
         """
@@ -271,8 +320,9 @@ Technology Stack:
             # Validate input
             if not user_input:
                 return {"success": False, "error": "Message is required"}
-            
+
             model = model or self.model
+            self._apply_reasoning_effort(reasoning_effort)
             
             # Get or create conversation
             if conversation_id:
@@ -351,6 +401,7 @@ Technology Stack:
         project_id: Optional[int] = None,
         current_file: Optional[Dict[str, Any]] = None,
         conversation_id: Optional[int] = None,
+        reasoning_effort: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Process a message using the Coding Agent (agent mode).
@@ -364,6 +415,7 @@ Technology Stack:
             project_id: Project ID (required for agent mode)
             current_file: Optional current file context
             conversation_id: Optional existing conversation ID
+            reasoning_effort: How much reasoning to use ('low', 'medium', 'high')
 
         Returns:
             Dict containing the response, metadata, and list of changed files
@@ -376,6 +428,7 @@ Technology Stack:
                 return {"success": False, "error": "Project ID is required for agent mode"}
 
             model = model or self.model
+            self._apply_reasoning_effort(reasoning_effort)
 
             # Get or create conversation
             if conversation_id:

--- a/backend/django/apps/Products/Imagi/Agents/services/chat_agent.py
+++ b/backend/django/apps/Products/Imagi/Agents/services/chat_agent.py
@@ -10,6 +10,12 @@ from typing import Optional
 
 from agents import Agent, RunContextWrapper
 
+from apps.Products.Imagi.Builder.services.models_service import (
+    get_backend_model_id,
+    resolve_reasoning_effort,
+)
+from .base_agent import build_model_settings
+
 # Configure logging
 logger = logging.getLogger(__name__)
 
@@ -105,41 +111,57 @@ def get_dynamic_chat_instructions(context: RunContextWrapper, agent: Agent) -> s
     return instructions
 
 
-def create_chat_agent(model: str = DEFAULT_MODEL) -> Agent:
+def create_chat_agent(model: str = DEFAULT_MODEL, reasoning_effort: Optional[str] = None) -> Agent:
     """
     Create a chat agent for natural language conversations.
-    
+
     Args:
-        model: The OpenAI model to use
-        
+        model: The public suite model id (mapped to the real OpenAI model)
+        reasoning_effort: How much reasoning to use ('low', 'medium', 'high')
+
     Returns:
         Agent: The configured chat agent
     """
+    backend_model = get_backend_model_id(model)
+    effort = resolve_reasoning_effort(model, reasoning_effort)
+    kwargs = {}
+    settings = build_model_settings(effort)
+    if settings is not None:
+        kwargs['model_settings'] = settings
     return Agent(
         name="Chat Agent",
         instructions=get_dynamic_chat_instructions,
-        model=model,
+        model=backend_model,
         handoff_description="A helpful assistant for chatting about web development, "
-                           "answering questions, and providing guidance."
+                           "answering questions, and providing guidance.",
+        **kwargs
     )
 
 
-def create_simple_chat_agent(model: str = DEFAULT_MODEL) -> Agent:
+def create_simple_chat_agent(model: str = DEFAULT_MODEL, reasoning_effort: Optional[str] = None) -> Agent:
     """
     Create a simple chat agent with static instructions.
-    
+
     Use this when you don't have context to pass to the agent.
-    
+
     Args:
-        model: The OpenAI model to use
-        
+        model: The public suite model id (mapped to the real OpenAI model)
+        reasoning_effort: How much reasoning to use ('low', 'medium', 'high')
+
     Returns:
         Agent: The configured chat agent
     """
+    backend_model = get_backend_model_id(model)
+    effort = resolve_reasoning_effort(model, reasoning_effort)
+    kwargs = {}
+    settings = build_model_settings(effort)
+    if settings is not None:
+        kwargs['model_settings'] = settings
     return Agent(
         name="Chat Agent",
         instructions=CHAT_AGENT_INSTRUCTIONS,
-        model=model,
+        model=backend_model,
         handoff_description="A helpful assistant for chatting about web development, "
-                           "answering questions, and providing guidance."
+                           "answering questions, and providing guidance.",
+        **kwargs
     )

--- a/backend/django/apps/Products/Imagi/Agents/services/coding_agent.py
+++ b/backend/django/apps/Products/Imagi/Agents/services/coding_agent.py
@@ -17,6 +17,11 @@ from apps.Products.Imagi.Builder.services.view_file_service import ViewFileServi
 from apps.Products.Imagi.Builder.services.create_file_service import CreateFileService
 from apps.Products.Imagi.Builder.services.delete_file_service import DeleteFileService
 from apps.Products.Imagi.Builder.services.directory_service import DirectoryService
+from apps.Products.Imagi.Builder.services.models_service import (
+    get_backend_model_id,
+    resolve_reasoning_effort,
+)
+from .base_agent import build_model_settings
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -366,21 +371,29 @@ def get_dynamic_coding_instructions(context: RunContextWrapper, agent: Agent) ->
     return instructions
 
 
-def create_coding_agent(model: str = DEFAULT_MODEL) -> Agent:
+def create_coding_agent(model: str = DEFAULT_MODEL, reasoning_effort: Optional[str] = None) -> Agent:
     """
     Create a coding agent that can chat and edit project files.
 
     Args:
-        model: The OpenAI model to use
+        model: The public suite model id (mapped to the real OpenAI model)
+        reasoning_effort: How much reasoning to use ('low', 'medium', 'high')
 
     Returns:
         Agent: The configured coding agent with file tools
     """
+    backend_model = get_backend_model_id(model)
+    effort = resolve_reasoning_effort(model, reasoning_effort)
+    kwargs = {}
+    settings = build_model_settings(effort)
+    if settings is not None:
+        kwargs['model_settings'] = settings
     return Agent(
         name="Coding Agent",
         instructions=get_dynamic_coding_instructions,
-        model=model,
+        model=backend_model,
         tools=[get_project_tree, list_project_files, read_file, update_file, create_file, delete_file, create_directory, delete_directory],
         handoff_description="A coding assistant that can chat about web development "
-                           "and directly edit files in the user's project."
+                           "and directly edit files in the user's project.",
+        **kwargs
     )

--- a/backend/django/apps/Products/Imagi/Builder/services/models_service.py
+++ b/backend/django/apps/Products/Imagi/Builder/services/models_service.py
@@ -15,47 +15,68 @@ logger = logging.getLogger(__name__)
 #   Sol   - flagship, most capable (default)
 #   Terra - balanced, general-purpose
 #   Luna  - light, fast and economical
+#
+# `backend_model` is the REAL OpenAI model id the suite id maps to at runtime.
+# The public "GPT 5.6 ..." names are Imagi's branding; requests to the OpenAI
+# API must use these underlying model ids. Change the right-hand side here if
+# your OpenAI account should call different underlying models.
 MODELS = {
     'gpt-5.6-sol': {
         'id': 'gpt-5.6-sol',
         'name': 'GPT 5.6 Sol',
         'provider': 'openai',
         'type': 'openai',
+        'backend_model': 'gpt-5',
         'description': 'OpenAI | GPT 5.6 Sol — flagship model for the most demanding building tasks',
         'capabilities': ['code_generation', 'chat', 'analysis'],
         'maxTokens': 128000,
         'input_price_per_m_tokens': 6,
         'output_price_per_m_tokens': 30,
         'api_version': 'responses',  # Uses OpenAI Responses API
-        'supports_temperature': False
+        'supports_temperature': False,
+        'supports_reasoning': True
     },
     'gpt-5.6-terra': {
         'id': 'gpt-5.6-terra',
         'name': 'GPT 5.6 Terra',
         'provider': 'openai',
         'type': 'openai',
+        'backend_model': 'gpt-5-mini',
         'description': 'OpenAI | GPT 5.6 Terra — balanced model for everyday chat and building assistance',
         'capabilities': ['code_generation', 'chat', 'analysis'],
         'maxTokens': 128000,
         'input_price_per_m_tokens': 3,
         'output_price_per_m_tokens': 15,
         'api_version': 'responses',  # Uses OpenAI Responses API
-        'supports_temperature': False
+        'supports_temperature': False,
+        'supports_reasoning': True
     },
     'gpt-5.6-luna': {
         'id': 'gpt-5.6-luna',
         'name': 'GPT 5.6 Luna',
         'provider': 'openai',
         'type': 'openai',
+        'backend_model': 'gpt-5-nano',
         'description': 'OpenAI | GPT 5.6 Luna — light, fast and economical model for quick tasks',
         'capabilities': ['code_generation', 'chat', 'analysis'],
         'maxTokens': 128000,
         'input_price_per_m_tokens': 1,
         'output_price_per_m_tokens': 5,
         'api_version': 'responses',  # Uses OpenAI Responses API
-        'supports_temperature': False
+        'supports_temperature': False,
+        'supports_reasoning': True
     }
 }
+
+# Reasoning effort levels users can pick per request. Applied to the OpenAI
+# Responses API `reasoning.effort` parameter for reasoning-capable models.
+REASONING_EFFORT_CHOICES = [
+    ('low', 'Low'),
+    ('medium', 'Medium'),
+    ('high', 'High'),
+]
+REASONING_EFFORT_IDS = [effort_id for effort_id, _ in REASONING_EFFORT_CHOICES]
+DEFAULT_REASONING_EFFORT = 'medium'
 
 # Provider Choices
 PROVIDER_CHOICES = [
@@ -205,15 +226,82 @@ def get_api_version_from_model_id(model_id: str) -> str:
 def get_models_by_provider(provider: str) -> List[Dict[str, Any]]:
     """
     Get all models for a specific provider.
-    
+
     Args:
         provider: The provider name
-        
+
     Returns:
         list: List of model definitions for the provider
     """
     return [model_data for model_id, model_data in MODELS.items()
             if model_data.get('provider') == provider]
+
+def get_backend_model_id(model_id: str) -> str:
+    """
+    Resolve a public suite model id (e.g. 'gpt-5.6-sol') to the real underlying
+    OpenAI model id used for API calls (e.g. 'gpt-5').
+
+    Falls back to the given id when the model is unknown or defines no explicit
+    backend model, so callers always receive a usable string.
+
+    Args:
+        model_id: The public model ID
+
+    Returns:
+        str: The underlying OpenAI model id to send to the API
+    """
+    model = get_model_by_id(model_id)
+    if model and model.get('backend_model'):
+        return model['backend_model']
+    return model_id
+
+def get_reasoning_effort_choices() -> List[Tuple[str, str]]:
+    """
+    Get reasoning effort choices for Django model fields / UI.
+
+    Returns:
+        list: List of tuples with (id, name) for each effort level
+    """
+    return REASONING_EFFORT_CHOICES
+
+def get_default_reasoning_effort() -> str:
+    """Get the default reasoning effort level."""
+    return DEFAULT_REASONING_EFFORT
+
+def is_valid_reasoning_effort(effort: str) -> bool:
+    """Whether the given reasoning effort level is recognized."""
+    return effort in REASONING_EFFORT_IDS
+
+def model_supports_reasoning(model_id: str) -> bool:
+    """
+    Whether the model supports the reasoning 'effort' parameter.
+    Defaults to False when the model is unknown.
+    """
+    model = get_model_by_id(model_id)
+    if not model:
+        return False
+    return model.get('supports_reasoning', False)
+
+def resolve_reasoning_effort(model_id: str, effort: str) -> str:
+    """
+    Resolve the reasoning effort to apply for a request.
+
+    Returns None when the model does not support reasoning (so callers can omit
+    the parameter entirely). Otherwise returns the requested effort when valid,
+    falling back to the default effort.
+
+    Args:
+        model_id: The public model ID
+        effort: The requested reasoning effort level (may be None/invalid)
+
+    Returns:
+        str or None: A valid effort level, or None if reasoning is unsupported
+    """
+    if not model_supports_reasoning(model_id):
+        return None
+    if effort and is_valid_reasoning_effort(effort):
+        return effort
+    return DEFAULT_REASONING_EFFORT
 
 
 class ModelsService:

--- a/frontend/vuejs/src/apps/products/imagi/components/organisms/sidebar/BuilderSidebarChat.vue
+++ b/frontend/vuejs/src/apps/products/imagi/components/organisms/sidebar/BuilderSidebarChat.vue
@@ -32,9 +32,9 @@
 
     <!-- Chat Input Section (fixed at bottom) -->
     <div class="shrink-0 border-t border-gray-200 dark:border-white/[0.08] bg-white dark:bg-[#0a0a0a] transition-colors duration-300">
-      <div class="p-4 space-y-3">
-        <!-- Text Input Area -->
-        <div class="relative">
+      <div class="p-4">
+        <!-- Input shell: textarea on top, controls toolbar below -->
+        <div class="chat-input-shell rounded-xl bg-gray-50 dark:bg-white/[0.03] border border-gray-200 dark:border-white/[0.06]">
           <textarea
             ref="promptTextarea"
             v-model="prompt"
@@ -43,53 +43,76 @@
             @keydown.enter.shift.exact="() => {}"
             @input="autoResizeTextarea"
             :disabled="!activeInstance || activeInstance.isProcessing"
-            rows="5"
-            class="w-full bg-gray-50 dark:bg-white/[0.03] border border-gray-200 dark:border-white/[0.06] text-gray-900 dark:text-white/90 placeholder-gray-400 dark:placeholder-white/30 text-sm px-3 pr-12 py-3 pb-10 resize-none rounded-lg leading-relaxed"
-            style="min-height: 130px; max-height: 280px;"
+            rows="4"
+            class="chat-textarea w-full bg-transparent text-gray-900 dark:text-white/90 placeholder-gray-400 dark:placeholder-white/30 text-sm px-3 pt-3 pb-1 resize-none leading-relaxed"
+            style="min-height: 92px; max-height: 240px;"
           ></textarea>
 
-          <!-- Mode and Model Dropdowns (Bottom Left inside input) -->
-          <div class="absolute left-2 bottom-2 flex items-center gap-1.5">
-            <!-- Mode Dropdown -->
-            <div class="dropdown-wrapper">
-              <i :class="['dropdown-icon fas', activeInstance?.mode === 'agent' ? 'fa-robot' : 'fa-comment-dots']"></i>
-              <select
-                :value="activeInstance?.mode ?? 'chat'"
-                :disabled="!activeInstance"
-                @change="handleModeSwitch(($event.target as HTMLSelectElement).value as BuilderMode)"
-                class="dropdown-select dropdown-select--with-icon text-xs"
-              >
-                <option value="chat">Chat</option>
-                <option value="agent">Agent</option>
-              </select>
-            </div>
-
-            <!-- Model Dropdown -->
-            <div class="dropdown-wrapper">
-              <i class="fas fa-microchip dropdown-icon"></i>
-              <select
-                :value="activeInstance?.selectedModelId ?? ''"
-                :disabled="!activeInstance"
-                @change="handleModelSelect(($event.target as HTMLSelectElement).value)"
-                class="dropdown-select dropdown-select--with-icon text-xs"
-              >
-                <option
-                  v-for="model in modelOptions"
-                  :key="model.id"
-                  :value="model.id"
+          <!-- Controls toolbar: dropdowns wrap on the left, send stays pinned right -->
+          <div class="flex items-end justify-between gap-2 px-2 pb-2 pt-1">
+            <div class="flex flex-wrap items-center gap-1.5 min-w-0">
+              <!-- Mode Dropdown -->
+              <div class="dropdown-wrapper" title="Mode">
+                <i :class="['dropdown-icon fas', activeInstance?.mode === 'agent' ? 'fa-robot' : 'fa-comment-dots']"></i>
+                <select
+                  :value="activeInstance?.mode ?? 'chat'"
+                  :disabled="!activeInstance"
+                  aria-label="Conversation mode"
+                  @change="handleModeSwitch(($event.target as HTMLSelectElement).value as BuilderMode)"
+                  class="dropdown-select dropdown-select--with-icon text-xs"
                 >
-                  {{ model.name }}
-                </option>
-              </select>
-            </div>
-          </div>
+                  <option value="chat">Chat</option>
+                  <option value="agent">Agent</option>
+                </select>
+              </div>
 
-          <!-- Send Button -->
-          <div class="absolute right-3 bottom-3">
+              <!-- Model Dropdown -->
+              <div class="dropdown-wrapper" title="Model">
+                <i class="fas fa-microchip dropdown-icon"></i>
+                <select
+                  :value="activeInstance?.selectedModelId ?? ''"
+                  :disabled="!activeInstance"
+                  aria-label="Model"
+                  @change="handleModelSelect(($event.target as HTMLSelectElement).value)"
+                  class="dropdown-select dropdown-select--with-icon text-xs"
+                >
+                  <option
+                    v-for="model in modelOptions"
+                    :key="model.id"
+                    :value="model.id"
+                  >
+                    {{ model.name }}
+                  </option>
+                </select>
+              </div>
+
+              <!-- Reasoning Effort Dropdown -->
+              <div class="dropdown-wrapper" title="How much reasoning the model uses">
+                <i class="fas fa-brain dropdown-icon"></i>
+                <select
+                  :value="activeInstance?.selectedEffort ?? 'medium'"
+                  :disabled="!activeInstance"
+                  aria-label="Reasoning effort"
+                  @change="handleEffortSelect(($event.target as HTMLSelectElement).value as ReasoningEffort)"
+                  class="dropdown-select dropdown-select--with-icon text-xs"
+                >
+                  <option
+                    v-for="effort in effortOptions"
+                    :key="effort.id"
+                    :value="effort.id"
+                  >
+                    {{ effort.name }}
+                  </option>
+                </select>
+              </div>
+            </div>
+
+            <!-- Send Button -->
             <button
               @click="handlePrompt"
               :disabled="!prompt.trim() || !activeInstance || activeInstance.isProcessing"
-              class="btn-3d flex items-center justify-center w-9 h-9 rounded-full transition-all duration-300"
+              aria-label="Send message"
+              class="btn-3d flex shrink-0 items-center justify-center w-9 h-9 rounded-full transition-all duration-300"
               :class="prompt.trim() && activeInstance && !activeInstance.isProcessing
                 ? 'bg-gradient-to-b from-gray-800 via-gray-900 to-gray-950 dark:from-white dark:via-gray-50 dark:to-gray-100 text-white dark:text-gray-900 border border-gray-700/50 dark:border-gray-300/50 shadow-lg hover:shadow-xl'
                 : 'bg-gradient-to-b from-gray-200 via-gray-100 to-gray-50 dark:from-white/[0.08] dark:via-white/[0.05] dark:to-white/[0.03] text-gray-400 dark:text-white/40 cursor-not-allowed border border-gray-300/70 dark:border-white/[0.12] shadow-sm'"
@@ -110,12 +133,15 @@ import { useAgentStore } from '../../../stores/agentStore'
 import { ChatConversation } from '../../organisms/chat'
 import type { BuilderMode } from '../../../types/components'
 import type { AIMessage, AIModel } from '../../../types/index'
+import type { ReasoningEffort, ReasoningEffortOption } from '../../../types/services'
+import { REASONING_EFFORTS } from '../../../types/services'
 
 // Props
 const props = defineProps<{
   selectedApp: any
   onPromptSubmit: (prompt: string) => Promise<void>
   onModelSelect: (modelId: string) => Promise<void>
+  onEffortSelect: (effort: ReasoningEffort) => Promise<void>
   onModeSwitch: (mode: BuilderMode) => Promise<void>
   onExamplePrompt: (example: string) => void
   isCollapsed?: boolean
@@ -142,6 +168,8 @@ const modelOptions = computed<AIModel[]>(() => {
     { id: 'gpt-5.6-luna', name: 'GPT 5.6 Luna', provider: 'openai' } as AIModel
   ]
 })
+
+const effortOptions = computed<ReasoningEffortOption[]>(() => REASONING_EFFORTS)
 
 // Helper to get friendly display name from file path
 function getDisplayName(path: string): string {
@@ -208,7 +236,7 @@ function autoResizeTextarea() {
   if (!promptTextarea.value) return
   promptTextarea.value.style.height = 'auto'
   const scrollHeight = promptTextarea.value.scrollHeight
-  const maxHeight = 280
+  const maxHeight = 240
   promptTextarea.value.style.height = `${Math.min(scrollHeight, maxHeight)}px`
 }
 
@@ -220,7 +248,7 @@ async function handlePrompt() {
   
   // Reset textarea height
   if (promptTextarea.value) {
-    promptTextarea.value.style.height = '130px'
+    promptTextarea.value.style.height = '92px'
   }
   
   await props.onPromptSubmit(promptText)
@@ -235,12 +263,31 @@ async function handleModelSelect(modelId: string) {
   await props.onModelSelect(modelId)
 }
 
+async function handleEffortSelect(effort: ReasoningEffort) {
+  await props.onEffortSelect(effort)
+}
+
 async function handleModeSwitch(mode: BuilderMode) {
   await props.onModeSwitch(mode)
 }
 </script>
 
 <style scoped>
+/* Input shell wraps the textarea + controls toolbar as one field */
+.chat-input-shell {
+  transition: border-color 0.18s ease, box-shadow 0.18s ease;
+}
+
+.chat-input-shell:focus-within {
+  border-color: rgba(99, 102, 241, 0.55);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+}
+
+.dark .chat-input-shell:focus-within {
+  border-color: rgba(129, 140, 248, 0.5);
+  box-shadow: 0 0 0 3px rgba(129, 140, 248, 0.18);
+}
+
 /* Dropdown wrapper provides room for leading icon */
 .dropdown-wrapper {
   position: relative;
@@ -283,7 +330,7 @@ async function handleModeSwitch(mode: BuilderMode) {
   color: rgb(55, 65, 81);
   font-weight: 600;
   letter-spacing: 0.01em;
-  padding: 0.375rem 1.75rem 0.375rem 0.75rem;
+  padding: 0.3rem 1.5rem 0.3rem 0.6rem;
   border-radius: 0.5rem;
   cursor: pointer;
   appearance: none;
@@ -297,7 +344,7 @@ async function handleModeSwitch(mode: BuilderMode) {
 }
 
 .dropdown-select--with-icon {
-  padding-left: 1.65rem;
+  padding-left: 1.5rem;
 }
 
 .dark .dropdown-select {
@@ -369,7 +416,7 @@ async function handleModeSwitch(mode: BuilderMode) {
   box-shadow: none !important;
 }
 
-/* Remove ALL focus rings and outlines from textarea */
+/* Textarea sits inside the input shell, which owns the border/focus ring */
 textarea,
 textarea:hover,
 textarea:focus,
@@ -383,16 +430,8 @@ textarea:active {
   box-shadow: none !important;
   -webkit-box-shadow: none !important;
   -webkit-tap-highlight-color: transparent !important;
-  border-color: rgb(229 231 235) !important;
+  border: none !important;
   transition: none !important;
-}
-
-.dark textarea,
-.dark textarea:hover,
-.dark textarea:focus,
-.dark textarea:focus-visible,
-.dark textarea:active {
-  border-color: rgba(255, 255, 255, 0.06) !important;
 }
 
 /* 3D Printed Button Effect - matching homepage */

--- a/frontend/vuejs/src/apps/products/imagi/services/agentService.ts
+++ b/frontend/vuejs/src/apps/products/imagi/services/agentService.ts
@@ -181,6 +181,7 @@ export const AgentService = {
   async processChat(projectId: string, data: {
     prompt: string;
     model: string;
+    reasoningEffort?: string;
     mode?: string;
     is_build_mode?: boolean;
     file?: any;
@@ -228,6 +229,7 @@ export const AgentService = {
       const payload = {
         message: data.prompt,
         model: data.model,
+        reasoning_effort: data.reasoningEffort,
         project_id: String(projectId),
         conversation_id: data.conversationId ?? undefined,
         mode: 'chat',
@@ -283,6 +285,7 @@ export const AgentService = {
   async processAgent(projectId: string, data: {
     prompt: string;
     model: string;
+    reasoningEffort?: string;
     file?: any;
     conversationId?: number | string | null;
   }): Promise<AgentResponse> {
@@ -319,6 +322,7 @@ export const AgentService = {
       const payload = {
         message: data.prompt,
         model: data.model,
+        reasoning_effort: data.reasoningEffort,
         project_id: String(projectId),
         conversation_id: data.conversationId ?? undefined,
         current_file: currentFile,

--- a/frontend/vuejs/src/apps/products/imagi/stores/agentStore.ts
+++ b/frontend/vuejs/src/apps/products/imagi/stores/agentStore.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
-import type { AIModel, AIMessage, AgentInstance, ConversationDto } from '../types/services'
+import type { AIModel, AIMessage, AgentInstance, ConversationDto, ReasoningEffort } from '../types/services'
+import { DEFAULT_REASONING_EFFORT } from '../types/services'
 import type { AgentState } from '../types/stores'
 import type { BuilderMode, ProjectFile } from '../types/components'
 import { FileService } from '../services/fileService'
@@ -18,6 +19,7 @@ function dtoToInstance(dto: ConversationDto, fallbackModelId: string | null): Ag
     title: dto.title || '',
     mode: dto.mode,
     selectedModelId: dto.model_name || fallbackModelId,
+    selectedEffort: DEFAULT_REASONING_EFFORT,
     selectedFile: null,
     conversation: [],
     isProcessing: false,
@@ -262,6 +264,14 @@ export const useAgentStore = defineStore('agent', {
         AgentService.updateConversation(instance.conversationId, { model_name: modelId })
           .catch(e => console.error('Failed to persist model:', e))
       }
+    },
+
+    // Reasoning effort is a per-request tuning knob kept in client state only
+    // (there is no backend field to persist it to).
+    setInstanceEffort(instanceId: string, effort: ReasoningEffort) {
+      const instance = this._findInstance(instanceId)
+      if (!instance) return
+      instance.selectedEffort = effort
     },
 
     setInstanceFile(instanceId: string, file: ProjectFile | null) {

--- a/frontend/vuejs/src/apps/products/imagi/types/services.ts
+++ b/frontend/vuejs/src/apps/products/imagi/types/services.ts
@@ -131,6 +131,24 @@ export const AI_MODELS: AIModel[] = [
   }
 ];
 
+/**
+ * Reasoning effort levels — how much reasoning the model uses per request.
+ */
+export type ReasoningEffort = 'low' | 'medium' | 'high';
+
+export interface ReasoningEffortOption {
+  id: ReasoningEffort;
+  name: string;
+}
+
+export const REASONING_EFFORTS: ReasoningEffortOption[] = [
+  { id: 'low', name: 'Low' },
+  { id: 'medium', name: 'Medium' },
+  { id: 'high', name: 'High' },
+];
+
+export const DEFAULT_REASONING_EFFORT: ReasoningEffort = 'medium';
+
 // Types for API responses
 export interface APIErrorResponse {
   error?: string;
@@ -179,6 +197,7 @@ export interface AgentInstance {
   title: string;
   mode: 'chat' | 'agent';
   selectedModelId: string | null;
+  selectedEffort: ReasoningEffort;
   selectedFile: any | null;
   conversation: AIMessage[];
   isProcessing: boolean;
@@ -213,6 +232,7 @@ export interface AIGenerationResponse {
 export interface ChatPayload {
   message: string;
   model: string;
+  reasoning_effort?: ReasoningEffort;
   project_id: string;
   conversation_id?: string;
   mode?: string;
@@ -226,6 +246,7 @@ export interface ChatPayload {
 export interface ChatProcessingPayload {
   message: string;
   model: string;
+  reasoning_effort?: ReasoningEffort;
   project_id: string;
   conversation_id?: string;
   mode: string;

--- a/frontend/vuejs/src/apps/products/imagi/views/Workspace.vue
+++ b/frontend/vuejs/src/apps/products/imagi/views/Workspace.vue
@@ -25,6 +25,7 @@
             :selected-app="null"
             :on-prompt-submit="handlePrompt"
             :on-model-select="handleModelSelect"
+            :on-effort-select="handleEffortSelect"
             :on-mode-switch="handleModeSwitch"
             :on-example-prompt="handleExamplePrompt"
             :is-collapsed="false"
@@ -89,6 +90,7 @@ defineOptions({ name: 'Workspace' })
 // Types
 import type { ProjectFile, BuilderMode } from '../types/components'
 import type { AIMessage } from '../types/index'
+import type { ReasoningEffort } from '../types/services'
 import { matchesSlug, toSlug } from '../utils/slug'
 
 // Ensure all services use the shared API client with proper timeout configurations
@@ -281,6 +283,7 @@ async function handlePrompt(promptText: string) {
         const response = await AgentService.processAgent(projectId.value, {
           prompt: promptText,
           model: instance.selectedModelId,
+          reasoningEffort: instance.selectedEffort,
           file: instance.selectedFile,
           conversationId: conversationIdBefore ?? undefined
         })
@@ -322,6 +325,7 @@ async function handlePrompt(promptText: string) {
       const response = await AgentService.processChat(projectId.value, {
         prompt: promptText,
         model: instance.selectedModelId,
+        reasoningEffort: instance.selectedEffort,
         mode: 'chat',
         file: instance.selectedFile,
         conversationId: conversationIdBefore ?? undefined
@@ -369,6 +373,12 @@ async function handleModelSelect(modelId: string) {
   const instance = store.activeInstance
   if (!instance) return
   store.setInstanceModel(instance.id, modelId)
+}
+
+async function handleEffortSelect(effort: ReasoningEffort) {
+  const instance = store.activeInstance
+  if (!instance) return
+  store.setInstanceEffort(instance.id, effort)
 }
 
 async function handleModeSwitch(mode: BuilderMode) {


### PR DESCRIPTION
## Summary

Replaces the single **GPT 5.5** model in the project build section with the **GPT 5.6 suite** — three user-selectable tiers — maps them to real OpenAI models at runtime, and adds a per-request reasoning-effort selector. Also reworks the prompt input form so the model/effort/mode controls and the send button lay out cleanly.

## The suite (tiered pricing, per million tokens)

| Model | ID | Real model | Input | Output | Role |
|---|---|---|---|---|---|
| GPT 5.6 Sol | `gpt-5.6-sol` | `gpt-5` | $6 | $30 | Flagship — **default** |
| GPT 5.6 Terra | `gpt-5.6-terra` | `gpt-5-mini` | $3 | $15 | Balanced |
| GPT 5.6 Luna | `gpt-5.6-luna` | `gpt-5-nano` | $1 | $5 | Light/economical |

## Backend

- **Model definitions** (`Builder/services/models_service.py`): three suite models with tiered pricing, default `gpt-5.6-sol`, and a `backend_model` field mapping each public id to the real OpenAI model. `get_backend_model_id()` centralizes the mapping (easily editable if the account uses different underlying models).
- **Agents**: `DEFAULT_MODEL` points at Sol across the base/chat/coding agents; agents are now built against the resolved real model.
- **Model selection**: the `chat` and `agent` endpoints accept any of the three suite models (falling back to the default for unknown ids) instead of forcing a single model.
- **Reasoning effort**: Low/Medium/High levels (default Medium), resolved via `resolve_reasoning_effort()`/`model_supports_reasoning()` and applied through `ModelSettings(reasoning=…)` on the OpenAI Responses API. Threaded through both API endpoints → `ImagiAgentService` → the chat/coding/orchestrator factories. SDK imports are guarded so missing support degrades gracefully.
- **Migration** `Agents/0003_alter_agentconversation_model_name` for the new `model_name` choices.

## Frontend

- **Model config** (`types/services.ts`): `AI_MODELS`/`MODEL_CONFIGS` list the three suite models; adds `ReasoningEffort` type, `REASONING_EFFORTS`, and per-instance `selectedEffort`.
- **Build sidebar** (`BuilderSidebarChat.vue`): restructured the prompt input into a single shell — textarea on top, controls toolbar below with **Mode · Model · Reasoning effort** dropdowns on the left and the send button pinned bottom-right. Replaces the previous absolutely positioned controls that overlapped the textarea and crowded the send button. Controls wrap gracefully on narrow sidebars; the shell shows a focus ring and supports dark mode.
- **Request flow** (`agentService.ts`, `agentStore.ts`, `Workspace.vue`): `reasoning_effort` is sent with each chat/agent request; effort is a client-side per-conversation setting (not persisted — there is no DB field for it).
- **Payments** (`ModelPricingSection.vue`): pricing display updated to the three tiers.

## Verification

- Frontend `vue-tsc` type-check and full production build both pass.
- All edited backend files compile; the new `models_service` helpers were unit-checked standalone. The Django test suite couldn't run in this environment (Django not installed); the migration mirrors the model's new `choices`.
- Input-form layout verified via a rendered screenshot at 340px and 280px sidebar widths — no overlap, everything reachable.

## Notes

- The suite ids `gpt-5.6-*` are Imagi branding; runtime calls use the mapped `backend_model` values. Adjust those if your OpenAI account should call different models.
- Reasoning effort resets to the default (Medium) on reload since it isn't stored on the conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019M2o63E1ZYjSjxWjKiVQJ6)_