### PR TITLE
Add test coverage for auth, payments, and projects (backend + frontend)

### DIFF
--- a/backend/django/apps/Auth/tests.py
+++ b/backend/django/apps/Auth/tests.py
@@ -1,0 +1,221 @@
+"""
+Tests for the Auth app.
+
+Covers the registration/user serializers and every authentication API
+endpoint (csrf, signin, register, logout, init, user-update).
+"""
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APITestCase
+
+from apps.Auth.api.serializers import RegisterSerializer, UserSerializer
+
+User = get_user_model()
+
+
+class RegisterSerializerTests(APITestCase):
+    """Validation rules enforced by RegisterSerializer."""
+
+    def _base_data(self, **overrides):
+        data = {
+            'username': 'alice',
+            'email': 'alice@example.com',
+            'password': 'sup3rSecret!',
+            'password_confirmation': 'sup3rSecret!',
+        }
+        data.update(overrides)
+        return data
+
+    def test_valid_payload_creates_user(self):
+        serializer = RegisterSerializer(data=self._base_data())
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        user = serializer.save()
+        self.assertEqual(user.username, 'alice')
+        self.assertEqual(user.email, 'alice@example.com')
+        # Password must be hashed, never stored in the clear.
+        self.assertTrue(user.check_password('sup3rSecret!'))
+        self.assertNotEqual(user.password, 'sup3rSecret!')
+
+    def test_password_mismatch_is_rejected(self):
+        serializer = RegisterSerializer(
+            data=self._base_data(password_confirmation='different!')
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn('password_confirmation', serializer.errors)
+
+    def test_duplicate_username_is_rejected(self):
+        User.objects.create_user(username='alice', password='whatever123')
+        serializer = RegisterSerializer(data=self._base_data())
+        self.assertFalse(serializer.is_valid())
+        self.assertIn('username', serializer.errors)
+
+    def test_duplicate_email_is_rejected_case_insensitively(self):
+        User.objects.create_user(
+            username='bob', email='ALICE@example.com', password='whatever123'
+        )
+        serializer = RegisterSerializer(data=self._base_data())
+        self.assertFalse(serializer.is_valid())
+        self.assertIn('email', serializer.errors)
+
+    def test_weak_password_is_rejected(self):
+        serializer = RegisterSerializer(
+            data=self._base_data(password='password', password_confirmation='password')
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn('password', serializer.errors)
+
+
+class UserSerializerTests(APITestCase):
+    """Read-only representation returned to the SPA."""
+
+    def test_name_falls_back_to_username(self):
+        user = User.objects.create_user(username='carol', password='whatever123')
+        data = UserSerializer(user).data
+        self.assertEqual(data['name'], 'carol')
+        self.assertEqual(data['balance'], 0)
+        self.assertEqual(data['username'], 'carol')
+
+    def test_name_uses_full_name_when_available(self):
+        user = User.objects.create_user(
+            username='dave', password='whatever123',
+            first_name='Dave', last_name='Smith',
+        )
+        data = UserSerializer(user).data
+        self.assertEqual(data['name'], 'Dave Smith')
+
+    def test_balance_and_id_are_read_only(self):
+        user = User.objects.create_user(username='erin', password='whatever123')
+        serializer = UserSerializer(
+            user, data={'balance': 999, 'username': 'erin2'}, partial=True
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        updated = serializer.save()
+        # username is writable, balance is not.
+        self.assertEqual(updated.username, 'erin2')
+        self.assertEqual(UserSerializer(updated).data['balance'], 0)
+
+
+class SigninViewTests(APITestCase):
+    def setUp(self):
+        self.url = reverse('auth_api:signin')
+        self.user = User.objects.create_user(
+            username='frank', email='frank@example.com', password='correct-horse-9'
+        )
+
+    def test_valid_credentials_return_token_and_user(self):
+        resp = self.client.post(
+            self.url, {'username': 'frank', 'password': 'correct-horse-9'}
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertIn('token', resp.data)
+        self.assertEqual(resp.data['user']['username'], 'frank')
+        # A token row must be created and match the returned key.
+        token = Token.objects.get(user=self.user)
+        self.assertEqual(token.key, resp.data['token'])
+
+    def test_wrong_password_returns_401(self):
+        resp = self.client.post(
+            self.url, {'username': 'frank', 'password': 'wrong'}
+        )
+        self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertFalse(Token.objects.filter(user=self.user).exists())
+
+    def test_missing_fields_return_400(self):
+        resp = self.client.post(self.url, {'username': 'frank'})
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_signin_is_idempotent_on_token(self):
+        first = self.client.post(
+            self.url, {'username': 'frank', 'password': 'correct-horse-9'}
+        )
+        second = self.client.post(
+            self.url, {'username': 'frank', 'password': 'correct-horse-9'}
+        )
+        self.assertEqual(first.data['token'], second.data['token'])
+
+
+class RegisterViewTests(APITestCase):
+    def setUp(self):
+        self.url = reverse('auth_api:register')
+
+    def test_register_creates_user_and_returns_token(self):
+        resp = self.client.post(self.url, {
+            'username': 'grace',
+            'email': 'grace@example.com',
+            'password': 'sup3rSecret!',
+            'password_confirmation': 'sup3rSecret!',
+        })
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        self.assertIn('token', resp.data)
+        self.assertEqual(resp.data['user']['username'], 'grace')
+        self.assertTrue(User.objects.filter(username='grace').exists())
+
+    def test_register_with_invalid_data_returns_400(self):
+        resp = self.client.post(self.url, {
+            'username': 'grace',
+            'email': 'not-an-email',
+            'password': 'x',
+            'password_confirmation': 'y',
+        })
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(User.objects.filter(username='grace').exists())
+
+
+class LogoutViewTests(APITestCase):
+    def setUp(self):
+        self.url = reverse('auth_api:logout')
+        self.user = User.objects.create_user(username='heidi', password='correct-horse-9')
+        self.token = Token.objects.create(user=self.user)
+
+    def test_logout_requires_authentication(self):
+        resp = self.client.post(self.url)
+        self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_logout_deletes_token(self):
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.token.key}')
+        resp = self.client.post(self.url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertFalse(Token.objects.filter(user=self.user).exists())
+
+
+class InitViewTests(APITestCase):
+    def setUp(self):
+        self.url = reverse('auth_api:init')
+        self.user = User.objects.create_user(username='ivan', password='correct-horse-9')
+
+    def test_unauthenticated_reports_not_authenticated(self):
+        resp = self.client.get(self.url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertFalse(resp.data['isAuthenticated'])
+        self.assertIsNone(resp.data['user'])
+
+    def test_authenticated_returns_user(self):
+        token = Token.objects.create(user=self.user)
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {token.key}')
+        resp = self.client.get(self.url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertTrue(resp.data['isAuthenticated'])
+        self.assertEqual(resp.data['user']['username'], 'ivan')
+
+
+class UserUpdateViewTests(APITestCase):
+    def setUp(self):
+        self.url = reverse('auth_api:user-update')
+        self.user = User.objects.create_user(
+            username='judy', email='judy@example.com', password='correct-horse-9'
+        )
+
+    def test_update_requires_authentication(self):
+        resp = self.client.patch(self.url, {'email': 'new@example.com'})
+        self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_authenticated_user_can_update_email(self):
+        token = Token.objects.create(user=self.user)
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {token.key}')
+        resp = self.client.patch(self.url, {'email': 'new@example.com'})
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.email, 'new@example.com')

--- a/backend/django/apps/Payments/api/views.py
+++ b/backend/django/apps/Payments/api/views.py
@@ -39,12 +39,9 @@ class CreditBalanceView(APIView):
             return Response({
                 'balance': balance
             })
-        except Exception as e:
-            logger.error(f"Error fetching balance: {str(e)}")
-            return Response(
-                {'error': 'Failed to fetch balance'},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
-            )
+        except Exception:
+            logger.exception("Error fetching balance")
+            raise
 
 class CreditPackagesView(APIView):
     """Get available credit packages."""
@@ -57,12 +54,9 @@ class CreditPackagesView(APIView):
             return Response({
                 'packages': serializer.data
             })
-        except Exception as e:
-            logger.error(f"Error fetching packages: {str(e)}")
-            return Response(
-                {'error': 'Failed to fetch packages'},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
-            )
+        except Exception:
+            logger.exception("Error fetching packages")
+            raise
 
 class PaymentHistoryView(generics.ListAPIView):
     """List user's payment history."""
@@ -154,11 +148,9 @@ def create_payment_intent(request):
         return Response({
             'error': 'Invalid amount format'
         }, status=status.HTTP_400_BAD_REQUEST)
-    except Exception as e:
-        logger.error(f"Error creating payment intent: {str(e)}")
-        return Response({
-            'error': str(e)
-        }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    except Exception:
+        logger.exception("Error creating payment intent")
+        raise
 
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
@@ -211,11 +203,9 @@ def process_payment(request):
         return Response({
             'error': e.user_message
         }, status=status.HTTP_400_BAD_REQUEST)
-    except Exception as e:
-        logger.error(f"Error processing payment: {str(e)}")
-        return Response({
-            'error': str(e)
-        }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    except Exception:
+        logger.exception("Error processing payment")
+        raise
 
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
@@ -260,11 +250,9 @@ def confirm_payment(request):
             'new_balance': result['new_balance']
         })
         
-    except Exception as e:
-        logger.error(f"Error confirming payment: {str(e)}")
-        return Response({
-            'error': str(e)
-        }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    except Exception:
+        logger.exception("Error confirming payment")
+        raise
 
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
@@ -311,11 +299,9 @@ def verify_payment(request):
         return Response({
             'error': str(e)
         }, status=status.HTTP_400_BAD_REQUEST)
-    except Exception as e:
-        logger.error(f"Error verifying payment: {str(e)}")
-        return Response({
-            'error': str(e)
-        }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    except Exception:
+        logger.exception("Error verifying payment")
+        raise
 
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
@@ -333,11 +319,9 @@ def check_credits(request):
         
         return Response(result)
         
-    except Exception as e:
-        logger.error(f"Error checking credits: {str(e)}")
-        return Response({
-            'error': str(e)
-        }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    except Exception:
+        logger.exception("Error checking credits")
+        raise
 
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
@@ -371,11 +355,9 @@ def deduct_credits(request):
             'new_balance': result['new_balance']
         })
         
-    except Exception as e:
-        logger.error(f"Error deducting credits: {str(e)}")
-        return Response({
-            'error': str(e)
-        }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    except Exception:
+        logger.exception("Error deducting credits")
+        raise
 
 class PaymentMethodsView(APIView):
     """Get user's saved payment methods."""
@@ -394,12 +376,9 @@ class PaymentMethodsView(APIView):
             
             return Response(payment_methods)
                 
-        except Exception as e:
-            logger.error(f"Error fetching payment methods: {str(e)}")
-            return Response(
-                {'error': 'Failed to fetch payment methods'},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
-            )
+        except Exception:
+            logger.exception("Error fetching payment methods")
+            raise
 
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
@@ -436,11 +415,9 @@ def setup_customer(request):
             'customer_id': customer.id
         })
         
-    except Exception as e:
-        logger.error(f"Error setting up customer: {str(e)}")
-        return Response({
-            'error': str(e)
-        }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    except Exception:
+        logger.exception("Error setting up customer")
+        raise
 
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
@@ -490,11 +467,9 @@ def attach_payment_method(request):
         return Response({
             'error': str(e)
         }, status=status.HTTP_400_BAD_REQUEST)
-    except Exception as e:
-        logger.error(f"Error attaching payment method: {str(e)}")
-        return Response({
-            'error': str(e)
-        }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    except Exception:
+        logger.exception("Error attaching payment method")
+        raise
 
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
@@ -598,11 +573,9 @@ def create_checkout_session(request):
         return Response({
             'error': 'Invalid amount format'
         }, status=status.HTTP_400_BAD_REQUEST)
-    except Exception as e:
-        logger.error(f"Error creating checkout session: {str(e)}")
-        return Response({
-            'error': str(e)
-        }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    except Exception:
+        logger.exception("Error creating checkout session")
+        raise
 
 
 @api_view(['POST'])
@@ -623,11 +596,9 @@ def create_portal_session(request):
             'url': portal_session.url
         })
 
-    except Exception as e:
-        logger.error(f"Error creating portal session: {str(e)}")
-        return Response({
-            'error': str(e)
-        }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    except Exception:
+        logger.exception("Error creating portal session")
+        raise
 
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
@@ -693,11 +664,9 @@ def get_session_status(request):
         return Response({
             'error': str(e)
         }, status=status.HTTP_400_BAD_REQUEST)
-    except Exception as e:
-        logger.error(f"Error checking session status: {str(e)}")
-        return Response({
-            'error': str(e)
-        }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    except Exception:
+        logger.exception("Error checking session status")
+        raise
 
 class PlansView(generics.ListAPIView):
     """List available subscription plans."""
@@ -722,12 +691,9 @@ class PlansView(generics.ListAPIView):
                 
             return Response(formatted_plans)
             
-        except Exception as e:
-            logger.error(f"Error fetching plans: {str(e)}")
-            return Response(
-                {'error': 'Failed to fetch plans'},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
-            )
+        except Exception:
+            logger.exception("Error fetching plans")
+            raise
 
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
@@ -752,11 +718,9 @@ def verify_webhook(request):
         return Response({
             'error': str(e)
         }, status=status.HTTP_400_BAD_REQUEST)
-    except Exception as e:
-        logger.error(f"Error verifying webhook: {str(e)}")
-        return Response({
-            'error': str(e)
-        }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+    except Exception:
+        logger.exception("Error verifying webhook")
+        raise
 
 @api_view(['POST'])
 @permission_classes([AllowAny])
@@ -796,12 +760,9 @@ def webhook(request):
         # Return success response
         return Response({'status': 'success'})
         
-    except Exception as e:
-        logger.error(f"Webhook error: {str(e)}")
-        return Response(
-            {'error': str(e)},
-            status=status.HTTP_500_INTERNAL_SERVER_ERROR
-        )
+    except Exception:
+        logger.exception("Webhook error")
+        raise
 
 def handle_payment_intent_succeeded(payment_intent):
     """Handle a successful payment intent."""

--- a/backend/django/apps/Payments/tests.py
+++ b/backend/django/apps/Payments/tests.py
@@ -1,2 +1,357 @@
+"""
+Tests for the Payments app.
 
-# Create your tests here.
+Covers the models, the credit / transaction / payment-method services (all
+pure database logic, Stripe never touched), and the API endpoints. Endpoints
+that reach Stripe are exercised with the Stripe service mocked out.
+"""
+
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APITestCase
+
+from apps.Payments.models import (
+    CreditBalance,
+    CreditPackage,
+    Payment,
+    PaymentMethod,
+    Transaction,
+)
+from apps.Payments.services.credit_service import CreditService
+from apps.Payments.services.payment_method_service import PaymentMethodService
+from apps.Payments.services.transaction_service import TransactionService
+
+User = get_user_model()
+
+
+def make_user(username='user1', **kwargs):
+    return User.objects.create_user(
+        username=username,
+        email=kwargs.pop('email', f'{username}@example.com'),
+        password=kwargs.pop('password', 'correct-horse-9'),
+        **kwargs,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Models
+# --------------------------------------------------------------------------- #
+class PaymentModelTests(APITestCase):
+    def test_calculate_credits_is_one_to_one(self):
+        self.assertEqual(Payment.calculate_credits(25), Decimal('25'))
+        self.assertEqual(Payment.calculate_credits('12.50'), Decimal('12.50'))
+
+
+class TransactionModelTests(APITestCase):
+    def setUp(self):
+        self.user = make_user()
+
+    def test_purchase_gets_default_description(self):
+        txn = Transaction.objects.create(
+            user=self.user, amount=Decimal('20'), transaction_type='purchase',
+            status='completed',
+        )
+        self.assertIn('Credit purchase', txn.description)
+
+    def test_usage_gets_default_description(self):
+        txn = Transaction.objects.create(
+            user=self.user, amount=Decimal('-5'), transaction_type='usage',
+            status='completed',
+        )
+        self.assertIn('Usage', txn.description)
+
+    def test_explicit_description_is_preserved(self):
+        txn = Transaction.objects.create(
+            user=self.user, amount=Decimal('20'), transaction_type='purchase',
+            status='completed', description='Custom note',
+        )
+        self.assertEqual(txn.description, 'Custom note')
+
+
+class PaymentMethodModelTests(APITestCase):
+    def setUp(self):
+        self.user = make_user()
+
+    def _make(self, pm_id, is_default=False):
+        return PaymentMethod.objects.create(
+            user=self.user, payment_method_id=pm_id, card_brand='visa',
+            last4='4242', exp_month=12, exp_year=2030, is_default=is_default,
+        )
+
+    def test_setting_new_default_clears_previous_default(self):
+        first = self._make('pm_1', is_default=True)
+        second = self._make('pm_2', is_default=True)
+        first.refresh_from_db()
+        second.refresh_from_db()
+        self.assertFalse(first.is_default)
+        self.assertTrue(second.is_default)
+
+
+# --------------------------------------------------------------------------- #
+# CreditService
+# --------------------------------------------------------------------------- #
+class CreditServiceTests(APITestCase):
+    def setUp(self):
+        self.user = make_user()
+        self.service = CreditService()
+
+    def test_get_balance_creates_zero_balance(self):
+        self.assertEqual(self.service.get_balance(self.user), 0.0)
+        self.assertTrue(CreditBalance.objects.filter(user=self.user).exists())
+
+    def test_add_credits_increases_balance(self):
+        result = self.service.add_credits(self.user, 30.0)
+        self.assertTrue(result['success'])
+        self.assertEqual(result['new_balance'], 30.0)
+        self.assertEqual(self.service.get_balance(self.user), 30.0)
+
+    def test_add_credits_marks_transaction_completed(self):
+        txn = Transaction.objects.create(
+            user=self.user, amount=Decimal('30'), transaction_type='purchase',
+            status='pending',
+        )
+        self.service.add_credits(self.user, 30.0, txn)
+        txn.refresh_from_db()
+        self.assertEqual(txn.status, 'completed')
+
+    def test_deduct_credits_reduces_balance_and_records_usage(self):
+        self.service.add_credits(self.user, 50.0)
+        result = self.service.deduct_credits(self.user, 20.0, 'Model run')
+        self.assertTrue(result['success'])
+        self.assertAlmostEqual(result['new_balance'], 30.0, places=2)
+        # A negative usage transaction should have been recorded.
+        usage = Transaction.objects.filter(user=self.user, transaction_type='usage')
+        self.assertEqual(usage.count(), 1)
+        self.assertEqual(usage.first().amount, Decimal('-20.0'))
+
+    def test_deduct_more_than_balance_fails(self):
+        self.service.add_credits(self.user, 5.0)
+        result = self.service.deduct_credits(self.user, 20.0)
+        self.assertFalse(result['success'])
+        self.assertEqual(result['error'], 'Insufficient credits')
+        # Balance is untouched.
+        self.assertEqual(self.service.get_balance(self.user), 5.0)
+
+    def test_deduct_non_positive_amount_fails(self):
+        result = self.service.deduct_credits(self.user, 0)
+        self.assertFalse(result['success'])
+
+    def test_check_credits_reports_sufficiency(self):
+        self.service.add_credits(self.user, 10.0)
+        ok = self.service.check_credits(self.user, 5.0)
+        self.assertTrue(ok['has_sufficient'])
+        short = self.service.check_credits(self.user, 25.0)
+        self.assertFalse(short['has_sufficient'])
+        self.assertAlmostEqual(short['needed_credits'], 15.0, places=2)
+
+
+# --------------------------------------------------------------------------- #
+# TransactionService
+# --------------------------------------------------------------------------- #
+class TransactionServiceTests(APITestCase):
+    def setUp(self):
+        self.user = make_user()
+        self.service = TransactionService()
+
+    def test_create_purchase_transaction(self):
+        txn = self.service.create_purchase_transaction(
+            self.user, 40.0, stripe_payment_intent_id='pi_123'
+        )
+        self.assertEqual(txn.transaction_type, 'purchase')
+        self.assertEqual(txn.status, 'pending')
+        self.assertEqual(txn.stripe_payment_intent_id, 'pi_123')
+
+    def test_create_usage_transaction_stores_negative_amount(self):
+        txn = self.service.create_usage_transaction(self.user, 3.0)
+        self.assertIsNotNone(txn)
+        self.assertEqual(txn.amount, Decimal('-3.0'))
+        self.assertEqual(txn.transaction_type, 'usage')
+
+    def test_get_payment_history_only_returns_completed_purchases(self):
+        self.service.create_purchase_transaction(self.user, 10.0)  # pending
+        done = self.service.create_purchase_transaction(self.user, 20.0)
+        done.status = 'completed'
+        done.save()
+        self.service.create_usage_transaction(self.user, 5.0)  # usage
+        history = self.service.get_payment_history(self.user)
+        self.assertEqual(list(history), [done])
+
+    def test_get_transactions_filters_by_status(self):
+        a = self.service.create_purchase_transaction(self.user, 10.0)
+        a.status = 'completed'
+        a.save()
+        self.service.create_purchase_transaction(self.user, 20.0)  # pending
+        result = self.service.get_transactions(self.user, status='completed')
+        self.assertEqual(result['count'], 1)
+        self.assertEqual(list(result['transactions']), [a])
+
+    def test_lookup_by_payment_intent(self):
+        txn = self.service.create_purchase_transaction(
+            self.user, 10.0, stripe_payment_intent_id='pi_abc'
+        )
+        found = self.service.get_transaction_by_payment_intent(self.user, 'pi_abc')
+        self.assertEqual(found, txn)
+        self.assertIsNone(
+            self.service.get_transaction_by_payment_intent(self.user, 'pi_missing')
+        )
+
+    def test_get_credit_packages_excludes_inactive_by_default(self):
+        CreditPackage.objects.create(
+            id='starter', name='Starter', amount=Decimal('10'),
+            credits=Decimal('10'), is_active=True,
+        )
+        CreditPackage.objects.create(
+            id='legacy', name='Legacy', amount=Decimal('5'),
+            credits=Decimal('5'), is_active=False,
+        )
+        packages = self.service.get_credit_packages()
+        self.assertEqual([p.id for p in packages], ['starter'])
+        self.assertEqual(len(self.service.get_credit_packages(include_inactive=True)), 2)
+
+
+# --------------------------------------------------------------------------- #
+# PaymentMethodService
+# --------------------------------------------------------------------------- #
+class PaymentMethodServiceTests(APITestCase):
+    def setUp(self):
+        self.user = make_user()
+        self.service = PaymentMethodService()
+
+    def test_stripe_customer_id_round_trip(self):
+        self.assertIsNone(self.service.get_stripe_customer_id(self.user))
+        self.assertTrue(self.service.set_stripe_customer_id(self.user, 'cus_1'))
+        self.assertEqual(self.service.get_stripe_customer_id(self.user), 'cus_1')
+
+    def test_first_payment_method_becomes_default(self):
+        pm = self.service.create_payment_method(self.user, {
+            'payment_method_id': 'pm_1', 'card_brand': 'visa',
+            'last4': '4242', 'exp_month': 12, 'exp_year': 2030,
+        })
+        self.assertTrue(pm.is_default)
+
+    def test_set_default_payment_method(self):
+        self.service.create_payment_method(self.user, {
+            'payment_method_id': 'pm_1', 'card_brand': 'visa',
+            'last4': '4242', 'exp_month': 12, 'exp_year': 2030,
+        })
+        self.service.create_payment_method(self.user, {
+            'payment_method_id': 'pm_2', 'card_brand': 'amex',
+            'last4': '0005', 'exp_month': 1, 'exp_year': 2031,
+        })
+        self.assertTrue(self.service.set_default_payment_method(self.user, 'pm_2'))
+        self.assertEqual(
+            self.service.get_default_payment_method(self.user).payment_method_id, 'pm_2'
+        )
+
+    def test_delete_default_reassigns_default(self):
+        self.service.create_payment_method(self.user, {
+            'payment_method_id': 'pm_1', 'card_brand': 'visa',
+            'last4': '4242', 'exp_month': 12, 'exp_year': 2030,
+        })
+        self.service.create_payment_method(self.user, {
+            'payment_method_id': 'pm_2', 'card_brand': 'amex',
+            'last4': '0005', 'exp_month': 1, 'exp_year': 2031,
+        })
+        # pm_1 is the default; deleting it should promote pm_2.
+        self.assertTrue(self.service.delete_payment_method(self.user, 'pm_1'))
+        remaining = self.service.get_payment_methods(self.user)
+        self.assertEqual(len(remaining), 1)
+        self.assertTrue(remaining[0].is_default)
+
+    def test_delete_missing_payment_method_returns_false(self):
+        self.assertFalse(self.service.delete_payment_method(self.user, 'pm_missing'))
+
+
+# --------------------------------------------------------------------------- #
+# API endpoints
+# --------------------------------------------------------------------------- #
+class PaymentsAPITests(APITestCase):
+    def setUp(self):
+        self.user = make_user()
+        self.token = Token.objects.create(user=self.user)
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.token.key}')
+
+    def test_balance_endpoint_requires_auth(self):
+        self.client.credentials()  # drop auth
+        resp = self.client.get(reverse('api-credit-balance'))
+        self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_balance_endpoint_returns_balance(self):
+        CreditService().add_credits(self.user, 42.0)
+        resp = self.client.get(reverse('api-credit-balance'))
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data['balance'], 42.0)
+
+    def test_check_credits_endpoint(self):
+        CreditService().add_credits(self.user, 10.0)
+        resp = self.client.post(
+            reverse('api-check-credits'), {'required_credits': 5}
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertTrue(resp.data['has_sufficient'])
+
+    def test_deduct_credits_endpoint_success(self):
+        CreditService().add_credits(self.user, 10.0)
+        resp = self.client.post(
+            reverse('api-deduct-credits'), {'credits': 4, 'description': 'run'}
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertAlmostEqual(resp.data['new_balance'], 6.0, places=2)
+
+    def test_deduct_credits_insufficient_returns_402(self):
+        CreditService().add_credits(self.user, 1.0)
+        resp = self.client.post(reverse('api-deduct-credits'), {'credits': 5})
+        self.assertEqual(resp.status_code, status.HTTP_402_PAYMENT_REQUIRED)
+
+    def test_packages_endpoint(self):
+        CreditPackage.objects.create(
+            id='starter', name='Starter', amount=Decimal('10'),
+            credits=Decimal('10'), is_active=True,
+        )
+        resp = self.client.get(reverse('api-credit-packages'))
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(resp.data['packages']), 1)
+
+    def test_history_endpoint_returns_completed_purchases(self):
+        svc = TransactionService()
+        done = svc.create_purchase_transaction(self.user, 15.0)
+        done.status = 'completed'
+        done.save()
+        resp = self.client.get(reverse('api-payment-history'))
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(resp.data['payments']), 1)
+        # PaymentHistorySerializer forces positive amounts for display.
+        self.assertEqual(resp.data['payments'][0]['amount'], 15.0)
+
+    def test_transactions_endpoint_scoped_to_user(self):
+        other = make_user('intruder')
+        TransactionService().create_purchase_transaction(other, 99.0)
+        TransactionService().create_purchase_transaction(self.user, 15.0)
+        resp = self.client.get(reverse('api-transaction-history'))
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data['total_count'], 1)
+
+    @patch('apps.Payments.api.views.stripe_service')
+    def test_process_payment_adds_credits_on_success(self, mock_stripe):
+        intent = MagicMock()
+        intent.id = 'pi_success'
+        intent.status = 'succeeded'
+        intent.client_secret = 'secret_123'
+        mock_stripe.create_direct_payment.return_value = intent
+
+        resp = self.client.post(reverse('api-process-payment'), {
+            'amount': 20, 'paymentMethodId': 'pm_card',
+        })
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertTrue(resp.data['success'])
+        self.assertEqual(resp.data['new_balance'], 20.0)
+        self.assertEqual(CreditService().get_balance(self.user), 20.0)
+
+    def test_process_payment_requires_amount_and_method(self):
+        resp = self.client.post(reverse('api-process-payment'), {'amount': 20})
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)

--- a/backend/django/apps/Products/Imagi/Builder/api/views.py
+++ b/backend/django/apps/Products/Imagi/Builder/api/views.py
@@ -23,7 +23,7 @@ from ..services.preview_service import PreviewService
 from apps.Products.Imagi.ProjectManager.models import Project as PMProject
 from apps.Products.Imagi.ProjectManager.services.project_management_service import ProjectManagementService
 from apps.Products.Imagi.ProjectManager.services.project_creation_service import ProjectCreationService
-from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import NotFound, APIException
 from ..services.version_control_service import VersionControlService
 from ..services.create_app_service import CreateAppService
 from ..services.directory_service import DirectoryService
@@ -53,6 +53,8 @@ class ProjectDirectoriesView(APIView):
             view_file_service = ViewFileService(project=project)
             files = view_file_service.list_files()
             return Response(files)
+        except APIException:
+            raise
         except Exception as e:
             logger.error(f"Error listing project files: {str(e)}")
             return Response({'error': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
@@ -71,6 +73,8 @@ class ProjectListCreateView(generics.ListCreateAPIView):
             project_creation_service = ProjectCreationService(self.request.user)
             project = project_creation_service.create_project(serializer.validated_data['name'])
             serializer.save(user=self.request.user, project=project)
+        except APIException:
+            raise
         except Exception as e:
             logger.error(f"Error creating project: {str(e)}")
             raise
@@ -133,6 +137,8 @@ class GenerateCodeView(APIView):
             response = models_service.generate_code(project, prompt, model, file_content)
             
             return Response(response)
+        except APIException:
+            raise
         except Exception as e:
             logger.error(f"Error generating code: {str(e)}")
             return Response(
@@ -170,6 +176,8 @@ class FileContentView(APIView):
             view_file_service = ViewFileService(project=project)
             content = view_file_service.get_file_content(file_path)
             return Response({'content': content})
+        except APIException:
+            raise
         except Exception as e:
             logger.error(f"Error getting file content: {str(e)}")
             return Response(
@@ -211,6 +219,8 @@ class FileContentView(APIView):
             file_data = view_file_service.update_file(file_path, content)
             
             return Response(file_data, status=status.HTTP_201_CREATED)
+        except APIException:
+            raise
         except Exception as e:
             logger.error(f"Error creating/updating file content: {str(e)}")
             return Response(
@@ -253,6 +263,8 @@ class PreviewView(APIView):
             }
 
             return Response(response_data)
+        except APIException:
+            raise
         except Exception as e:
             logger.error(f"Error starting preview server: {str(e)}")
             return Response({
@@ -268,6 +280,8 @@ class PreviewView(APIView):
             result = preview_service.stop_preview()
             
             return Response(result)
+        except APIException:
+            raise
         except Exception as e:
             logger.error(f"Error stopping preview server: {str(e)}")
             return Response({
@@ -300,8 +314,11 @@ class CreateFileView(APIView):
                     status=status.HTTP_404_NOT_FOUND
                 )
                 
-            # Validate request data
-            file_data = request.data
+            # Copy request data before mutating: a form-encoded request
+            # yields an immutable QueryDict, so assigning name/type below
+            # would raise. .copy() returns a mutable copy for both JSON and
+            # form payloads.
+            file_data = request.data.copy()
             
             if not file_data.get('path') and not file_data.get('name'):
                 return Response(
@@ -347,6 +364,8 @@ class CreateFileView(APIView):
             # Automatic view/URL creation removed - implement via OpenAI Agents SDK if needed
             
             return Response(result, status=status.HTTP_201_CREATED)
+        except APIException:
+            raise
         except Exception as e:
             logger.error(f"Error creating file: {str(e)}")
             return Response(
@@ -392,6 +411,8 @@ class DeleteFileView(APIView):
             delete_file_service = DeleteFileService(project=project)
             result = delete_file_service.delete_file(file_path)
             return Response(result, status=status.HTTP_200_OK)
+        except APIException:
+            raise
         except Exception as e:
             logger.error(f"Error deleting file: {str(e)}")
             return Response(
@@ -432,6 +453,8 @@ class CreateDirectoryView(APIView):
             directory_service = DirectoryService(project=project)
             result = directory_service.create_directory(dir_path)
             return Response(result, status=status.HTTP_201_CREATED)
+        except APIException:
+            raise
         except Exception as e:
             logger.error(f"Error creating directory: {str(e)}")
             return Response(
@@ -476,6 +499,8 @@ class DeleteDirectoryView(APIView):
             directory_service = DirectoryService(project=project)
             result = directory_service.delete_directory(dir_path, recursive=recursive)
             return Response(result, status=status.HTTP_200_OK)
+        except APIException:
+            raise
         except Exception as e:
             logger.error(f"Error deleting directory: {str(e)}")
             return Response(
@@ -534,6 +559,8 @@ class FileUndoView(APIView):
                     view_file_service.update_file(file_path, result['content'])
             
             return Response(result)
+        except APIException:
+            raise
         except Exception as e:
             logger.error(f"Error undoing file changes: {str(e)}")
             return Response(
@@ -573,6 +600,8 @@ class AnalyzeTemplateView(APIView):
             
             return Response(response_data)
             
+        except APIException:
+            raise
         except Exception as e:
             logger.error(f"Error analyzing template: {str(e)}")
             return Response(
@@ -613,6 +642,8 @@ class VersionControlHistoryView(APIView):
                     'error': result.get('message', 'Failed to get version history')
                 }, status=status.HTTP_400_BAD_REQUEST)
                 
+        except APIException:
+            raise
         except Exception as e:
             logger.error(f"Error getting version history: {str(e)}")
             return Response({
@@ -648,6 +679,8 @@ class VersionControlHistoryView(APIView):
                     'error': result.get('message', 'Failed to create version')
                 }, status=status.HTTP_400_BAD_REQUEST)
                 
+        except APIException:
+            raise
         except Exception as e:
             logger.error(f"Error creating version: {str(e)}")
             return Response({
@@ -699,6 +732,8 @@ class VersionControlResetView(APIView):
                     'error': result.get('message', 'Failed to reset project')
                 }, status=status.HTTP_400_BAD_REQUEST)
                 
+        except APIException:
+            raise
         except Exception as e:
             logger.error(f"Error resetting project: {str(e)}")
             return Response({
@@ -753,6 +788,8 @@ class CreateAppView(APIView):
             else:
                 return Response(result, status=status.HTTP_400_BAD_REQUEST)
                 
+        except APIException:
+            raise
         except Exception as e:
             logger.error(f"Error creating app: {str(e)}")
             return Response(
@@ -801,6 +838,8 @@ class ProjectLayoutView(APIView):
                     'updated_at': None
                 })
                 
+        except APIException:
+            raise
         except Exception as e:
             logger.error(f"Error loading project layout: {str(e)}")
             return Response({
@@ -838,6 +877,8 @@ class ProjectLayoutView(APIView):
                 'updated_at': layout.updated_at.isoformat()
             })
                 
+        except APIException:
+            raise
         except Exception as e:
             logger.error(f"Error saving project layout: {str(e)}")
             return Response({
@@ -864,6 +905,8 @@ class ProjectLayoutView(APIView):
                 'message': f'Layout reset successfully (deleted {deleted_count} record(s))'
             })
                 
+        except APIException:
+            raise
         except Exception as e:
             logger.error(f"Error resetting project layout: {str(e)}")
             return Response({

--- a/backend/django/apps/Products/Imagi/Builder/api/views.py
+++ b/backend/django/apps/Products/Imagi/Builder/api/views.py
@@ -55,9 +55,9 @@ class ProjectDirectoriesView(APIView):
             return Response(files)
         except APIException:
             raise
-        except Exception as e:
-            logger.error(f"Error listing project files: {str(e)}")
-            return Response({'error': str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        except Exception:
+            logger.exception("Error listing project files")
+            raise
 
 @method_decorator(never_cache, name='dispatch')
 class ProjectListCreateView(generics.ListCreateAPIView):
@@ -75,8 +75,8 @@ class ProjectListCreateView(generics.ListCreateAPIView):
             serializer.save(user=self.request.user, project=project)
         except APIException:
             raise
-        except Exception as e:
-            logger.error(f"Error creating project: {str(e)}")
+        except Exception:
+            logger.exception("Error creating project")
             raise
 
 @method_decorator(never_cache, name='dispatch')
@@ -139,12 +139,9 @@ class GenerateCodeView(APIView):
             return Response(response)
         except APIException:
             raise
-        except Exception as e:
-            logger.error(f"Error generating code: {str(e)}")
-            return Response(
-                {'error': str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
-            )
+        except Exception:
+            logger.exception("Error generating code")
+            raise
 
 @method_decorator(never_cache, name='dispatch')
 class AIModelsView(APIView):
@@ -178,12 +175,9 @@ class FileContentView(APIView):
             return Response({'content': content})
         except APIException:
             raise
-        except Exception as e:
-            logger.error(f"Error getting file content: {str(e)}")
-            return Response(
-                {'error': str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
-            )
+        except Exception:
+            logger.exception("Error getting file content")
+            raise
             
     def post(self, request, project_id, file_path):
         """Create or update file content."""
@@ -221,12 +215,9 @@ class FileContentView(APIView):
             return Response(file_data, status=status.HTTP_201_CREATED)
         except APIException:
             raise
-        except Exception as e:
-            logger.error(f"Error creating/updating file content: {str(e)}")
-            return Response(
-                {'error': str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
-            )
+        except Exception:
+            logger.exception("Error creating/updating file content")
+            raise
 
 # Removed old process_input view - use Agents API instead
 
@@ -282,12 +273,9 @@ class PreviewView(APIView):
             return Response(result)
         except APIException:
             raise
-        except Exception as e:
-            logger.error(f"Error stopping preview server: {str(e)}")
-            return Response({
-                'success': False,
-                'error': str(e)
-            }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        except Exception:
+            logger.exception("Error stopping preview server")
+            raise
 
 @method_decorator(never_cache, name='dispatch')
 class CreateFileView(APIView):
@@ -366,12 +354,9 @@ class CreateFileView(APIView):
             return Response(result, status=status.HTTP_201_CREATED)
         except APIException:
             raise
-        except Exception as e:
-            logger.error(f"Error creating file: {str(e)}")
-            return Response(
-                {'error': str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
-            )
+        except Exception:
+            logger.exception("Error creating file")
+            raise
 
 @method_decorator(never_cache, name='dispatch')
 class DeleteFileView(APIView):
@@ -413,12 +398,9 @@ class DeleteFileView(APIView):
             return Response(result, status=status.HTTP_200_OK)
         except APIException:
             raise
-        except Exception as e:
-            logger.error(f"Error deleting file: {str(e)}")
-            return Response(
-                {'error': str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
-            )
+        except Exception:
+            logger.exception("Error deleting file")
+            raise
 
 
 @method_decorator(never_cache, name='dispatch')
@@ -455,12 +437,9 @@ class CreateDirectoryView(APIView):
             return Response(result, status=status.HTTP_201_CREATED)
         except APIException:
             raise
-        except Exception as e:
-            logger.error(f"Error creating directory: {str(e)}")
-            return Response(
-                {'error': str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
-            )
+        except Exception:
+            logger.exception("Error creating directory")
+            raise
 
 
 @method_decorator(never_cache, name='dispatch')
@@ -501,12 +480,9 @@ class DeleteDirectoryView(APIView):
             return Response(result, status=status.HTTP_200_OK)
         except APIException:
             raise
-        except Exception as e:
-            logger.error(f"Error deleting directory: {str(e)}")
-            return Response(
-                {'error': str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
-            )
+        except Exception:
+            logger.exception("Error deleting directory")
+            raise
 
 
 @method_decorator(never_cache, name='dispatch')
@@ -561,12 +537,9 @@ class FileUndoView(APIView):
             return Response(result)
         except APIException:
             raise
-        except Exception as e:
-            logger.error(f"Error undoing file changes: {str(e)}")
-            return Response(
-                {'error': str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
-            )
+        except Exception:
+            logger.exception("Error undoing file changes")
+            raise
 
 @method_decorator(never_cache, name='dispatch')
 class AnalyzeTemplateView(APIView):
@@ -602,12 +575,9 @@ class AnalyzeTemplateView(APIView):
             
         except APIException:
             raise
-        except Exception as e:
-            logger.error(f"Error analyzing template: {str(e)}")
-            return Response(
-                {'error': str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
-            )
+        except Exception:
+            logger.exception("Error analyzing template")
+            raise
 
 @method_decorator(never_cache, name='dispatch')
 class VersionControlHistoryView(APIView):
@@ -644,12 +614,9 @@ class VersionControlHistoryView(APIView):
                 
         except APIException:
             raise
-        except Exception as e:
-            logger.error(f"Error getting version history: {str(e)}")
-            return Response({
-                'success': False,
-                'error': f"Error getting version history: {str(e)}"
-            }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        except Exception:
+            logger.exception("Error getting version history")
+            raise
     
     def post(self, request, project_id):
         """Create a new version (commit)."""
@@ -681,12 +648,9 @@ class VersionControlHistoryView(APIView):
                 
         except APIException:
             raise
-        except Exception as e:
-            logger.error(f"Error creating version: {str(e)}")
-            return Response({
-                'success': False,
-                'error': f"Error creating version: {str(e)}"
-            }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        except Exception:
+            logger.exception("Error creating version")
+            raise
 
 @method_decorator(never_cache, name='dispatch')
 class VersionControlResetView(APIView):
@@ -734,12 +698,9 @@ class VersionControlResetView(APIView):
                 
         except APIException:
             raise
-        except Exception as e:
-            logger.error(f"Error resetting project: {str(e)}")
-            return Response({
-                'success': False,
-                'error': f"Error resetting project: {str(e)}"
-            }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        except Exception:
+            logger.exception("Error resetting project")
+            raise
 
 @method_decorator(never_cache, name='dispatch')
 class CreateAppView(APIView):
@@ -790,12 +751,9 @@ class CreateAppView(APIView):
                 
         except APIException:
             raise
-        except Exception as e:
-            logger.error(f"Error creating app: {str(e)}")
-            return Response(
-                {'error': str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
-            )
+        except Exception:
+            logger.exception("Error creating app")
+            raise
 
 
 @method_decorator(never_cache, name='dispatch')
@@ -840,12 +798,9 @@ class ProjectLayoutView(APIView):
                 
         except APIException:
             raise
-        except Exception as e:
-            logger.error(f"Error loading project layout: {str(e)}")
-            return Response({
-                'success': False,
-                'error': str(e)
-            }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        except Exception:
+            logger.exception("Error loading project layout")
+            raise
 
     def post(self, request, project_id):
         """Save layout positions and connections."""
@@ -879,12 +834,9 @@ class ProjectLayoutView(APIView):
                 
         except APIException:
             raise
-        except Exception as e:
-            logger.error(f"Error saving project layout: {str(e)}")
-            return Response({
-                'success': False,
-                'error': str(e)
-            }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        except Exception:
+            logger.exception("Error saving project layout")
+            raise
 
     def delete(self, request, project_id):
         """Delete saved layout (reset to default)."""
@@ -907,9 +859,6 @@ class ProjectLayoutView(APIView):
                 
         except APIException:
             raise
-        except Exception as e:
-            logger.error(f"Error resetting project layout: {str(e)}")
-            return Response({
-                'success': False,
-                'error': str(e)
-            }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        except Exception:
+            logger.exception("Error resetting project layout")
+            raise

--- a/backend/django/apps/Products/Imagi/Builder/tests.py
+++ b/backend/django/apps/Products/Imagi/Builder/tests.py
@@ -103,6 +103,18 @@ class BuilderAPITests(APITestCase):
         self.assertEqual(resp.data['path'], relative_path)
         self.assertTrue(os.path.exists(os.path.join(self.project_root, relative_path)))
 
+    def test_create_file_accepts_form_encoded_data(self):
+        # Regression: form posts arrive as an immutable QueryDict; the view must
+        # copy it before deriving name/type instead of raising (which surfaced
+        # as a 500). Note the default (non-json) client format is multipart.
+        relative_path = 'frontend/vuejs/src/apps/blog/views/Form.vue'
+        resp = self.client.post(
+            reverse('api-create-file', args=[self.project.id]),
+            {'path': relative_path, 'content': 'form body'},
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(os.path.exists(os.path.join(self.project_root, relative_path)))
+
     def test_create_file_requires_path_or_name(self):
         resp = self.client.post(
             reverse('api-create-file', args=[self.project.id]),
@@ -110,7 +122,7 @@ class BuilderAPITests(APITestCase):
         )
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_create_file_on_other_users_project_is_rejected(self):
+    def test_create_file_on_other_users_project_returns_404(self):
         other = User.objects.create_user(username='intruder', password='testpass123')
         other_root = tempfile.mkdtemp(prefix='builder_other_')
         self.addCleanup(lambda: shutil.rmtree(other_root, ignore_errors=True))
@@ -122,10 +134,22 @@ class BuilderAPITests(APITestCase):
             reverse('api-create-file', args=[other_project.id]),
             {'path': relative_path, 'content': 'x'}, format='json',
         )
-        # The project is owned by another user, so the request must not succeed
-        # and no file may be written into their project directory.
-        self.assertGreaterEqual(resp.status_code, 400)
+        # Another user's project is not visible, so the caller gets a clean 404
+        # (not a 500), and nothing is written into their directory.
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
         self.assertFalse(os.path.exists(os.path.join(other_root, relative_path)))
+
+    def test_file_content_of_other_users_project_returns_404(self):
+        other = User.objects.create_user(username='snoop', password='testpass123')
+        other_root = tempfile.mkdtemp(prefix='builder_snoop_')
+        self.addCleanup(lambda: shutil.rmtree(other_root, ignore_errors=True))
+        other_project = PMProject.objects.create(
+            user=other, name="Snoop Project", project_path=other_root
+        )
+        resp = self.client.get(
+            reverse('api-file-content', args=[other_project.id, 'a/b.vue'])
+        )
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_file_content_round_trip(self):
         relative_path = 'frontend/vuejs/src/apps/blog/views/Home.vue'

--- a/backend/django/apps/Products/Imagi/Builder/tests.py
+++ b/backend/django/apps/Products/Imagi/Builder/tests.py
@@ -1,258 +1,154 @@
-from django.test import TestCase, Client
-from django.contrib.auth.models import User
-from django.urls import reverse
-from .models import Conversation, Page, Message
-from apps.Products.Imagi.ProjectManager.models import Project as PMProject
-from apps.Products.Imagi.Builder.services.create_file_service import CreateFileService
+"""
+Tests for the Builder app.
+
+Covers the Builder models, the CreateFileService, and the current Builder DRF
+API (file creation/content, the models endpoint, auth gating and project
+ownership).
+
+Note: the previous server-rendered view/service tests (`builder:landing_page`,
+`process_builder_mode_input`, ...) were removed. Those exercised a legacy
+template UI and pre-SDK agent helpers that no longer exist — the workspace is
+now a Vue SPA talking to the DRF API exercised below.
+"""
+
 import os
 import shutil
 import tempfile
 
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APITestCase
+
+from apps.Products.Imagi.ProjectManager.models import Project as PMProject
+from apps.Products.Imagi.Builder.models import Conversation, Page, Message
+from apps.Products.Imagi.Builder.services.create_file_service import CreateFileService
+
+
 class BuilderModelTests(TestCase):
     def setUp(self):
-        # Create a test user
-        self.user = User.objects.create_user(
-            username='testuser',
-            password='testpass123'
-        )
+        self.user = User.objects.create_user(username='testuser', password='testpass123')
 
-        # Create a project
         self.project_root = tempfile.mkdtemp(prefix='builder_model_')
         self.project = PMProject.objects.create(
-            user=self.user,
-            name="Test Project",
-            project_path=self.project_root
+            user=self.user, name="Test Project", project_path=self.project_root
         )
         self.addCleanup(lambda: shutil.rmtree(self.project_root, ignore_errors=True))
 
-        # Create a conversation
         self.conversation = Conversation.objects.create(
-            user=self.user,
-            project_id=self.project.id
+            user=self.user, project_id=self.project.id
         )
-        
-        # Create a page
         self.page = Page.objects.create(
-            conversation=self.conversation,
-            filename="index.html"
+            conversation=self.conversation, filename="index.html"
         )
 
     def test_project_creation(self):
-        """Test project model creation and string representation"""
         self.assertEqual(str(self.project), "Test Project (testuser)")
         self.assertEqual(self.project.slug, "test-project")
 
     def test_conversation_creation(self):
-        """Test conversation model creation and string representation"""
-        expected_str = f"Conversation {self.conversation.id} for testuser - Project ID: {self.project.id}"
+        expected_str = (
+            f"Conversation {self.conversation.id} for testuser "
+            f"- Project ID: {self.project.id}"
+        )
         self.assertEqual(str(self.conversation), expected_str)
 
     def test_page_creation(self):
-        """Test page model creation and string representation"""
         expected_str = f"Page index.html in Conversation {self.conversation.id}"
         self.assertEqual(str(self.page), expected_str)
 
     def test_message_creation(self):
-        """Test message model creation and string representation"""
         message = Message.objects.create(
-            conversation=self.conversation,
-            page=self.page,
-            role='user',
-            content='Test message'
+            conversation=self.conversation, page=self.page,
+            role='user', content='Test message',
         )
-        expected_str = "User message for index.html"
-        self.assertEqual(str(message), expected_str)
+        self.assertEqual(str(message), "User message for index.html")
 
-class BuilderViewTests(TestCase):
+
+class BuilderAPITests(APITestCase):
+    """The current Builder REST API (replaces the legacy view tests)."""
+
     def setUp(self):
-        # Create test user and log them in
-        self.user = User.objects.create_user(
-            username='testuser',
-            password='testpass123'
-        )
-        self.client = Client()
-        self.client.login(username='testuser', password='testpass123')
+        self.user = User.objects.create_user(username='builder', password='testpass123')
+        self.token = Token.objects.create(user=self.user)
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.token.key}')
 
-        self.project_root = tempfile.mkdtemp(prefix='builder_view_')
+        self.project_root = tempfile.mkdtemp(prefix='builder_api_')
         self.project = PMProject.objects.create(
-            user=self.user,
-            name="Test Project",
-            project_path=self.project_root
+            user=self.user, name="API Project", project_path=self.project_root
         )
+        self.addCleanup(lambda: shutil.rmtree(self.project_root, ignore_errors=True))
 
-    def tearDown(self):
-        shutil.rmtree(self.project_root, ignore_errors=True)
+    def test_models_endpoint_requires_auth(self):
+        self.client.credentials()  # drop auth
+        resp = self.client.get(reverse('api-ai-models'))
+        self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
 
-    def test_landing_page_view(self):
-        """Test the landing page view"""
-        response = self.client.get(reverse('builder:landing_page'))
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, 'builder/builder_landing_page.html')
-        self.assertIn('projects', response.context)
+    def test_models_endpoint_returns_models(self):
+        resp = self.client.get(reverse('api-ai-models'))
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertIn('models', resp.data)
+        self.assertGreater(len(resp.data['models']), 0)
 
-    def test_create_project_view(self):
-        """Test project creation"""
-        response = self.client.post(
-            reverse('builder:create_project'),
-            {'project_name': 'New Test Project'}
+    def test_create_file_writes_to_disk(self):
+        relative_path = 'frontend/vuejs/src/apps/blog/views/About.vue'
+        resp = self.client.post(
+            reverse('api-create-file', args=[self.project.id]),
+            {'path': relative_path, 'content': 'hello world'},
+            format='json',
         )
-        self.assertEqual(response.status_code, 302)  # Redirect after creation
-        self.assertTrue(PMProject.objects.filter(name='New Test Project').exists())
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(resp.data['path'], relative_path)
+        self.assertTrue(os.path.exists(os.path.join(self.project_root, relative_path)))
 
-    def test_delete_project_view(self):
-        """Test project deletion"""
-        response = self.client.post(
-            reverse('builder:delete_project', args=[self.project.id])
+    def test_create_file_requires_path_or_name(self):
+        resp = self.client.post(
+            reverse('api-create-file', args=[self.project.id]),
+            {'content': 'x'}, format='json',
         )
-        self.assertEqual(response.status_code, 302)  # Redirect after deletion
-        self.assertFalse(PMProject.objects.filter(id=self.project.id).exists())
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_project_workspace_view(self):
-        """Test the project workspace view"""
-        response = self.client.get(
-            reverse('builder:project_workspace', 
-                   args=[self.project.slug])
+    def test_create_file_on_other_users_project_is_rejected(self):
+        other = User.objects.create_user(username='intruder', password='testpass123')
+        other_root = tempfile.mkdtemp(prefix='builder_other_')
+        self.addCleanup(lambda: shutil.rmtree(other_root, ignore_errors=True))
+        other_project = PMProject.objects.create(
+            user=other, name="Their Project", project_path=other_root
         )
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, 'builder/oasis_builder.html')
+        relative_path = 'frontend/vuejs/src/x.vue'
+        resp = self.client.post(
+            reverse('api-create-file', args=[other_project.id]),
+            {'path': relative_path, 'content': 'x'}, format='json',
+        )
+        # The project is owned by another user, so the request must not succeed
+        # and no file may be written into their project directory.
+        self.assertGreaterEqual(resp.status_code, 400)
+        self.assertFalse(os.path.exists(os.path.join(other_root, relative_path)))
 
-class BuilderServiceTests(TestCase):
-    def setUp(self):
-        # Create test user
-        self.user = User.objects.create_user(
-            username='testuser',
-            password='testpass123'
+    def test_file_content_round_trip(self):
+        relative_path = 'frontend/vuejs/src/apps/blog/views/Home.vue'
+        self.client.post(
+            reverse('api-create-file', args=[self.project.id]),
+            {'path': relative_path, 'content': 'the content'},
+            format='json',
         )
-
-        self.project_root = tempfile.mkdtemp(prefix='builder_service_')
-        self.project = PMProject.objects.create(
-            user=self.user,
-            name="Test Project",
-            project_path=self.project_root
+        resp = self.client.get(
+            reverse('api-file-content', args=[self.project.id, relative_path])
         )
-
-        # Create conversation and page
-        self.conversation = Conversation.objects.create(
-            user=self.user,
-            project_id=self.project.id
-        )
-        
-        self.page = Page.objects.create(
-            conversation=self.conversation,
-            filename="index.html"
-        )
-
-    def tearDown(self):
-        shutil.rmtree(self.project_root, ignore_errors=True)
-
-    def test_process_builder_mode_input(self):
-        """Test the builder mode input processing"""
-        from apps.Products.Imagi.Agents.services import process_builder_mode_input
-        
-        # Create necessary directories
-        os.makedirs(os.path.join(self.project_root, "templates"), exist_ok=True)
-        os.makedirs(os.path.join(self.project_root, "static/css"), exist_ok=True)
-        
-        response = process_builder_mode_input(
-            user_input="Create a simple landing page",
-            model="gpt-5.6-sol",
-            file_name="index.html",
-            user=self.user
-        )
-        
-        self.assertIn('success', response)
-        if response['success']:
-            self.assertIn('response', response)
-
-    def test_undo_last_action(self):
-        """Test the undo last action functionality"""
-        from apps.Products.Imagi.Agents.services import undo_last_action_service
-        
-        # Create test messages
-        Message.objects.create(
-            conversation=self.conversation,
-            page=self.page,
-            role='assistant',
-            content='First version'
-        )
-        
-        Message.objects.create(
-            conversation=self.conversation,
-            page=self.page,
-            role='assistant',
-            content='Second version'
-        )
-        
-        content, message, status_code = undo_last_action_service(
-            self.user,
-            "index.html"
-        )
-        
-        self.assertEqual(status_code, 200)
-        self.assertEqual(Message.objects.filter(
-            conversation=self.conversation,
-            page=self.page
-        ).count(), 1)
-
-class BuilderIntegrationTests(TestCase):
-    def setUp(self):
-        # Set up test user and client
-        self.user = User.objects.create_user(
-            username='testuser',
-            password='testpass123'
-        )
-        self.client = Client()
-        self.client.login(username='testuser', password='testpass123')
-
-    def test_project_lifecycle(self):
-        """Test the complete lifecycle of a project"""
-        # 1. Create project
-        response = self.client.post(
-            reverse('builder:create_project'),
-            {'project_name': 'Lifecycle Test Project'}
-        )
-        self.assertEqual(response.status_code, 302)
-        
-        project = PMProject.objects.get(name='Lifecycle Test Project')
-        
-        # 2. Access project workspace
-        response = self.client.get(
-            reverse('builder:project_workspace', 
-                   args=[project.slug])
-        )
-        self.assertEqual(response.status_code, 200)
-        
-        # 3. Generate content
-        response = self.client.post(
-            reverse('builder:process_input'),
-            {
-                'user_input': 'Create a simple landing page',
-                'model': 'gpt-5.6-sol',
-                'file': 'index.html',
-                'mode': 'build'
-            }
-        )
-        self.assertEqual(response.status_code, 200)
-        
-        # 4. Delete project
-        response = self.client.post(
-            reverse('builder:delete_project', args=[project.id])
-        )
-        self.assertEqual(response.status_code, 302)
-        self.assertFalse(PMProject.objects.filter(id=project.id).exists())
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data['content'], 'the content')
 
 
 class CreateFileServiceTests(TestCase):
     def setUp(self):
         self.user = User.objects.create_user(
-            username='fileserviceuser',
-            password='testpass123'
+            username='fileserviceuser', password='testpass123'
         )
         self.project_root = tempfile.mkdtemp(prefix='imagi_file_service_')
         self.project = PMProject.objects.create(
-            user=self.user,
-            name='File Service Project',
-            project_path=self.project_root
+            user=self.user, name='File Service Project', project_path=self.project_root
         )
         self.service = CreateFileService(project=self.project)
 

--- a/backend/django/apps/Products/Imagi/Builder/tests.py
+++ b/backend/django/apps/Products/Imagi/Builder/tests.py
@@ -14,6 +14,7 @@ now a Vue SPA talking to the DRF API exercised below.
 import os
 import shutil
 import tempfile
+from unittest.mock import patch
 
 from django.contrib.auth.models import User
 from django.test import TestCase
@@ -150,6 +151,22 @@ class BuilderAPITests(APITestCase):
             reverse('api-file-content', args=[other_project.id, 'a/b.vue'])
         )
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    @patch('apps.Products.Imagi.Builder.api.views.CreateFileService')
+    def test_unexpected_service_error_returns_safe_500(self, mock_service_cls):
+        # An unexpected service failure must surface as a generic 500 handled by
+        # the central exception handler — not a leaked internal error string.
+        mock_service_cls.return_value.create_file.side_effect = Exception(
+            'sensitive detail: /srv/secret/path'
+        )
+        resp = self.client.post(
+            reverse('api-create-file', args=[self.project.id]),
+            {'path': 'frontend/vuejs/src/x.vue', 'content': 'y'},
+            format='json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertIn('error', resp.data)
+        self.assertNotIn('sensitive detail', str(resp.data))
 
     def test_file_content_round_trip(self):
         relative_path = 'frontend/vuejs/src/apps/blog/views/Home.vue'

--- a/backend/django/apps/Products/Imagi/ProjectManager/api/views.py
+++ b/backend/django/apps/Products/Imagi/ProjectManager/api/views.py
@@ -1,12 +1,16 @@
+import logging
+
 from rest_framework import generics, permissions, status
 from rest_framework.response import Response
-from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import NotFound, APIException
 from rest_framework.views import APIView
 from ..services import ProjectCreationService, ProjectManagementService
 from .serializers import (
-    ProjectSerializer, 
+    ProjectSerializer,
     ProjectCreateSerializer
 )
+
+logger = logging.getLogger(__name__)
 
 class ProjectListView(generics.ListAPIView):
     permission_classes = [permissions.IsAuthenticated]
@@ -24,20 +28,21 @@ class ProjectCreateView(generics.CreateAPIView):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         
+        project = None
         try:
             project = serializer.save()  # Don't pass user here, handle it in serializer
             service = ProjectCreationService(request.user)
             service.create_project(project)
-            
+
             response_serializer = ProjectSerializer(project)
             return Response(response_serializer.data, status=status.HTTP_201_CREATED)
-        except Exception as e:
+        except Exception:
+            # Roll back the half-created project, then let the central exception
+            # handler return a safe 500 instead of leaking the raw error string.
             if project:
                 project.delete()
-            return Response(
-                {'error': str(e)}, 
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
-            )
+            logger.exception("Error creating project")
+            raise
         
 class ProjectDetailView(generics.RetrieveUpdateAPIView):
     permission_classes = [permissions.IsAuthenticated]
@@ -82,8 +87,6 @@ class ProjectInitializeView(APIView):
     permission_classes = [permissions.IsAuthenticated]
     
     def post(self, request, pk):
-        import logging
-        logger = logging.getLogger(__name__)
         logger.info(f"Initialize request received for project {pk}")
         
         try:
@@ -96,11 +99,9 @@ class ProjectInitializeView(APIView):
                 try:
                     os.makedirs(settings.PROJECTS_ROOT, exist_ok=True)
                     logger.info(f"Created PROJECTS_ROOT directory: {settings.PROJECTS_ROOT}")
-                except Exception as root_err:
-                    logger.error(f"Failed to create PROJECTS_ROOT directory: {str(root_err)}")
-                    return Response({
-                        'error': f"Failed to create projects directory: {str(root_err)}",
-                    }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+                except Exception:
+                    logger.exception("Failed to create PROJECTS_ROOT directory")
+                    raise
             
             service = ProjectCreationService(request.user)
             management_service = ProjectManagementService(request.user)
@@ -155,15 +156,9 @@ class ProjectInitializeView(APIView):
                     project.project_path = project_path
                     project.save()
                     logger.info(f"Assigned default project path: {project_path}")
-                except Exception as path_err:
-                    logger.error(f"Failed to assign default project path: {str(path_err)}")
-                    import traceback
-                    logger.error(f"Stack trace: {traceback.format_exc()}")
-                    return Response({
-                        'error': f"Project has no valid path: {str(path_err)}",
-                        'project_id': project.id,
-                        'name': project.name
-                    }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+                except Exception:
+                    logger.exception("Failed to assign default project path")
+                    raise
             
             # Initialize the project
             try:
@@ -196,22 +191,18 @@ class ProjectInitializeView(APIView):
                             'project_id': project.id,
                             'name': project.name
                         }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-            except Exception as e:
-                logger.error(f"Failed to initialize project {project.name} (ID: {project.id}): {str(e)}")
-                import traceback
-                logger.error(f"Stack trace: {traceback.format_exc()}")
-                return Response({
-                    'error': str(e),
-                    'project_id': project.id,
-                    'name': project.name
-                }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
-        except Exception as outer_e:
-            logger.error(f"Unhandled exception in project initialization: {str(outer_e)}")
-            import traceback
-            logger.error(f"Stack trace: {traceback.format_exc()}")
-            return Response({
-                'error': f"Server error: {str(outer_e)}"
-            }, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            except Exception:
+                logger.exception(
+                    "Failed to initialize project %s (ID: %s)", project.name, project.id
+                )
+                raise
+        except APIException:
+            # NotFound (missing/other-user project) and friends must keep their
+            # proper status instead of being masked as a 500.
+            raise
+        except Exception:
+            logger.exception("Unhandled exception in project initialization")
+            raise
 
 class ProjectStatusView(APIView):
     """

--- a/backend/django/apps/Products/Imagi/ProjectManager/tests.py
+++ b/backend/django/apps/Products/Imagi/ProjectManager/tests.py
@@ -176,6 +176,33 @@ class ProjectManagerAPITests(APITestCase):
         )
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
 
+    @patch(
+        'apps.Products.Imagi.ProjectManager.api.views.ProjectCreationService.create_project'
+    )
+    def test_create_failure_rolls_back_and_returns_safe_500(self, mock_create):
+        # A failure during file generation must roll back the half-created
+        # project and return a generic 500 (no leaked internal error string).
+        mock_create.side_effect = Exception('secret path /srv/imagi/secret')
+        resp = self.client.post(
+            reverse('project_manager:project-create'),
+            {'name': 'Rollback Me', 'description': ''},
+        )
+        self.assertEqual(resp.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertNotIn('secret path', str(resp.data))
+        self.assertFalse(
+            Project.objects.filter(
+                user=self.user, name='Rollback Me', is_active=True
+            ).exists()
+        )
+
+    def test_initialize_missing_project_returns_404(self):
+        # get_project() raises NotFound; it must surface as a 404, not be
+        # swallowed into a 500 by the view's outer exception handler.
+        resp = self.client.post(
+            reverse('project_manager:project-initialize', args=[99999])
+        )
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
     def test_detail_retrieve_own_project(self):
         project = Project.objects.create(user=self.user, name='Detail App')
         resp = self.client.get(

--- a/backend/django/apps/Products/Imagi/ProjectManager/tests.py
+++ b/backend/django/apps/Products/Imagi/ProjectManager/tests.py
@@ -1,130 +1,237 @@
-from django.test import TestCase
-from django.contrib.auth import get_user_model
-from django.conf import settings
-import os
+"""
+Tests for the ProjectManager app.
+
+These focus on the logic that is safe and fast to exercise: the Project model
+(slug/path generation, validation, soft vs hard delete), the create serializer,
+the management service, and the REST API. The heavy filesystem/subprocess work
+performed by ProjectCreationService is mocked out so the suite stays fast and
+does not pollute the repository or depend on npm/Django scaffolding.
+"""
+
 import shutil
-import json
-from .models import Project
-from .services.project_creation_service import ProjectCreationService
-from .services.project_management_service import ProjectManagementService
+import tempfile
+from unittest.mock import patch
 
-class ProjectManagerTests(TestCase):
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APITestCase
+
+from apps.Products.Imagi.ProjectManager.models import Project
+from apps.Products.Imagi.ProjectManager.services.project_management_service import (
+    ProjectManagementService,
+)
+
+User = get_user_model()
+
+# A throwaway PROJECTS_ROOT so the services' os.makedirs() calls never touch
+# the real repository. Created once for the module, removed at teardown.
+_TMP_PROJECTS_ROOT = tempfile.mkdtemp(prefix='imagi_pm_tests_')
+
+
+def tearDownModule():
+    shutil.rmtree(_TMP_PROJECTS_ROOT, ignore_errors=True)
+
+
+@override_settings(PROJECTS_ROOT=_TMP_PROJECTS_ROOT)
+class ProjectModelTests(TestCase):
     def setUp(self):
-        self.User = get_user_model()
-        self.user = self.User.objects.create_user(
-            username='testuser',
-            password='testpass123'
-        )
-        self.creation_service = ProjectCreationService(self.user)
-        self.management_service = ProjectManagementService(self.user)
+        self.user = User.objects.create_user(username='owner', password='pw123456')
+        self.other = User.objects.create_user(username='other', password='pw123456')
 
-    def tearDown(self):
-        # Clean up created project directories
-        user_projects_dir = os.path.join(settings.PROJECTS_ROOT, str(self.user.id))
-        if os.path.exists(user_projects_dir):
-            shutil.rmtree(user_projects_dir)
+    def test_slug_is_generated_from_name(self):
+        project = Project.objects.create(user=self.user, name='My Cool App')
+        self.assertEqual(project.slug, 'my-cool-app')
 
-    def test_create_project(self):
-        # First create the project object
-        project = Project.objects.create(
-            user=self.user,
-            name='TestProject'
-        )
-        
-        # Now use the service to create project files
-        self.creation_service.create_project(project)
-        
-        self.assertEqual(project.user, self.user)
-        self.assertEqual(project.name, 'TestProject')
+    def test_slug_is_made_unique(self):
+        # The same name is only unique per-user, but slugs are unique globally,
+        # so two different users picking the same name still get distinct slugs.
+        first = Project.objects.create(user=self.user, name='Duplicate Name')
+        second = Project.objects.create(user=self.other, name='Duplicate Name')
+        self.assertEqual(first.slug, 'duplicate-name')
+        self.assertEqual(second.slug, 'duplicate-name-1')
+
+    def test_project_path_is_generated(self):
+        project = Project.objects.create(user=self.user, name='Path App')
         self.assertTrue(project.project_path)
-        
-        # Verify project is created in imagi_projects directory
-        expected_base_path = os.path.join(settings.PROJECTS_ROOT, str(self.user.id))
-        self.assertTrue(project.project_path.startswith(expected_base_path))
-        
-        # Verify directory structure
-        self.assertTrue(os.path.exists(project.project_path))
-        self.assertTrue(os.path.exists(os.path.join(project.project_path, 'templates')))
-        self.assertTrue(os.path.exists(os.path.join(project.project_path, 'static')))
-        
-        # Verify template files
-        self.assertTrue(os.path.exists(os.path.join(project.project_path, 'templates', 'base.html')))
-        self.assertTrue(os.path.exists(os.path.join(project.project_path, 'static', 'css', 'style.css')))
+        self.assertIn(self.user.username, project.project_path)
+        self.assertIn(project.slug, project.project_path)
 
-    def test_delete_project(self):
-        """Test that project deletion removes both database record and files"""
-        # First create a project
-        project = Project.objects.create(
-            user=self.user,
-            name='TestDeleteProject'
-        )
-        
-        # Generate files for the project
-        self.creation_service.create_project(project)
-        
-        # Verify project exists in database
+    def test_clean_rejects_short_names(self):
+        project = Project(user=self.user, name='ab')
+        with self.assertRaises(ValidationError):
+            project.clean()
+
+    def test_soft_delete_marks_inactive(self):
+        project = Project.objects.create(user=self.user, name='Soft Delete')
+        project.delete()
+        project.refresh_from_db()
+        self.assertFalse(project.is_active)
         self.assertTrue(Project.objects.filter(id=project.id).exists())
-        
-        # Verify project files exist
-        self.assertTrue(os.path.exists(project.project_path))
-        
-        # Delete the project
-        self.management_service.delete_project(project)
-        
-        # Verify project is deleted from database
+
+    def test_hard_delete_removes_row(self):
+        project = Project.objects.create(user=self.user, name='Hard Delete')
+        pid = project.id
+        project.delete(hard_delete=True)
+        self.assertFalse(Project.objects.filter(id=pid).exists())
+
+
+@override_settings(PROJECTS_ROOT=_TMP_PROJECTS_ROOT)
+class ProjectCreateSerializerTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='owner', password='pw123456')
+        self.token = Token.objects.create(user=self.user)
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.token.key}')
+
+    def test_duplicate_active_name_rejected(self):
+        Project.objects.create(user=self.user, name='Existing Project')
+        from apps.Products.Imagi.ProjectManager.api.serializers import (
+            ProjectCreateSerializer,
+        )
+
+        request = type('R', (), {'user': self.user})()
+        serializer = ProjectCreateSerializer(
+            data={'name': 'Existing Project'}, context={'request': request}
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn('name', serializer.errors)
+
+
+@override_settings(PROJECTS_ROOT=_TMP_PROJECTS_ROOT)
+class ProjectManagementServiceTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='owner', password='pw123456')
+        self.other = User.objects.create_user(username='other', password='pw123456')
+        self.service = ProjectManagementService(self.user)
+
+    def test_get_active_projects_scoped_to_user(self):
+        mine = Project.objects.create(user=self.user, name='Mine')
+        Project.objects.create(user=self.other, name='Theirs')
+        inactive = Project.objects.create(user=self.user, name='Archived')
+        inactive.delete()  # soft delete
+        active = list(self.service.get_active_projects())
+        self.assertEqual(active, [mine])
+
+    def test_get_project_returns_none_for_other_users_project(self):
+        theirs = Project.objects.create(user=self.other, name='Theirs')
+        self.assertIsNone(self.service.get_project(theirs.id))
+
+    @patch.object(ProjectManagementService, '_stop_project_server_and_cleanup_pid')
+    @patch.object(ProjectManagementService, '_delete_project_directory')
+    def test_delete_project_hard_deletes_row(self, mock_dir, mock_pid):
+        project = Project.objects.create(user=self.user, name='To Delete')
+        pid = project.id
+        result = self.service.delete_project(project)
+        self.assertTrue(result['success'])
+        self.assertFalse(Project.objects.filter(id=pid).exists())
+
+
+@override_settings(PROJECTS_ROOT=_TMP_PROJECTS_ROOT)
+class ProjectManagerAPITests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='owner', password='pw123456')
+        self.other = User.objects.create_user(username='other', password='pw123456')
+        self.token = Token.objects.create(user=self.user)
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.token.key}')
+
+    def test_list_requires_authentication(self):
+        self.client.credentials()
+        resp = self.client.get(reverse('project_manager:project-list'))
+        self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_list_returns_only_own_active_projects(self):
+        Project.objects.create(user=self.user, name='Mine One')
+        Project.objects.create(user=self.other, name='Not Mine')
+        archived = Project.objects.create(user=self.user, name='Archived')
+        archived.delete()
+        resp = self.client.get(reverse('project_manager:project-list'))
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        # The list endpoint is paginated, so projects live under "results".
+        names = [p['name'] for p in resp.data['results']]
+        self.assertEqual(names, ['Mine One'])
+
+    @patch(
+        'apps.Products.Imagi.ProjectManager.api.views.ProjectCreationService.create_project'
+    )
+    def test_create_project(self, mock_create):
+        mock_create.side_effect = lambda project: project
+        resp = self.client.post(
+            reverse('project_manager:project-create'),
+            {'name': 'Brand New App', 'description': 'hello'},
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(resp.data['name'], 'Brand New App')
+        self.assertTrue(
+            Project.objects.filter(user=self.user, name='Brand New App').exists()
+        )
+        mock_create.assert_called_once()
+
+    def test_create_duplicate_name_returns_400(self):
+        Project.objects.create(user=self.user, name='Taken Name')
+        resp = self.client.post(
+            reverse('project_manager:project-create'), {'name': 'Taken Name'}
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_detail_retrieve_own_project(self):
+        project = Project.objects.create(user=self.user, name='Detail App')
+        resp = self.client.get(
+            reverse('project_manager:project-detail', args=[project.id])
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data['name'], 'Detail App')
+
+    def test_detail_of_other_users_project_returns_404(self):
+        project = Project.objects.create(user=self.other, name='Their App')
+        resp = self.client.get(
+            reverse('project_manager:project-detail', args=[project.id])
+        )
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    @patch.object(ProjectManagementService, '_stop_project_server_and_cleanup_pid')
+    @patch.object(ProjectManagementService, '_delete_project_directory')
+    def test_delete_project_endpoint(self, mock_dir, mock_pid):
+        project = Project.objects.create(user=self.user, name='Delete Me')
+        resp = self.client.delete(
+            reverse('project_manager:project-delete', args=[project.id])
+        )
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(Project.objects.filter(id=project.id).exists())
-        
-        # Verify project files are deleted
-        self.assertFalse(os.path.exists(project.project_path))
 
-    def test_generated_frontend_has_required_packages(self):
-        """Generated project should include required node packages in frontend/vuejs/package.json"""
-        project = Project.objects.create(
-            user=self.user,
-            name='DepsProject'
+    def test_delete_missing_project_returns_404(self):
+        resp = self.client.delete(
+            reverse('project_manager:project-delete', args=[99999])
         )
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
 
-        self.creation_service.create_project(project)
-
-        # Locate generated frontend package.json
-        package_json_path = os.path.join(project.project_path, 'frontend', 'vuejs', 'package.json')
-        self.assertTrue(os.path.exists(package_json_path), f"package.json not found at {package_json_path}")
-
-        with open(package_json_path, 'r') as f:
-            pkg = json.load(f)
-
-        # Check a representative set of dependencies
-        deps = pkg.get('dependencies', {})
-        dev_deps = pkg.get('devDependencies', {})
-
-        required_deps = [
-            'vue', 'vue-router', 'pinia', 'axios', 'tailwindcss',
-            '@headlessui/vue', '@heroicons/vue', '@fortawesome/fontawesome-svg-core',
-            '@fortawesome/free-solid-svg-icons', '@fortawesome/vue-fontawesome'
-        ]
-        for dep in required_deps:
-            self.assertIn(dep, deps, f"Missing dependency: {dep}")
-
-        required_dev_deps = [
-            '@vitejs/plugin-vue', 'vite', 'typescript', 'vue-tsc', 'eslint', 'prettier'
-        ]
-        for dep in required_dev_deps:
-            self.assertIn(dep, dev_deps, f"Missing devDependency: {dep}")
-
-    def test_generated_frontend_router_auto_imports_app_routes(self):
-        """Generated project router should auto-import app route modules via import.meta.glob and define a 404 fallback."""
-        project = Project.objects.create(
-            user=self.user,
-            name='RouterProject'
+    def test_status_endpoint(self):
+        project = Project.objects.create(user=self.user, name='Status App')
+        resp = self.client.get(
+            reverse('project_manager:project-status', args=[project.id])
         )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data['name'], 'Status App')
+        self.assertFalse(resp.data['is_initialized'])
 
-        self.creation_service.create_project(project)
+    @patch(
+        'apps.Products.Imagi.ProjectManager.api.views.ProjectCreationService.initialize_project'
+    )
+    def test_initialize_endpoint(self, mock_init):
+        project = Project.objects.create(user=self.user, name='Init App')
 
-        router_path = os.path.join(project.project_path, 'frontend', 'vuejs', 'src', 'router', 'index.js')
-        self.assertTrue(os.path.exists(router_path), f"Router file not found at {router_path}")
+        def _mark_initialized(proj):
+            proj.is_initialized = True
+            proj.save()
+            return {'success': True}
 
-        with open(router_path, 'r') as f:
-            router_src = f.read()
-
-        self.assertIn("import.meta.glob", router_src, "Router should use import.meta.glob to load app routes")
-        self.assertIn("'/:pathMatch(.*)*'", router_src, "Router should include a 404 fallback route")
+        mock_init.side_effect = _mark_initialized
+        resp = self.client.post(
+            reverse('project_manager:project-initialize', args=[project.id])
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertTrue(resp.data['success'])
+        project.refresh_from_db()
+        self.assertTrue(project.is_initialized)

--- a/backend/django/imagi/exception_handler.py
+++ b/backend/django/imagi/exception_handler.py
@@ -1,0 +1,41 @@
+"""
+Project-wide DRF exception handling.
+
+DRF's default handler renders APIExceptions (400/401/403/404/...) as JSON but
+lets any *other* exception fall through to Django, which — outside DEBUG —
+returns an opaque HTML 500 with no JSON body the SPA can parse.
+
+`api_exception_handler` keeps DRF's behavior for APIExceptions and, for
+genuinely unexpected errors, logs the full traceback server-side and returns a
+safe, generic JSON 500. This lets views stop wrapping every call in a broad
+`except Exception` that both fabricates the 500 and leaks `str(exc)` (which can
+expose filesystem paths, SQL, etc.) to the client.
+"""
+
+import logging
+
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import exception_handler as drf_exception_handler
+
+logger = logging.getLogger(__name__)
+
+
+def api_exception_handler(exc, context):
+    """Return DRF's response for handled exceptions; a safe 500 otherwise."""
+    response = drf_exception_handler(exc, context)
+    if response is not None:
+        # A recognised APIException (validation, auth, permission, not-found,
+        # ...). DRF already produced the correct status and body.
+        return response
+
+    # Anything else is an unexpected server-side failure. Log it with the full
+    # traceback for debugging, but never surface the raw error to the client.
+    view = context.get('view')
+    view_name = view.__class__.__name__ if view is not None else 'unknown view'
+    logger.exception('Unhandled exception in %s', view_name)
+
+    return Response(
+        {'error': 'A server error occurred. Please try again later.'},
+        status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+    )

--- a/backend/django/imagi/settings.py
+++ b/backend/django/imagi/settings.py
@@ -195,6 +195,8 @@ REST_FRAMEWORK = {
     ],
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 25,
+    # Log unexpected errors and return a safe generic 500 (never leak str(exc)).
+    'EXCEPTION_HANDLER': 'imagi.exception_handler.api_exception_handler',
 }
 
 

--- a/frontend/vuejs/package-lock.json
+++ b/frontend/vuejs/package-lock.json
@@ -41,6 +41,7 @@
         "@types/uuid": "^10.0.0",
         "@vitejs/plugin-vue": "^6.0.4",
         "@vue/eslint-config-typescript": "^14.7.0",
+        "@vue/test-utils": "^2.4.11",
         "@vue/tsconfig": "^0.8.1",
         "autoprefixer": "^10.4.17",
         "eslint": "^10.0.2",
@@ -55,6 +56,7 @@
         "typescript": "~5.9.3",
         "vite": "^7.3.1",
         "vite-plugin-vue-devtools": "^8.0.6",
+        "vitest": "^4.1.10",
         "vue-tsc": "^3.2.5"
       },
       "engines": {
@@ -1436,6 +1438,24 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1521,6 +1541,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@oxlint/binding-android-arm-eabi": {
       "version": "1.50.0",
@@ -1843,6 +1870,17 @@
       ],
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@polka/url": {
@@ -2209,6 +2247,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@stripe/stripe-js": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-3.5.0.tgz",
@@ -2275,6 +2320,24 @@
       "version": "24.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node24/-/node24-24.0.4.tgz",
       "integrity": "sha512-2A933l5P5oCbv6qSxHs7ckKwobs8BDAe9SJ/Xr2Hy+nDlwmLE1GhFh/g/vXGRZWgxBg9nX/5piDtHR9Dkw/XuA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2630,6 +2693,129 @@
       "peerDependencies": {
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0",
         "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@volar/language-core": {
@@ -2999,6 +3185,27 @@
       "integrity": "sha512-w7SR0A5zyRByL9XUkCfdLs7t9XOHUyJ67qPGQjOou3p6GvBeBW+AVjUUmlxtZ4PIYaRvE+1LmK44O4uajlZwcg==",
       "license": "MIT"
     },
+    "node_modules/@vue/test-utils": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.11.tgz",
+      "integrity": "sha512-GDqaqZsA6m2E5vNzej0aYiIb6BX8xV9pNSbbbXKOfEYwg7ZNblVX8suyqmUBThq8VIrgAJNxn+z72hVtUeiWHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-beautify": "^1.14.9",
+        "vue-component-type-helpers": "^3.0.0"
+      },
+      "peerDependencies": {
+        "@vue/compiler-dom": "3.x",
+        "@vue/server-renderer": "3.x",
+        "vue": "3.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/server-renderer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vue/tsconfig": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@vue/tsconfig/-/tsconfig-0.8.1.tgz",
@@ -3016,6 +3223,16 @@
         "vue": {
           "optional": true
         }
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/acorn": {
@@ -3073,6 +3290,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
@@ -3120,6 +3350,16 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ast-kit": {
       "version": "2.2.0",
@@ -3385,6 +3625,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chart.js": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
@@ -3412,6 +3662,26 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -3438,6 +3708,17 @@
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
       "license": "MIT"
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -3661,12 +3942,88 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/editorconfig": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
+      "integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@one-ini/wasm": "0.1.1",
+        "commander": "^10.0.0",
+        "minimatch": "^9.0.1",
+        "semver": "^7.5.3"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/editorconfig/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/editorconfig/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
       "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "7.0.1",
@@ -3707,6 +4064,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -4042,6 +4406,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
@@ -4189,6 +4563,23 @@
         }
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -4289,6 +4680,28 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -4299,6 +4712,39 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/gopd": {
@@ -4422,6 +4868,13 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -4472,6 +4925,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -4568,6 +5031,22 @@
         "node": ">=20.19.5"
       }
     },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -4577,6 +5056,35 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/js-beautify": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+      "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^1.0.4",
+        "glob": "^10.4.2",
+        "js-cookie": "^3.0.5",
+        "nopt": "^7.2.1"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -4913,6 +5421,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
@@ -5012,6 +5530,22 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nopt": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -5127,6 +5661,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/ohash": {
@@ -5250,6 +5798,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parse5": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
@@ -5306,6 +5861,30 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -5596,6 +6175,13 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -5879,6 +6465,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/sirv": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
@@ -5910,6 +6516,124 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/sucrase": {
@@ -6092,6 +6816,23 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6135,6 +6876,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -6682,6 +7433,109 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
@@ -6719,6 +7573,13 @@
         "chart.js": "^4.1.1",
         "vue": "^3.0.0-0 || ^2.7.0"
       }
+    },
+    "node_modules/vue-component-type-helpers": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.3.7.tgz",
+      "integrity": "sha512-Skkhw9agYSgsWqv7bxSOGJZa9SaiJbZVGdXuFWnrzKaQYHnw9qbjD630rw6RyMqDbp54nfLCLw5SZA55if7JLg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vue-eslint-parser": {
       "version": "10.4.0",
@@ -6945,6 +7806,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -6953,6 +7831,104 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wsl-utils": {

--- a/frontend/vuejs/package.json
+++ b/frontend/vuejs/package.json
@@ -9,6 +9,8 @@
     "preview": "vite preview",
     "build-only": "vite build",
     "type-check": "vue-tsc --build",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "run-s lint:*",
     "lint:oxlint": "oxlint . --fix",
     "lint:eslint": "eslint . --fix --cache",
@@ -48,6 +50,7 @@
     "@types/uuid": "^10.0.0",
     "@vitejs/plugin-vue": "^6.0.4",
     "@vue/eslint-config-typescript": "^14.7.0",
+    "@vue/test-utils": "^2.4.11",
     "@vue/tsconfig": "^0.8.1",
     "autoprefixer": "^10.4.17",
     "eslint": "^10.0.2",
@@ -62,6 +65,7 @@
     "typescript": "~5.9.3",
     "vite": "^7.3.1",
     "vite-plugin-vue-devtools": "^8.0.6",
+    "vitest": "^4.1.10",
     "vue-tsc": "^3.2.5"
   },
   "engines": {

--- a/frontend/vuejs/src/apps/payments/stores/__tests__/payments.spec.ts
+++ b/frontend/vuejs/src/apps/payments/stores/__tests__/payments.spec.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+// The store instantiates `new PaymentService()` at module load, so the mock
+// class must hand back a shared object whose methods we can drive per-test.
+const service = vi.hoisted(() => ({
+  getBalance: vi.fn(),
+  getTransactions: vi.fn(),
+  getPaymentMethods: vi.fn(),
+  setupCustomer: vi.fn(),
+  attachPaymentMethod: vi.fn(),
+  createPaymentIntent: vi.fn(),
+  processPayment: vi.fn(),
+  confirmPayment: vi.fn(),
+  verifyPayment: vi.fn(),
+  getPlans: vi.fn(),
+  getPackages: vi.fn(),
+  createCheckoutSession: vi.fn(),
+  getSessionStatus: vi.fn(),
+  checkCredits: vi.fn(),
+  deductCredits: vi.fn(),
+}))
+vi.mock('../../services/payment_service', () => ({
+  // Returning an object from the constructor makes `new PaymentService()`
+  // resolve to our shared mock.
+  default: class {
+    constructor() {
+      return service
+    }
+  },
+}))
+
+import { usePaymentStore } from '@/apps/payments/stores/payments'
+
+describe('payments store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    Object.values(service).forEach((fn) => fn.mockReset())
+  })
+
+  describe('fetchBalance', () => {
+    it('stores the balance and keeps userCredits in sync', async () => {
+      service.getBalance.mockResolvedValue({ balance: 75 })
+      const store = usePaymentStore()
+      const result = await store.fetchBalance()
+
+      expect(result).toBe(75)
+      expect(store.balance).toBe(75)
+      expect(store.userCredits).toBe(75)
+      expect(store.lastUpdated).not.toBeNull()
+      expect(store.isLoadingBalance).toBe(false)
+    })
+
+    it('records an error for a malformed response', async () => {
+      service.getBalance.mockResolvedValue({ nope: true })
+      const store = usePaymentStore()
+      const result = await store.fetchBalance()
+
+      expect(result).toBeNull()
+      expect(store.error).toBe('Invalid balance response format')
+    })
+
+    it('captures thrown errors', async () => {
+      service.getBalance.mockRejectedValue(new Error('network down'))
+      const store = usePaymentStore()
+      const result = await store.fetchBalance()
+
+      expect(result).toBeNull()
+      expect(store.error).toBe('network down')
+      expect(store.isLoadingBalance).toBe(false)
+    })
+  })
+
+  describe('fetchTransactions', () => {
+    it('stores transactions and total count', async () => {
+      service.getTransactions.mockResolvedValue({
+        transactions: [{ id: 1 }, { id: 2 }],
+        total_count: 2,
+      })
+      const store = usePaymentStore()
+      await store.fetchTransactions()
+
+      expect(store.transactions).toHaveLength(2)
+      expect(store.totalTransactions).toBe(2)
+    })
+  })
+
+  describe('fetchPaymentMethods + computed', () => {
+    it('populates methods and derives hasPaymentMethods / defaultPaymentMethod', async () => {
+      const methods = [
+        { id: 'pm_1', is_default: false },
+        { id: 'pm_2', is_default: true },
+      ]
+      service.getPaymentMethods.mockResolvedValue(methods)
+      const store = usePaymentStore()
+
+      expect(store.hasPaymentMethods).toBe(false)
+      await store.fetchPaymentMethods()
+
+      expect(store.hasPaymentMethods).toBe(true)
+      expect(store.defaultPaymentMethod).toEqual({ id: 'pm_2', is_default: true })
+    })
+
+    it('falls back to the first method when none is marked default', async () => {
+      service.getPaymentMethods.mockResolvedValue([
+        { id: 'pm_1', is_default: false },
+        { id: 'pm_2', is_default: false },
+      ])
+      const store = usePaymentStore()
+      await store.fetchPaymentMethods()
+      expect(store.defaultPaymentMethod).toEqual({ id: 'pm_1', is_default: false })
+    })
+  })
+
+  describe('processPayment', () => {
+    it('updates the balance from the new_balance field on success', async () => {
+      service.processPayment.mockResolvedValue({ success: true, new_balance: 120 })
+      const store = usePaymentStore()
+      const result = await store.processPayment({ amount: 20, paymentMethodId: 'pm_1' })
+
+      expect(result.success).toBe(true)
+      expect(store.balance).toBe(120)
+      expect(store.userCredits).toBe(120)
+      expect(store.isProcessingPayment).toBe(false)
+    })
+
+    it('propagates errors and resets the processing flag', async () => {
+      service.processPayment.mockRejectedValue(new Error('card declined'))
+      const store = usePaymentStore()
+      await expect(
+        store.processPayment({ amount: 20, paymentMethodId: 'pm_1' }),
+      ).rejects.toThrow('card declined')
+      expect(store.error).toBe('card declined')
+      expect(store.isProcessingPayment).toBe(false)
+    })
+  })
+
+  describe('deductCredits', () => {
+    it('updates the balance when the service returns newBalance', async () => {
+      service.deductCredits.mockResolvedValue({ success: true, newBalance: 8 })
+      const store = usePaymentStore()
+      const result = await store.deductCredits(2, 'model run')
+
+      expect(result.newBalance).toBe(8)
+      expect(store.balance).toBe(8)
+    })
+  })
+
+  describe('getSessionStatus', () => {
+    it('refreshes the balance when a session completes', async () => {
+      service.getSessionStatus.mockResolvedValue({ status: 'complete' })
+      service.getBalance.mockResolvedValue({ balance: 200 })
+      const store = usePaymentStore()
+      await store.getSessionStatus('cs_123')
+      expect(service.getBalance).toHaveBeenCalled()
+      expect(store.balance).toBe(200)
+    })
+  })
+
+  describe('resetState', () => {
+    it('clears all state back to defaults', async () => {
+      service.getBalance.mockResolvedValue({ balance: 50 })
+      const store = usePaymentStore()
+      await store.fetchBalance()
+      expect(store.balance).toBe(50)
+
+      store.resetState()
+      expect(store.balance).toBeNull()
+      expect(store.userCredits).toBeNull()
+      expect(store.transactions).toEqual([])
+      expect(store.error).toBeNull()
+    })
+  })
+})

--- a/frontend/vuejs/src/apps/products/imagi/stores/__tests__/projectStore.spec.ts
+++ b/frontend/vuejs/src/apps/products/imagi/stores/__tests__/projectStore.spec.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+
+// Mock the API client (pulled in transitively via the auth store).
+const apiMock = vi.hoisted(() => ({ get: vi.fn(), post: vi.fn() }))
+vi.mock('@/shared/services/api', () => ({
+  default: apiMock,
+  getCsrfToken: vi.fn(),
+}))
+
+// Mock the project service (all static methods).
+const projectService = vi.hoisted(() => ({
+  getProjects: vi.fn(),
+  getProject: vi.fn(),
+  createProject: vi.fn(),
+  updateProject: vi.fn(),
+  deleteProject: vi.fn(),
+  initializeProject: vi.fn(),
+  getActivities: vi.fn(),
+  getStats: vi.fn(),
+  clearProjectsCache: vi.fn(),
+}))
+vi.mock('../../services/projectService', () => ({
+  ProjectService: projectService,
+}))
+
+import { useProjectStore } from '@/apps/products/imagi/stores/projectStore'
+
+describe('project store', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    setActivePinia(createPinia())
+    Object.values(projectService).forEach((fn) => fn.mockReset())
+  })
+
+  describe('updateProjects', () => {
+    it('normalizes projects and indexes them by id', () => {
+      const store = useProjectStore()
+      store.updateProjects([
+        { id: 1, name: 'Alpha' },
+        { id: 2, name: 'Beta' },
+        null,
+        'garbage',
+      ])
+
+      expect(store.projects).toHaveLength(2)
+      expect(store.hasProjects).toBe(true)
+      expect(store.getProjectById('1')?.name).toBe('Alpha')
+      // normalizeProject coerces ids to strings.
+      expect(store.projects[0].id).toBe('1')
+    })
+  })
+
+  describe('slug getters', () => {
+    it('finds a project by its URL slug', () => {
+      const store = useProjectStore()
+      store.updateProjects([{ id: 1, name: 'My Cool App' }])
+      expect(store.getProjectBySlug('my-cool-app')?.name).toBe('My Cool App')
+      expect(store.getProjectBySlug('nope')).toBeUndefined()
+    })
+
+    it('derives a slug for a project', () => {
+      const store = useProjectStore()
+      expect(store.getSlugForProject({ name: 'Some Thing' } as any)).toBe('some-thing')
+    })
+  })
+
+  describe('sortedProjects', () => {
+    it('orders projects newest-first by created_at', () => {
+      const store = useProjectStore()
+      store.updateProjects([
+        { id: 1, name: 'Older', created_at: '2024-01-01T00:00:00Z' },
+        { id: 2, name: 'Newer', created_at: '2024-06-01T00:00:00Z' },
+      ])
+      expect(store.sortedProjects.map((p) => p.name)).toEqual(['Newer', 'Older'])
+    })
+  })
+
+  describe('setAuthenticated', () => {
+    it('clears projects when logging out', () => {
+      const store = useProjectStore()
+      store.setAuthenticated(true)
+      store.updateProjects([{ id: 1, name: 'Alpha' }])
+      expect(store.projects).toHaveLength(1)
+
+      store.setAuthenticated(false)
+      expect(store.projects).toHaveLength(0)
+      expect(store.initialized).toBe(false)
+    })
+  })
+
+  describe('createProject', () => {
+    it('throws when the user is not authenticated', async () => {
+      const store = useProjectStore()
+      store.setAuthenticated(false)
+      await expect(
+        store.createProject({ name: 'X', description: '' }),
+      ).rejects.toThrow('You must be logged in')
+    })
+
+    it('adds the created project to local state', async () => {
+      projectService.createProject.mockResolvedValue({
+        id: 99,
+        name: 'Fresh Project',
+        description: 'desc',
+      })
+      projectService.initializeProject.mockResolvedValue({ success: true })
+
+      const store = useProjectStore()
+      store.setAuthenticated(true)
+      const created = await store.createProject({
+        name: 'Fresh Project',
+        description: 'desc',
+      })
+
+      expect(created.id).toBe('99')
+      expect(store.getProjectById('99')?.name).toBe('Fresh Project')
+      expect(projectService.createProject).toHaveBeenCalled()
+    })
+  })
+
+  describe('deleteProject', () => {
+    it('requires authentication', async () => {
+      const store = useProjectStore()
+      store.setAuthenticated(false)
+      await expect(store.deleteProject('1')).rejects.toThrow('You must be logged in')
+    })
+
+    it('optimistically removes the project and records the deletion', async () => {
+      projectService.deleteProject.mockResolvedValue(undefined)
+      const store = useProjectStore()
+      store.setAuthenticated(true)
+      store.updateProjects([
+        { id: 1, name: 'Keep' },
+        { id: 2, name: 'Remove' },
+      ])
+
+      await store.deleteProject('2')
+
+      expect(store.getProjectById('2')).toBeUndefined()
+      expect(store.projects.map((p) => p.name)).toEqual(['Keep'])
+      const deleted = JSON.parse(localStorage.getItem('deletedProjects') || '[]')
+      expect(deleted).toContain('2')
+      expect(projectService.deleteProject).toHaveBeenCalledWith('2')
+    })
+
+    it('treats a 404 from the server as success', async () => {
+      const err: any = new Error('not found')
+      err.response = { status: 404 }
+      projectService.deleteProject.mockRejectedValue(err)
+      const store = useProjectStore()
+      store.setAuthenticated(true)
+      store.updateProjects([{ id: 5, name: 'Ghost' }])
+
+      await expect(store.deleteProject('5')).resolves.toBeUndefined()
+      expect(store.getProjectById('5')).toBeUndefined()
+    })
+  })
+
+  describe('fetchProjects', () => {
+    it('skips fetching when not authenticated', async () => {
+      const store = useProjectStore()
+      store.setAuthenticated(false)
+      const result = await store.fetchProjects()
+      expect(result).toEqual([])
+      expect(projectService.getProjects).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/vuejs/src/apps/products/imagi/types/__tests__/normalizeProject.spec.ts
+++ b/frontend/vuejs/src/apps/products/imagi/types/__tests__/normalizeProject.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeProject } from '../components'
+
+describe('normalizeProject', () => {
+  it('returns an empty object for falsy input', () => {
+    expect(normalizeProject(null)).toEqual({})
+  })
+
+  it('coerces the id to a string', () => {
+    expect(normalizeProject({ id: 42, name: 'X' }).id).toBe('42')
+  })
+
+  it('generates an id when none is provided', () => {
+    const project = normalizeProject({ name: 'No Id' })
+    expect(typeof project.id).toBe('string')
+    expect(project.id.length).toBeGreaterThan(0)
+  })
+
+  it('applies sensible defaults', () => {
+    const project = normalizeProject({ id: 1 })
+    expect(project.name).toBe('Untitled Project')
+    expect(project.description).toBe('')
+    expect(project.is_active).toBe(true)
+    expect(project.is_initialized).toBe(false)
+    expect(project.generation_status).toBe('pending')
+    expect(project.files).toEqual([])
+  })
+
+  it('trims name and description', () => {
+    const project = normalizeProject({ id: 1, name: '  Spaced  ', description: '  hi  ' })
+    expect(project.name).toBe('Spaced')
+    expect(project.description).toBe('hi')
+  })
+
+  it('maps camelCase timestamps to snake_case fields', () => {
+    const project = normalizeProject({
+      id: 1,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-02-01T00:00:00Z',
+    })
+    expect(project.created_at).toBe('2024-01-01T00:00:00Z')
+    expect(project.updated_at).toBe('2024-02-01T00:00:00Z')
+  })
+})

--- a/frontend/vuejs/src/apps/products/imagi/utils/__tests__/slug.spec.ts
+++ b/frontend/vuejs/src/apps/products/imagi/utils/__tests__/slug.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { toSlug, matchesSlug, getProjectSlug } from '../slug'
+
+describe('toSlug', () => {
+  it('lowercases and hyphenates spaces', () => {
+    expect(toSlug('My Cool App')).toBe('my-cool-app')
+  })
+
+  it('replaces underscores with hyphens', () => {
+    expect(toSlug('my_cool_app')).toBe('my-cool-app')
+  })
+
+  it('strips special characters', () => {
+    expect(toSlug('Hello, World! @2024')).toBe('hello-world-2024')
+  })
+
+  it('collapses multiple separators into one hyphen', () => {
+    expect(toSlug('a   b___c')).toBe('a-b-c')
+  })
+
+  it('trims leading and trailing hyphens', () => {
+    expect(toSlug('  --Edge--  ')).toBe('edge')
+  })
+})
+
+describe('matchesSlug', () => {
+  it('matches a name against its slug case-insensitively', () => {
+    expect(matchesSlug('My Cool App', 'my-cool-app')).toBe(true)
+    expect(matchesSlug('My Cool App', 'MY-COOL-APP')).toBe(true)
+  })
+
+  it('does not match unrelated slugs', () => {
+    expect(matchesSlug('My Cool App', 'other-app')).toBe(false)
+  })
+})
+
+describe('getProjectSlug', () => {
+  it('returns the slug for a project object', () => {
+    expect(getProjectSlug({ name: 'Test Project' })).toBe('test-project')
+  })
+})

--- a/frontend/vuejs/src/shared/stores/__tests__/auth.spec.ts
+++ b/frontend/vuejs/src/shared/stores/__tests__/auth.spec.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import axios from 'axios'
+import type { User } from '@/apps/auth/types/auth'
+
+// Mock the shared API client so no real network calls happen.
+const apiMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  post: vi.fn(),
+}))
+vi.mock('@/shared/services/api', () => ({
+  default: apiMock,
+  getCsrfToken: vi.fn(),
+}))
+
+import { useAuthStore } from '@/shared/stores/auth'
+
+const sampleUser: User = {
+  id: 1,
+  username: 'alice',
+  email: 'alice@example.com',
+  name: 'Alice',
+  balance: 42,
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+}
+
+describe('auth store', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    delete axios.defaults.headers.common['Authorization']
+    setActivePinia(createPinia())
+    apiMock.get.mockReset()
+    apiMock.post.mockReset()
+  })
+
+  describe('setAuthState', () => {
+    it('persists token and user and sets the axios auth header', () => {
+      const store = useAuthStore()
+      store.setAuthState(sampleUser, 'tok-123')
+
+      expect(store.isAuthenticated).toBe(true)
+      expect(store.token).toBe('tok-123')
+      expect(store.currentUser).toEqual(sampleUser)
+      expect(axios.defaults.headers.common['Authorization']).toBe('Token tok-123')
+
+      // Token stored with an expiry envelope; user stored as JSON.
+      const storedToken = JSON.parse(localStorage.getItem('token') as string)
+      expect(storedToken.value).toBe('tok-123')
+      expect(storedToken.expires).toBeGreaterThan(Date.now())
+      expect(JSON.parse(localStorage.getItem('user') as string)).toEqual(sampleUser)
+    })
+
+    it('clears stored auth when called with nulls', () => {
+      const store = useAuthStore()
+      store.setAuthState(sampleUser, 'tok-123')
+      store.setAuthState(null, null)
+
+      expect(store.isAuthenticated).toBe(false)
+      expect(localStorage.getItem('token')).toBeNull()
+      expect(localStorage.getItem('user')).toBeNull()
+      expect(axios.defaults.headers.common['Authorization']).toBeUndefined()
+    })
+  })
+
+  describe('getters', () => {
+    it('exposes the current user and balance', () => {
+      const store = useAuthStore()
+      store.setAuthState(sampleUser, 'tok-123')
+      expect(store.currentUser).toEqual(sampleUser)
+      expect(store.userBalance).toBe(42)
+    })
+
+    it('defaults balance to 0 when no user', () => {
+      const store = useAuthStore()
+      expect(store.userBalance).toBe(0)
+    })
+  })
+
+  describe('clearAuth / logout', () => {
+    it('resets all auth state', async () => {
+      const store = useAuthStore()
+      store.setAuthState(sampleUser, 'tok-123')
+      await store.clearAuth()
+
+      expect(store.token).toBeNull()
+      expect(store.user).toBeNull()
+      expect(store.isAuthenticated).toBe(false)
+      expect(localStorage.getItem('token')).toBeNull()
+    })
+
+    it('logout delegates to clearAuth', async () => {
+      const store = useAuthStore()
+      store.setAuthState(sampleUser, 'tok-123')
+      await store.logout()
+      expect(store.isAuthenticated).toBe(false)
+    })
+  })
+
+  describe('stored token hydration', () => {
+    it('restores a valid non-expired token on creation', () => {
+      localStorage.setItem(
+        'token',
+        JSON.stringify({ value: 'stored-tok', expires: Date.now() + 100000 }),
+      )
+      localStorage.setItem('user', JSON.stringify(sampleUser))
+      const store = useAuthStore()
+      expect(store.token).toBe('stored-tok')
+      expect(store.isAuthenticated).toBe(true)
+    })
+
+    it('ignores an expired token on creation', () => {
+      localStorage.setItem(
+        'token',
+        JSON.stringify({ value: 'old-tok', expires: Date.now() - 1000 }),
+      )
+      const store = useAuthStore()
+      expect(store.token).toBeNull()
+      expect(store.isAuthenticated).toBe(false)
+    })
+  })
+
+  describe('initAuth', () => {
+    it('validates a stored token against the server', async () => {
+      localStorage.setItem(
+        'token',
+        JSON.stringify({ value: 'stored-tok', expires: Date.now() + 100000 }),
+      )
+      apiMock.get.mockResolvedValue({
+        data: { isAuthenticated: true, user: sampleUser },
+      })
+
+      const store = useAuthStore()
+      const result = await store.initAuth()
+
+      expect(result).toBe(true)
+      expect(apiMock.get).toHaveBeenCalledWith('/v1/auth/init/')
+      expect(store.currentUser).toEqual(sampleUser)
+      expect(store.isAuthenticated).toBe(true)
+    })
+
+    it('returns false when there is no stored token', async () => {
+      const store = useAuthStore()
+      const result = await store.initAuth()
+      expect(result).toBe(false)
+      expect(store.isAuthenticated).toBe(false)
+    })
+  })
+})

--- a/frontend/vuejs/vitest.config.ts
+++ b/frontend/vuejs/vitest.config.ts
@@ -1,0 +1,22 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+  test: {
+    // jsdom gives us window/localStorage/document for store + component tests.
+    environment: 'jsdom',
+    globals: true,
+    // Only pick up co-located test files under __tests__ (already excluded
+    // from the app tsconfig so they never affect type-check / build).
+    include: ['src/**/__tests__/**/*.{test,spec}.{ts,js}'],
+    clearMocks: true,
+    restoreMocks: true,
+  },
+})


### PR DESCRIPTION
Backend (Django, `manage.py test`):
- Auth: RegisterSerializer/UserSerializer validation and the signin,
  register, logout, init and user-update endpoints (20 tests).
- Payments: models, credit/transaction/payment-method services, and API
  endpoints with Stripe mocked out (33 tests).
- ProjectManager: Project model (slug/path/validation/soft-vs-hard delete),
  create serializer, management service, and the REST API with the heavy
  filesystem/subprocess work mocked (20 tests). Replaces the outdated
  end-to-end create test that asserted directories the service now cleans up
  and wrote into the repo via npm/django scaffolding.

Frontend (Vue 3, Vitest):
- Wire up Vitest (jsdom) with a config and `test`/`test:watch` scripts;
  tests live in `__tests__` dirs already excluded from type-check/build.
- Auth store: setAuthState/clearAuth, getters, token hydration/expiry, initAuth.
- Payments store: fetchBalance, processPayment, deductCredits, computed
  payment-method getters, resetState (PaymentService mocked).
- Projects store: updateProjects normalization, slug getters, sortedProjects,
  auth gating, optimistic create/delete (ProjectService mocked); plus slug and
  normalizeProject utilities.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013J43v8vmtgC5m1WXvYooNE