### PR TITLE
Modernize the build-mode agent harness with Claude Code / Codex patterns

### DIFF
--- a/backend/django/apps/Products/Imagi/Agents/api/views.py
+++ b/backend/django/apps/Products/Imagi/Agents/api/views.py
@@ -240,6 +240,8 @@ def agent(request):
             'conversation_id': result.get('conversation_id'),
             'response': result.get('response', ''),
             'files_changed': result.get('files_changed', []),
+            'tool_calls': result.get('tool_calls', []),
+            'plan': result.get('plan', []),
             'single_message': result.get('single_message', True),
         }
 

--- a/backend/django/apps/Products/Imagi/Agents/services/__init__.py
+++ b/backend/django/apps/Products/Imagi/Agents/services/__init__.py
@@ -2,9 +2,16 @@
 Agents services module - OpenAI Agents SDK.
 """
 
-from .base_agent import ImagiAgentService, get_agent_service, AgentContext, DEFAULT_MODEL
+from .base_agent import (
+    ImagiAgentService,
+    get_agent_service,
+    AgentContext,
+    DEFAULT_MODEL,
+    compact_history,
+    extract_run_metadata,
+)
 from .chat_agent import create_chat_agent, create_simple_chat_agent
-from .coding_agent import create_coding_agent
+from .coding_agent import create_coding_agent, load_project_memory
 
 
 __all__ = [
@@ -12,7 +19,10 @@ __all__ = [
     'get_agent_service',
     'AgentContext',
     'DEFAULT_MODEL',
+    'compact_history',
+    'extract_run_metadata',
     'create_chat_agent',
     'create_simple_chat_agent',
     'create_coding_agent',
+    'load_project_memory',
 ]

--- a/backend/django/apps/Products/Imagi/Agents/services/base_agent.py
+++ b/backend/django/apps/Products/Imagi/Agents/services/base_agent.py
@@ -1,15 +1,17 @@
 """
 Base Agent Service using OpenAI Agents SDK.
 
-This module provides the main orchestrator agent for the Imagi workspace.
-It manages handoffs to specialized sub-agents based on the user's request.
+This module provides the agent harness for the Imagi workspace: it owns
+conversation persistence, context construction (including automatic history
+compaction), the agent run loop, and extraction of structured run metadata
+(plan, tool calls, changed files) for the workspace UI.
 """
 
 import json
 import os
 import logging
 from typing import Optional, Dict, Any, List
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from dotenv import load_dotenv
 
 from agents import Agent, Runner, handoff, RunConfig
@@ -43,6 +45,19 @@ OPENAI_API_KEY = os.getenv('OPENAI_KEY') or getattr(settings, 'OPENAI_KEY', None
 # Default model for agents
 DEFAULT_MODEL = "gpt-5.6-sol"
 
+# Upper bound on agent-loop iterations for a single request. Chat mode has no
+# tools so it resolves in one turn; agent mode gets room for plan → search →
+# read → edit → verify cycles without letting a confused run spin forever.
+MAX_CHAT_TURNS = 6
+MAX_AGENT_TURNS = 30
+
+# Character budget for conversation history sent to the model. When exceeded,
+# older messages are compacted into a short summary (auto-compaction, like
+# Claude Code) so long-running conversations keep working instead of growing
+# without bound.
+HISTORY_MAX_CHARS = 60_000
+COMPACTED_SNIPPET_CHARS = 120
+
 
 def build_model_settings(reasoning_effort: Optional[str] = None):
     """
@@ -62,6 +77,81 @@ def build_model_settings(reasoning_effort: Optional[str] = None):
     return ModelSettings()
 
 
+def compact_history(messages: List[Dict[str, str]], max_chars: int = HISTORY_MAX_CHARS) -> List[Dict[str, str]]:
+    """Compact a conversation history to fit within a character budget.
+
+    Keeps the most recent messages verbatim and replaces older ones with a
+    single summary message listing what was discussed, so the model retains
+    a thread of the conversation without the full text.
+    """
+    total = sum(len(m.get("content") or "") for m in messages)
+    if total <= max_chars:
+        return messages
+
+    # Walk backwards keeping recent messages until the budget is half-spent;
+    # the rest of the budget stays available for the summary + new input.
+    kept: List[Dict[str, str]] = []
+    budget = max_chars // 2
+    used = 0
+    for msg in reversed(messages):
+        size = len(msg.get("content") or "")
+        if kept and used + size > budget:
+            break
+        kept.append(msg)
+        used += size
+    kept.reverse()
+
+    dropped = messages[:len(messages) - len(kept)]
+    if not dropped:
+        return kept
+
+    lines = []
+    for msg in dropped:
+        first_line = (msg.get("content") or "").strip().splitlines()
+        snippet = first_line[0][:COMPACTED_SNIPPET_CHARS] if first_line else ""
+        lines.append(f"- {msg.get('role', 'user')}: {snippet}")
+
+    summary = (
+        f"[Conversation compacted: {len(dropped)} earlier messages were summarized "
+        "to fit the context window. One-line summaries of the omitted messages:]\n"
+        + "\n".join(lines)
+    )
+    return [{"role": "user", "content": summary}] + kept
+
+
+def extract_run_metadata(result) -> Dict[str, Any]:
+    """Extract structured metadata from an Agents SDK run result.
+
+    Returns the names of tools the agent called and the project files it
+    changed, so the API can surface the agent's activity to the workspace UI
+    (the way Claude Code shows its tool transcript).
+    """
+    tool_calls: List[str] = []
+    files_changed: List[str] = []
+
+    for item in getattr(result, 'new_items', []) or []:
+        item_type = getattr(item, 'type', '')
+
+        if item_type == 'tool_call_item':
+            raw = getattr(item, 'raw_item', None)
+            name = getattr(raw, 'name', None)
+            if name:
+                tool_calls.append(name)
+
+        # 'function_call_output' kept as a fallback for older SDK versions
+        elif item_type in ('tool_call_output_item', 'function_call_output'):
+            output = getattr(item, 'output', None)
+            try:
+                parsed = json.loads(output) if isinstance(output, str) else output
+                if isinstance(parsed, dict) and parsed.get("success") and parsed.get("path"):
+                    if parsed["path"] not in files_changed:
+                        files_changed.append(parsed["path"])
+            except (json.JSONDecodeError, TypeError, AttributeError):
+                pass
+
+    return {"tool_calls": tool_calls, "files_changed": files_changed}
+
+
 @dataclass
 class AgentContext:
     """Context object passed to all agents during a run."""
@@ -69,21 +159,24 @@ class AgentContext:
     project_id: Optional[int] = None
     project_name: Optional[str] = None
     project_description: Optional[str] = None
+    project_path: Optional[str] = None
     conversation_id: Optional[int] = None
     current_file: Optional[Dict[str, Any]] = None
     mode: str = "chat"
+    # Working plan maintained by the agent via the update_plan tool
+    plan: List[Dict[str, str]] = field(default_factory=list)
 
 
 class ImagiAgentService:
     """
     Main agent service for the Imagi workspace using OpenAI Agents SDK.
-    
+
     This service handles:
     - Agent orchestration and handoffs
     - Conversation persistence
     - Integration with Django models
     """
-    
+
     def __init__(self, model: str = DEFAULT_MODEL, reasoning_effort: Optional[str] = None):
         """
         Initialize the agent service.
@@ -98,14 +191,14 @@ class ImagiAgentService:
         self._chat_agent = None
         self._coding_agent = None
         self._orchestrator_agent = None
-        
+
         # Verify API key is available
         if not OPENAI_API_KEY:
             logger.warning("OpenAI API key not found - agent features may not work properly")
         else:
             # Set environment variable for the agents SDK
             os.environ['OPENAI_API_KEY'] = OPENAI_API_KEY
-    
+
     def _apply_reasoning_effort(self, reasoning_effort: Optional[str]) -> None:
         """Update the reasoning effort, invalidating cached agents if it changed."""
         if reasoning_effort is not None and reasoning_effort != self.reasoning_effort:
@@ -129,29 +222,29 @@ class ImagiAgentService:
             from .chat_agent import create_chat_agent
             self._chat_agent = create_chat_agent(self.model, self.reasoning_effort)
         return self._chat_agent
-    
+
     @property
     def orchestrator_agent(self) -> Agent:
         """
         Get or create the main orchestrator agent.
-        
+
         The orchestrator can hand off to specialized sub-agents.
         """
         if self._orchestrator_agent is None:
             self._orchestrator_agent = self._create_orchestrator_agent()
         return self._orchestrator_agent
-    
+
     def _create_orchestrator_agent(self) -> Agent:
         """Create the main orchestrator agent with handoffs."""
         instructions = f"""{RECOMMENDED_PROMPT_PREFIX}
 
-You are Imagi, an AI-powered web development assistant. You help users build, 
+You are Imagi, an AI-powered web development assistant. You help users build,
 understand, and improve their web applications.
 
 Your capabilities include:
 1. **Chat Mode**: Have natural conversations about web development, explain concepts,
    answer questions, and provide guidance on best practices.
-2. **Build Mode** (coming soon): Generate and modify code for Vue.js components, 
+2. **Build Mode** (coming soon): Generate and modify code for Vue.js components,
    Django templates, and other web development artifacts.
 
 Current Behavior:
@@ -167,7 +260,7 @@ Technology Stack:
 - State management: Pinia
 - HTTP client: Axios
 """
-        
+
         from apps.Products.Imagi.Builder.services.models_service import get_backend_model_id
         backend_model = get_backend_model_id(self.model)
         kwargs = {}
@@ -187,11 +280,11 @@ Technology Stack:
             ],
             **kwargs
         )
-    
+
     # -------------------------------------------------------------------------
     # Conversation Management
     # -------------------------------------------------------------------------
-    
+
     def get_conversation(self, conversation_id: int, user) -> Optional[AgentConversation]:
         """Get an existing conversation by ID."""
         try:
@@ -199,7 +292,7 @@ Technology Stack:
         except Exception as e:
             logger.error(f"Error getting conversation {conversation_id}: {str(e)}")
             return None
-    
+
     def create_conversation(
         self,
         user,
@@ -219,15 +312,15 @@ Technology Stack:
             mode=mode,
             title=title,
         )
-        
+
         prompt_content = system_prompt or CHAT_AGENT_INSTRUCTIONS
         SystemPrompt.objects.create(
             conversation=conversation,
             content=prompt_content
         )
-        
+
         return conversation
-    
+
     def add_user_message(self, conversation: AgentConversation, content: str) -> AgentMessage:
         """Add a user message to the conversation."""
         message = AgentMessage.objects.create(
@@ -241,7 +334,7 @@ Technology Stack:
         else:
             conversation.save(update_fields=["updated_at"])
         return message
-    
+
     def add_assistant_message(self, conversation: AgentConversation, content: str) -> AgentMessage:
         """Add an assistant message to the conversation."""
         return AgentMessage.objects.create(
@@ -249,48 +342,147 @@ Technology Stack:
             role="assistant",
             content=content
         )
-    
+
     def build_conversation_history(self, conversation: AgentConversation) -> List[Dict[str, str]]:
-        """Build conversation history for the agent."""
+        """Build conversation history for the agent, compacting when long."""
         messages = []
-        
+
         history_messages = AgentMessage.objects.filter(
             conversation=conversation
         ).order_by('created_at')
-        
+
         for msg in history_messages:
             messages.append({
                 "role": msg.role,
                 "content": msg.content
             })
-        
-        return messages
-    
+
+        return compact_history(messages)
+
     def get_project_info(self, project_id: Optional[int], user) -> Dict[str, Any]:
         """Get project information."""
         project_info = {
             "project_id": project_id,
             "project_name": None,
             "project_description": None,
+            "project_path": None,
         }
-        
+
         if not project_id:
             return project_info
-        
+
         try:
             from apps.Products.Imagi.ProjectManager.models import Project
             project = Project.objects.get(id=project_id, user=user)
             project_info["project_name"] = project.name
             project_info["project_description"] = getattr(project, 'description', None)
+            project_info["project_path"] = getattr(project, 'project_path', None)
         except Exception as e:
             logger.warning(f"Could not get project info: {e}")
-        
+
         return project_info
-    
+
     # -------------------------------------------------------------------------
-    # Main Chat Processing
+    # Main Processing
     # -------------------------------------------------------------------------
-    
+
+    def _run(
+        self,
+        agent: Agent,
+        mode: str,
+        workflow_name: str,
+        max_turns: int,
+        user_input: str,
+        user,
+        model: Optional[str] = None,
+        project_id: Optional[int] = None,
+        current_file: Optional[Dict[str, Any]] = None,
+        conversation_id: Optional[int] = None,
+        reasoning_effort: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Shared harness core: persist the message, build context and history,
+        run the agent, and persist + return the structured result."""
+        conversation = None
+        try:
+            if not user_input:
+                return {"success": False, "error": "Message is required"}
+
+            model = model or self.model
+            self._apply_reasoning_effort(reasoning_effort)
+
+            # Get or create conversation
+            if conversation_id:
+                conversation = self.get_conversation(conversation_id, user)
+            if conversation is None:
+                conversation = self.create_conversation(
+                    user, model, project_id=project_id, mode=mode
+                )
+
+            # Add user message to conversation
+            self.add_user_message(conversation, user_input)
+
+            # Get project info
+            project_info = self.get_project_info(project_id, user)
+
+            # Build context for the agent
+            context = AgentContext(
+                user_id=user.id,
+                project_id=project_id,
+                project_name=project_info["project_name"],
+                project_description=project_info["project_description"],
+                project_path=project_info["project_path"],
+                conversation_id=conversation.id,
+                current_file=current_file,
+                mode=mode,
+            )
+
+            # Build (compacted) conversation history, excluding the message we
+            # just persisted — it is appended as the current input below.
+            conversation_history = self.build_conversation_history(conversation)
+            if conversation_history and conversation_history[-1]["role"] == "user" \
+                    and conversation_history[-1]["content"] == user_input:
+                conversation_history = conversation_history[:-1]
+
+            input_messages = list(conversation_history)
+            input_messages.append({"role": "user", "content": user_input})
+
+            result = Runner.run_sync(
+                agent,
+                input=input_messages,
+                context=context,
+                max_turns=max_turns,
+                run_config=RunConfig(
+                    workflow_name=workflow_name,
+                    trace_metadata={"user_id": str(user.id)}
+                )
+            )
+
+            response_content = result.final_output or ""
+            metadata = extract_run_metadata(result)
+
+            # Add assistant message to conversation
+            self.add_assistant_message(conversation, response_content)
+
+            return {
+                "success": True,
+                "response": response_content,
+                "conversation_id": conversation.id,
+                "files_changed": metadata["files_changed"],
+                "tool_calls": metadata["tool_calls"],
+                "plan": context.plan,
+                "single_message": True,
+            }
+
+        except Exception as e:
+            logger.error(f"Error in {workflow_name}: {str(e)}")
+            import traceback
+            logger.error(traceback.format_exc())
+            return {
+                "success": False,
+                "error": str(e),
+                "conversation_id": conversation.id if conversation else None,
+            }
+
     def process_chat(
         self,
         user_input: str,
@@ -302,96 +494,23 @@ Technology Stack:
         reasoning_effort: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
-        Process a chat message using the OpenAI Agents SDK.
+        Process a chat message using the chat agent (no file tools).
 
-        Args:
-            user_input: The user's message
-            user: The Django user object
-            model: The AI model to use (defaults to self.model)
-            project_id: Optional project ID
-            current_file: Optional current file context
-            conversation_id: Optional existing conversation ID
-            reasoning_effort: How much reasoning to use ('low', 'medium', 'high')
-
-        Returns:
-            Dict containing the response and metadata
+        Returns a dict containing the response and metadata.
         """
-        try:
-            # Validate input
-            if not user_input:
-                return {"success": False, "error": "Message is required"}
-
-            model = model or self.model
-            self._apply_reasoning_effort(reasoning_effort)
-            
-            # Get or create conversation
-            if conversation_id:
-                conversation = self.get_conversation(conversation_id, user)
-                if not conversation:
-                    conversation = self.create_conversation(user, model, project_id=project_id)
-            else:
-                conversation = self.create_conversation(user, model, project_id=project_id)
-            
-            # Add user message to conversation
-            self.add_user_message(conversation, user_input)
-            
-            # Get project info
-            project_info = self.get_project_info(project_id, user)
-            
-            # Build context for the agent
-            context = AgentContext(
-                user_id=user.id,
-                project_id=project_id,
-                project_name=project_info["project_name"],
-                project_description=project_info["project_description"],
-                conversation_id=conversation.id,
-                current_file=current_file,
-                mode="chat"
-            )
-            
-            # Build conversation history (excluding the current message we just added)
-            conversation_history = self.build_conversation_history(conversation)
-            if conversation_history and conversation_history[-1]["role"] == "user":
-                conversation_history = conversation_history[:-1]
-            
-            # Build input for the agent
-            input_messages = []
-            if conversation_history:
-                input_messages.extend(conversation_history)
-            input_messages.append({"role": "user", "content": user_input})
-            
-            # Run the chat agent directly (skip orchestrator for now)
-            result = Runner.run_sync(
-                self.chat_agent,
-                input=input_messages,
-                context=context,
-                run_config=RunConfig(
-                    workflow_name="imagi_chat",
-                    trace_metadata={"user_id": str(user.id)}
-                )
-            )
-            
-            response_content = result.final_output or ""
-            
-            # Add assistant message to conversation
-            self.add_assistant_message(conversation, response_content)
-            
-            return {
-                "success": True,
-                "response": response_content,
-                "conversation_id": conversation.id,
-                "single_message": True,
-            }
-            
-        except Exception as e:
-            logger.error(f"Error in process_chat: {str(e)}")
-            import traceback
-            logger.error(traceback.format_exc())
-            return {
-                "success": False,
-                "error": str(e),
-                "conversation_id": conversation.id if 'conversation' in locals() else None
-            }
+        return self._run(
+            agent=self.chat_agent,
+            mode="chat",
+            workflow_name="imagi_chat",
+            max_turns=MAX_CHAT_TURNS,
+            user_input=user_input,
+            user=user,
+            model=model,
+            project_id=project_id,
+            current_file=current_file,
+            conversation_id=conversation_id,
+            reasoning_effort=reasoning_effort,
+        )
 
     def process_agent(
         self,
@@ -406,110 +525,26 @@ Technology Stack:
         """
         Process a message using the Coding Agent (agent mode).
 
-        The coding agent can both chat and edit project files using function tools.
-
-        Args:
-            user_input: The user's message
-            user: The Django user object
-            model: The AI model to use (defaults to self.model)
-            project_id: Project ID (required for agent mode)
-            current_file: Optional current file context
-            conversation_id: Optional existing conversation ID
-            reasoning_effort: How much reasoning to use ('low', 'medium', 'high')
-
-        Returns:
-            Dict containing the response, metadata, and list of changed files
+        The coding agent can both chat and edit project files using function
+        tools. Returns the response plus run metadata: the files it changed,
+        the tools it called, and its working plan.
         """
-        try:
-            if not user_input:
-                return {"success": False, "error": "Message is required"}
+        if not project_id:
+            return {"success": False, "error": "Project ID is required for agent mode"}
 
-            if not project_id:
-                return {"success": False, "error": "Project ID is required for agent mode"}
-
-            model = model or self.model
-            self._apply_reasoning_effort(reasoning_effort)
-
-            # Get or create conversation
-            if conversation_id:
-                conversation = self.get_conversation(conversation_id, user)
-                if not conversation:
-                    conversation = self.create_conversation(user, model, project_id=project_id)
-            else:
-                conversation = self.create_conversation(user, model, project_id=project_id)
-
-            # Add user message to conversation
-            self.add_user_message(conversation, user_input)
-
-            # Get project info
-            project_info = self.get_project_info(project_id, user)
-
-            # Build context for the agent
-            context = AgentContext(
-                user_id=user.id,
-                project_id=project_id,
-                project_name=project_info["project_name"],
-                project_description=project_info["project_description"],
-                conversation_id=conversation.id,
-                current_file=current_file,
-                mode="agent"
-            )
-
-            # Build conversation history
-            conversation_history = self.build_conversation_history(conversation)
-            if conversation_history and conversation_history[-1]["role"] == "user":
-                conversation_history = conversation_history[:-1]
-
-            # Build input for the agent
-            input_messages = []
-            if conversation_history:
-                input_messages.extend(conversation_history)
-            input_messages.append({"role": "user", "content": user_input})
-
-            # Run the coding agent
-            result = Runner.run_sync(
-                self.coding_agent,
-                input=input_messages,
-                context=context,
-                run_config=RunConfig(
-                    workflow_name="imagi_agent",
-                    trace_metadata={"user_id": str(user.id)}
-                )
-            )
-
-            response_content = result.final_output or ""
-
-            # Extract files changed from tool call outputs
-            files_changed = []
-            for item in result.new_items:
-                if hasattr(item, 'type') and item.type == 'function_call_output':
-                    try:
-                        output = json.loads(item.output) if isinstance(item.output, str) else item.output
-                        if isinstance(output, dict) and output.get("success") and output.get("path"):
-                            files_changed.append(output["path"])
-                    except (json.JSONDecodeError, TypeError, AttributeError):
-                        pass
-
-            # Add assistant message to conversation
-            self.add_assistant_message(conversation, response_content)
-
-            return {
-                "success": True,
-                "response": response_content,
-                "conversation_id": conversation.id,
-                "files_changed": files_changed,
-                "single_message": True,
-            }
-
-        except Exception as e:
-            logger.error(f"Error in process_agent: {str(e)}")
-            import traceback
-            logger.error(traceback.format_exc())
-            return {
-                "success": False,
-                "error": str(e),
-                "conversation_id": conversation.id if 'conversation' in locals() else None
-            }
+        return self._run(
+            agent=self.coding_agent,
+            mode="agent",
+            workflow_name="imagi_agent",
+            max_turns=MAX_AGENT_TURNS,
+            user_input=user_input,
+            user=user,
+            model=model,
+            project_id=project_id,
+            current_file=current_file,
+            conversation_id=conversation_id,
+            reasoning_effort=reasoning_effort,
+        )
 
 
 # Singleton instance

--- a/backend/django/apps/Products/Imagi/Agents/services/coding_agent.py
+++ b/backend/django/apps/Products/Imagi/Agents/services/coding_agent.py
@@ -2,26 +2,24 @@
 Coding Agent using OpenAI Agents SDK.
 
 This module provides a specialized coding agent that can both chat with the user
-AND edit files in their Imagi project using function tools.
+AND edit files in their Imagi project. Its tool surface and working style follow
+modern coding-agent harnesses (Claude Code, OpenAI Codex CLI): search before
+reading, read before editing, targeted edits over full rewrites, and an explicit
+plan for multi-step work.
 """
 
-import json
-import os
 import logging
+import os
 from typing import Optional
 
-from agents import Agent, RunContextWrapper, function_tool
+from agents import Agent, RunContextWrapper
 
-from apps.Products.Imagi.ProjectManager.models import Project
-from apps.Products.Imagi.Builder.services.view_file_service import ViewFileService
-from apps.Products.Imagi.Builder.services.create_file_service import CreateFileService
-from apps.Products.Imagi.Builder.services.delete_file_service import DeleteFileService
-from apps.Products.Imagi.Builder.services.directory_service import DirectoryService
 from apps.Products.Imagi.Builder.services.models_service import (
     get_backend_model_id,
     resolve_reasoning_effort,
 )
 from .base_agent import build_model_settings
+from .tools import CODING_AGENT_TOOLS
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -29,17 +27,30 @@ logger = logging.getLogger(__name__)
 # Default model
 DEFAULT_MODEL = "gpt-5.6-sol"
 
+# Project memory files, in priority order (Codex reads AGENTS.md,
+# Claude Code reads CLAUDE.md). Only the first one found is loaded.
+PROJECT_MEMORY_FILES = ('AGENTS.md', 'CLAUDE.md')
+PROJECT_MEMORY_MAX_CHARS = 6000
+
 # Coding agent system instructions
 CODING_AGENT_INSTRUCTIONS = """You are Imagi, an expert AI coding assistant for building web applications. You can both chat with users AND directly edit files in their project.
 
-You have access to tools that let you browse the project structure, list files, read, create, update, and delete project files. Use them when the user asks you to make code changes. When the user just asks a question or wants guidance, respond conversationally without using tools.
+You have tools to plan your work, search the project, and read, create, edit, and delete files. Use them when the user asks for code changes. When the user just asks a question or wants guidance, respond conversationally without using tools.
 
-Key Responsibilities:
-1. ALWAYS call get_project_tree FIRST when you need to make changes — it shows the full directory structure so you know exactly where files live.
-2. Read files before making changes to understand existing code and context.
-3. Make targeted, minimal edits — change only what's needed.
-4. When creating or updating files, always provide the complete file content.
-5. After making changes, briefly summarize what you did and why.
+Working Style (follow this loop):
+1. PLAN — for any task with 3+ distinct steps, call update_plan first with all steps, then keep it updated as you work (mark steps in_progress/completed). Skip planning for trivial requests.
+2. DISCOVER — locate the code you need before reading whole files:
+   - get_project_tree for an overview of the directory layout
+   - glob_files to find files by path pattern (e.g. '**/router/index.ts')
+   - grep_files to find where something is defined or referenced
+3. READ — always read a file (read_file) before modifying it. Output is line-numbered like `cat -n`; strip the line-number prefix when copying text for edits.
+4. EDIT — prefer edit_file (exact string replacement) for changes to existing files; it is targeted and cannot clobber unrelated code. Use update_file only for full rewrites, and create_file for new files. old_string must match the file exactly, including indentation, and be unique (or pass replace_all).
+5. VERIFY & REPORT — after making changes, confirm every tool call succeeded, then briefly summarize what you changed and why. Keep summaries short and concrete.
+
+Editing Rules:
+- Make targeted, minimal edits — change only what's needed.
+- Match the style, naming, and idiom of the surrounding code.
+- When a change spans several files (e.g. a new view plus its route), finish ALL of them before summarizing.
 
 Project Structure (CRITICAL — read carefully):
 - This is a dual-stack project with TWO separate codebases:
@@ -62,15 +73,15 @@ File Paths (CRITICAL):
 - When adding a new route, update 'frontend/vuejs/src/apps/{app_name}/router/index.ts'
 
 Workflow for Creating New Views:
-1. Call get_project_tree to see the directory structure
-2. Identify the correct app directory (e.g. src/apps/home/)
-3. Read the app's existing router (e.g. frontend/vuejs/src/apps/home/router/index.ts) to understand route patterns
-4. Create the view file at the correct path (e.g. frontend/vuejs/src/apps/home/views/NewView.vue)
-5. Update the app's router to add the new route
-6. If needed, update the app's views/index.ts barrel export
+1. Use glob_files or get_project_tree to find the correct app directory (e.g. src/apps/home/)
+2. Read the app's existing router (e.g. frontend/vuejs/src/apps/home/router/index.ts) to understand route patterns
+3. Create the view file at the correct path (e.g. frontend/vuejs/src/apps/home/views/NewView.vue)
+4. Update the app's router to add the new route (edit_file with a targeted insertion)
+5. If needed, update the app's views/index.ts barrel export
 
 Error Handling:
 - If a tool returns an error or "success": false, you MUST inform the user that the operation failed. NEVER claim success when a tool reported an error.
+- If edit_file fails because old_string was not found or not unique, re-read the file and retry with the exact current text — do not fall back to update_file unless a full rewrite is genuinely needed.
 
 Technology Stack:
 - Backend: Django with REST framework
@@ -81,265 +92,32 @@ Technology Stack:
 - HTTP client: Axios
 """
 
-# File extension to type mapping
-_EXT_TYPE_MAP = {
-    '.vue': 'vue', '.ts': 'typescript', '.tsx': 'typescript',
-    '.js': 'javascript', '.jsx': 'javascript', '.css': 'css',
-    '.html': 'html', '.py': 'python', '.json': 'json',
-    '.md': 'markdown', '.txt': 'text',
-}
 
-# Patterns indicating a frontend file path
-_FRONTEND_PATH_PREFIXES = (
-    'src/', 'public/', 'package.json', 'vite.config', 'tsconfig',
-    'tailwind.config', 'postcss.config', 'index.html', 'env.d.ts',
-)
-_FRONTEND_EXTENSIONS = {'.vue', '.ts', '.tsx', '.jsx'}
+def load_project_memory(project_path: Optional[str]) -> Optional[str]:
+    """Load per-project agent instructions (AGENTS.md / CLAUDE.md) if present.
 
-# Patterns indicating a backend file path
-_BACKEND_PATH_PREFIXES = (
-    'templates/', 'static/', 'apps/', 'api/', 'manage.py', 'Pipfile',
-)
-
-
-def _is_dual_stack(project):
-    """Check if project has both frontend/vuejs and backend/django directories."""
-    pp = project.project_path
-    return (
-        os.path.isdir(os.path.join(pp, 'frontend', 'vuejs'))
-        and os.path.isdir(os.path.join(pp, 'backend', 'django'))
-    )
-
-
-def _normalize_file_path(project, file_path: str) -> str:
-    """Normalize a file path for dual-stack projects.
-
-    The LLM may omit the 'frontend/vuejs/' or 'backend/django/' prefix.
-    This function detects that and adds the correct prefix so files are
-    written to the location that list_project_files actually scans.
+    Users can drop an AGENTS.md at their project root to give the agent
+    durable, project-specific guidance — the same convention Codex and
+    Claude Code use. Content is truncated to keep the prompt bounded.
     """
-    file_path = file_path.strip().lstrip('/')
-
-    if not _is_dual_stack(project):
-        return file_path
-
-    # Already has the correct prefix — leave it alone
-    if file_path.startswith('frontend/') or file_path.startswith('backend/'):
-        return file_path
-
-    # Check for frontend patterns
-    ext = os.path.splitext(file_path)[1].lower()
-    if any(file_path.startswith(p) for p in _FRONTEND_PATH_PREFIXES) or ext in _FRONTEND_EXTENSIONS:
-        normalized = f'frontend/vuejs/{file_path}'
-        logger.info(f"Path normalized (frontend): '{file_path}' -> '{normalized}'")
-        return normalized
-
-    # Check for backend patterns
-    if any(file_path.startswith(p) for p in _BACKEND_PATH_PREFIXES) or ext == '.py':
-        normalized = f'backend/django/{file_path}'
-        logger.info(f"Path normalized (backend): '{file_path}' -> '{normalized}'")
-        return normalized
-
-    # Ambiguous — return as-is and let the service handle it
-    return file_path
-
-
-def _infer_file_type(file_path: str) -> str:
-    """Infer file type from extension for CreateFileService."""
-    ext = os.path.splitext(file_path)[1].lower()
-    return _EXT_TYPE_MAP.get(ext, '')
-
-
-def _error_result(message: str) -> str:
-    """Build a JSON error result that instructs the LLM to report failure."""
-    return json.dumps({
-        "success": False,
-        "error": message,
-        "instruction": "Tell the user this operation FAILED. Do NOT say the file was created or updated.",
-    })
-
-
-def _get_project(ctx):
-    """Resolve the Project model from agent context."""
-    try:
-        return Project.objects.get(id=ctx.project_id, user_id=ctx.user_id, is_active=True)
-    except Project.DoesNotExist:
-        raise ValueError(f"Project {ctx.project_id} not found for user {ctx.user_id}")
-
-
-@function_tool
-def get_project_tree(ctx: RunContextWrapper) -> str:
-    """Get the directory tree of the user's project. Shows all directories and files organised hierarchically.
-
-    ALWAYS call this tool first before creating or modifying files so you know the exact directory structure.
-    This helps you find where views, routers, components, and other files live.
-    """
-    try:
-        project = _get_project(ctx.context)
-        service = ViewFileService(project=project)
-        tree = service.get_directory_tree()
-        return json.dumps(tree, indent=2)
-    except Exception as e:
-        logger.error(f"Error getting project tree: {e}")
-        return _error_result(str(e))
-
-
-@function_tool
-def list_project_files(ctx: RunContextWrapper) -> str:
-    """List all files in the user's project (both frontend and backend). Returns file paths and types."""
-    try:
-        project = _get_project(ctx.context)
-        service = ViewFileService(project=project)
-        files = service.list_all_project_files()
-        # Return a simplified list for the agent
-        file_list = [{"path": f["path"], "type": f.get("type", "unknown")} for f in files]
-        return json.dumps(file_list, indent=2)
-    except Exception as e:
-        logger.error(f"Error listing project files: {e}")
-        return _error_result(str(e))
-
-
-@function_tool
-def read_file(ctx: RunContextWrapper, file_path: str) -> str:
-    """Read the content of a file in the user's project. Use this to understand existing code before making changes.
-
-    Args:
-        file_path: The relative path to the file within the project (e.g. 'frontend/vuejs/src/App.vue').
-    """
-    try:
-        project = _get_project(ctx.context)
-        file_path = _normalize_file_path(project, file_path)
-
-        # Check if path is a directory rather than a file
-        full_path = os.path.join(project.project_path, file_path)
-        if os.path.isdir(full_path):
-            # List directory contents to be helpful
-            entries = sorted(os.listdir(full_path))
-            dirs = [e for e in entries if os.path.isdir(os.path.join(full_path, e)) and not e.startswith('.')]
-            files = [e for e in entries if os.path.isfile(os.path.join(full_path, e)) and not e.startswith('.')]
-            return json.dumps({
-                "error": f"'{file_path}' is a directory, not a file. Use get_project_tree to browse directories.",
-                "directory_contents": {"dirs": dirs, "files": files},
-            })
-
-        service = ViewFileService(project=project)
-        content = service.get_file_content(file_path)
-        return content
-    except Exception as e:
-        logger.error(f"Error reading file {file_path}: {e}")
-        return _error_result(str(e))
-
-
-@function_tool
-def update_file(ctx: RunContextWrapper, file_path: str, content: str) -> str:
-    """Update an existing file in the user's project with new content. Always read the file first to understand the current content.
-
-    Args:
-        file_path: The relative path to the file within the project.
-        content: The complete new content for the file.
-    """
-    try:
-        project = _get_project(ctx.context)
-        file_path = _normalize_file_path(project, file_path)
-        service = ViewFileService(project=project)
-        result = service.update_file(file_path, content)
-
-        # Verify the file was actually written
-        full_path = os.path.join(project.project_path, file_path)
-        if not os.path.isfile(full_path):
-            return _error_result(f"update_file appeared to succeed but file not found at {file_path}")
-
-        return json.dumps({"success": True, "path": file_path, "message": result.get("message", "File updated successfully")})
-    except Exception as e:
-        logger.error(f"Error updating file {file_path}: {e}")
-        return _error_result(str(e))
-
-
-@function_tool
-def create_file(ctx: RunContextWrapper, file_path: str, content: str) -> str:
-    """Create a new file in the user's project.
-
-    Args:
-        file_path: The relative path for the new file within the project (e.g. 'frontend/vuejs/src/components/MyComponent.vue').
-        content: The content for the new file.
-    """
-    try:
-        project = _get_project(ctx.context)
-        file_path = _normalize_file_path(project, file_path)
-        file_type = _infer_file_type(file_path)
-        service = CreateFileService(project=project)
-        result = service.create_file({"name": file_path, "content": content, "type": file_type})
-
-        # Verify the file was actually written
-        full_path = os.path.join(project.project_path, file_path)
-        if not os.path.isfile(full_path):
-            return _error_result(f"create_file appeared to succeed but file not found at {file_path}")
-
-        actual_path = result.get("path", file_path)
-        return json.dumps({"success": True, "path": actual_path, "message": f"File created at {actual_path}"})
-    except Exception as e:
-        logger.error(f"Error creating file {file_path}: {e}")
-        return _error_result(str(e))
-
-
-@function_tool
-def delete_file(ctx: RunContextWrapper, file_path: str) -> str:
-    """Delete a file from the user's project.
-
-    Args:
-        file_path: The relative path to the file within the project (e.g. 'frontend/vuejs/src/components/OldComponent.vue').
-    """
-    try:
-        project = _get_project(ctx.context)
-        file_path = _normalize_file_path(project, file_path)
-        service = DeleteFileService(project=project)
-        result = service.delete_file(file_path)
-
-        # Verify the file was actually removed
-        full_path = os.path.join(project.project_path, file_path)
-        if os.path.isfile(full_path):
-            return _error_result(f"delete_file appeared to succeed but file still exists at {file_path}")
-
-        return json.dumps({"success": True, "path": file_path, "message": result.get("message", "File deleted successfully")})
-    except Exception as e:
-        logger.error(f"Error deleting file {file_path}: {e}")
-        return _error_result(str(e))
-
-
-@function_tool
-def create_directory(ctx: RunContextWrapper, dir_path: str) -> str:
-    """Create a new directory in the user's project.
-
-    Args:
-        dir_path: The relative path for the new directory within the project (e.g. 'frontend/vuejs/src/components/NewFeature').
-    """
-    try:
-        project = _get_project(ctx.context)
-        dir_path = _normalize_file_path(project, dir_path)
-        service = DirectoryService(project=project)
-        result = service.create_directory(dir_path)
-        return json.dumps({"success": True, "path": dir_path, "message": result.get("message", "Directory created successfully")})
-    except Exception as e:
-        logger.error(f"Error creating directory {dir_path}: {e}")
-        return _error_result(str(e))
-
-
-@function_tool
-def delete_directory(ctx: RunContextWrapper, dir_path: str) -> str:
-    """Delete a directory from the user's project. This will recursively delete the directory and all its contents.
-
-    Args:
-        dir_path: The relative path to the directory within the project (e.g. 'frontend/vuejs/src/components/OldFeature').
-    """
-    try:
-        project = _get_project(ctx.context)
-        dir_path = _normalize_file_path(project, dir_path)
-        service = DirectoryService(project=project)
-        result = service.delete_directory(dir_path, recursive=True)
-        return json.dumps({"success": True, "path": dir_path, "message": result.get("message", "Directory deleted successfully")})
-    except Exception as e:
-        logger.error(f"Error deleting directory {dir_path}: {e}")
-        return _error_result(str(e))
+    if not project_path or not os.path.isdir(project_path):
+        return None
+    for filename in PROJECT_MEMORY_FILES:
+        candidate = os.path.join(project_path, filename)
+        if not os.path.isfile(candidate):
+            continue
+        try:
+            with open(candidate, 'r', encoding='utf-8') as f:
+                content = f.read().strip()
+        except (OSError, UnicodeDecodeError) as e:
+            logger.warning(f"Could not read project memory file {candidate}: {e}")
+            continue
+        if not content:
+            continue
+        if len(content) > PROJECT_MEMORY_MAX_CHARS:
+            content = content[:PROJECT_MEMORY_MAX_CHARS] + "\n… [truncated]"
+        return f"Project Memory (from {filename} in the project root — follow these instructions):\n{content}"
+    return None
 
 
 def get_dynamic_coding_instructions(context: RunContextWrapper, agent: Agent) -> str:
@@ -350,6 +128,7 @@ def get_dynamic_coding_instructions(context: RunContextWrapper, agent: Agent) ->
     if ctx:
         project_name = getattr(ctx, 'project_name', None)
         project_description = getattr(ctx, 'project_description', None)
+        project_path = getattr(ctx, 'project_path', None)
         current_file = getattr(ctx, 'current_file', None)
 
         additional_context = []
@@ -367,6 +146,10 @@ def get_dynamic_coding_instructions(context: RunContextWrapper, agent: Agent) ->
 
         if additional_context:
             instructions += "\n\nCurrent Context:\n" + "\n".join(additional_context)
+
+        memory = load_project_memory(project_path)
+        if memory:
+            instructions += f"\n\n{memory}"
 
     return instructions
 
@@ -392,7 +175,7 @@ def create_coding_agent(model: str = DEFAULT_MODEL, reasoning_effort: Optional[s
         name="Coding Agent",
         instructions=get_dynamic_coding_instructions,
         model=backend_model,
-        tools=[get_project_tree, list_project_files, read_file, update_file, create_file, delete_file, create_directory, delete_directory],
+        tools=list(CODING_AGENT_TOOLS),
         handoff_description="A coding assistant that can chat about web development "
                            "and directly edit files in the user's project.",
         **kwargs

--- a/backend/django/apps/Products/Imagi/Agents/services/tools.py
+++ b/backend/django/apps/Products/Imagi/Agents/services/tools.py
@@ -1,0 +1,645 @@
+"""
+Function tools for the Imagi coding agent.
+
+The tool surface follows the design of modern coding-agent harnesses
+(Claude Code, OpenAI Codex CLI):
+
+- Discovery:  get_project_tree, list_project_files, glob_files, grep_files
+- Reading:    read_file (line-numbered, supports offset/limit)
+- Editing:    edit_file (targeted string replacement), write_file-style
+              update_file/create_file, delete_file, directory tools
+- Planning:   update_plan (Codex-style step list surfaced to the UI)
+
+Each tool is a thin wrapper around a plain implementation function so the
+behavior can be unit-tested without the Agents SDK runtime.
+"""
+
+import fnmatch
+import json
+import logging
+import os
+import re
+from typing import List, Optional
+from typing_extensions import TypedDict
+
+from agents import RunContextWrapper, function_tool
+
+from apps.Products.Imagi.ProjectManager.models import Project
+from apps.Products.Imagi.Builder.services.view_file_service import ViewFileService
+from apps.Products.Imagi.Builder.services.create_file_service import CreateFileService
+from apps.Products.Imagi.Builder.services.delete_file_service import DeleteFileService
+from apps.Products.Imagi.Builder.services.directory_service import DirectoryService
+
+logger = logging.getLogger(__name__)
+
+# Directories that are never searched, read, or listed
+SKIP_DIRS = {
+    'node_modules', '__pycache__', '.git', 'dist', 'build',
+    'staticfiles', 'media', '.venv', 'venv',
+}
+
+# Limits that keep tool output within a sane context budget
+READ_DEFAULT_LIMIT = 2000        # lines returned by read_file by default
+READ_MAX_LINE_CHARS = 500        # long lines are truncated
+GREP_MAX_RESULTS = 50
+GLOB_MAX_RESULTS = 200
+GREP_MAX_FILE_BYTES = 1_000_000  # skip files larger than ~1MB when searching
+
+# File extension to type mapping (for CreateFileService)
+_EXT_TYPE_MAP = {
+    '.vue': 'vue', '.ts': 'typescript', '.tsx': 'typescript',
+    '.js': 'javascript', '.jsx': 'javascript', '.css': 'css',
+    '.html': 'html', '.py': 'python', '.json': 'json',
+    '.md': 'markdown', '.txt': 'text',
+}
+
+# Patterns indicating a frontend file path
+_FRONTEND_PATH_PREFIXES = (
+    'src/', 'public/', 'package.json', 'vite.config', 'tsconfig',
+    'tailwind.config', 'postcss.config', 'index.html', 'env.d.ts',
+)
+_FRONTEND_EXTENSIONS = {'.vue', '.ts', '.tsx', '.jsx'}
+
+# Patterns indicating a backend file path
+_BACKEND_PATH_PREFIXES = (
+    'templates/', 'static/', 'apps/', 'api/', 'manage.py', 'Pipfile',
+)
+
+
+class PlanStep(TypedDict):
+    """One step of the agent's working plan (Codex update_plan style)."""
+    step: str
+    status: str  # 'pending' | 'in_progress' | 'completed'
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _is_dual_stack(project) -> bool:
+    """Check if project has both frontend/vuejs and backend/django directories."""
+    pp = project.project_path
+    return (
+        os.path.isdir(os.path.join(pp, 'frontend', 'vuejs'))
+        and os.path.isdir(os.path.join(pp, 'backend', 'django'))
+    )
+
+
+def normalize_file_path(project, file_path: str) -> str:
+    """Normalize a file path for dual-stack projects.
+
+    The LLM may omit the 'frontend/vuejs/' or 'backend/django/' prefix.
+    This function detects that and adds the correct prefix so files are
+    written to the location that the project scanners actually see.
+    """
+    file_path = file_path.strip().lstrip('/')
+
+    if not _is_dual_stack(project):
+        return file_path
+
+    # Already has the correct prefix — leave it alone
+    if file_path.startswith('frontend/') or file_path.startswith('backend/'):
+        return file_path
+
+    ext = os.path.splitext(file_path)[1].lower()
+    if any(file_path.startswith(p) for p in _FRONTEND_PATH_PREFIXES) or ext in _FRONTEND_EXTENSIONS:
+        normalized = f'frontend/vuejs/{file_path}'
+        logger.info(f"Path normalized (frontend): '{file_path}' -> '{normalized}'")
+        return normalized
+
+    if any(file_path.startswith(p) for p in _BACKEND_PATH_PREFIXES) or ext == '.py':
+        normalized = f'backend/django/{file_path}'
+        logger.info(f"Path normalized (backend): '{file_path}' -> '{normalized}'")
+        return normalized
+
+    return file_path
+
+
+def resolve_safe_path(project, file_path: str) -> str:
+    """Resolve a project-relative path to an absolute path inside the project.
+
+    Raises ValueError when the path escapes the project root (e.g. via '..'
+    segments or absolute paths), so tools can never read or write outside the
+    user's project directory.
+    """
+    root = os.path.realpath(project.project_path)
+    full = os.path.realpath(os.path.join(root, file_path))
+    if full != root and not full.startswith(root + os.sep):
+        raise ValueError(f"Path '{file_path}' is outside the project directory")
+    return full
+
+
+def infer_file_type(file_path: str) -> str:
+    """Infer file type from extension for CreateFileService."""
+    ext = os.path.splitext(file_path)[1].lower()
+    return _EXT_TYPE_MAP.get(ext, '')
+
+
+def _error_result(message: str) -> str:
+    """Build a JSON error result that instructs the LLM to report failure."""
+    return json.dumps({
+        "success": False,
+        "error": message,
+        "instruction": "Tell the user this operation FAILED. Do NOT say the file was created or updated.",
+    })
+
+
+def _get_project(ctx):
+    """Resolve the Project model from agent context."""
+    try:
+        return Project.objects.get(id=ctx.project_id, user_id=ctx.user_id, is_active=True)
+    except Project.DoesNotExist:
+        raise ValueError(f"Project {ctx.project_id} not found for user {ctx.user_id}")
+
+
+def _iter_project_files(project_path: str):
+    """Yield (abs_path, rel_path) for every non-hidden file, pruning skip dirs."""
+    for root, dirs, filenames in os.walk(project_path):
+        dirs[:] = sorted(d for d in dirs if d not in SKIP_DIRS and not d.startswith('.'))
+        for filename in sorted(filenames):
+            if filename.startswith('.'):
+                continue
+            abs_path = os.path.join(root, filename)
+            yield abs_path, os.path.relpath(abs_path, project_path)
+
+
+# ---------------------------------------------------------------------------
+# Implementation functions (plain, unit-testable)
+# ---------------------------------------------------------------------------
+
+def read_file_impl(project, file_path: str, offset: int = 1, limit: int = READ_DEFAULT_LIMIT) -> str:
+    """Read a file returning `cat -n` style line-numbered output.
+
+    Supports reading a slice of large files via offset (1-based) and limit.
+    """
+    file_path = normalize_file_path(project, file_path)
+    full_path = resolve_safe_path(project, file_path)
+
+    if os.path.isdir(full_path):
+        entries = sorted(os.listdir(full_path))
+        dirs = [e for e in entries if os.path.isdir(os.path.join(full_path, e)) and not e.startswith('.')]
+        files = [e for e in entries if os.path.isfile(os.path.join(full_path, e)) and not e.startswith('.')]
+        return json.dumps({
+            "error": f"'{file_path}' is a directory, not a file. Use get_project_tree to browse directories.",
+            "directory_contents": {"dirs": dirs, "files": files},
+        })
+
+    if not os.path.isfile(full_path):
+        raise FileNotFoundError(f"File not found: {file_path}")
+
+    with open(full_path, 'r', encoding='utf-8') as f:
+        lines = f.read().splitlines()
+
+    total = len(lines)
+    offset = max(1, offset)
+    if offset > total and total > 0:
+        raise ValueError(f"offset {offset} is past the end of the file ({total} lines)")
+    limit = max(1, limit)
+    window = lines[offset - 1:offset - 1 + limit]
+
+    numbered = []
+    for i, line in enumerate(window, start=offset):
+        if len(line) > READ_MAX_LINE_CHARS:
+            line = line[:READ_MAX_LINE_CHARS] + '… [line truncated]'
+        numbered.append(f"{i}\t{line}")
+
+    header = f"[file: {file_path} | lines {offset}-{offset + len(window) - 1} of {total}]"
+    if offset - 1 + limit < total:
+        header += " (more lines below — call read_file again with a higher offset)"
+    return header + "\n" + "\n".join(numbered)
+
+
+def edit_file_impl(
+    project,
+    file_path: str,
+    old_string: str,
+    new_string: str,
+    replace_all: bool = False,
+) -> dict:
+    """Perform an exact string replacement in a file (Claude Code Edit tool).
+
+    old_string must match the file content exactly and, unless replace_all is
+    set, must be unique in the file.
+    """
+    if old_string == new_string:
+        raise ValueError("new_string must be different from old_string")
+    if not old_string:
+        raise ValueError("old_string must not be empty (use create_file for new files)")
+
+    file_path = normalize_file_path(project, file_path)
+    full_path = resolve_safe_path(project, file_path)
+    if not os.path.isfile(full_path):
+        raise FileNotFoundError(f"File not found: {file_path}")
+
+    with open(full_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    count = content.count(old_string)
+    if count == 0:
+        raise ValueError(
+            "old_string not found in file. Read the file first and copy the exact "
+            "text to replace, including whitespace and indentation."
+        )
+    if count > 1 and not replace_all:
+        raise ValueError(
+            f"old_string appears {count} times in the file. Provide a longer, unique "
+            "snippet (include surrounding lines) or set replace_all=true."
+        )
+
+    if replace_all:
+        new_content = content.replace(old_string, new_string)
+        replacements = count
+    else:
+        new_content = content.replace(old_string, new_string, 1)
+        replacements = 1
+
+    with open(full_path, 'w', encoding='utf-8') as f:
+        f.write(new_content)
+
+    return {"success": True, "path": file_path, "replacements": replacements}
+
+
+def grep_impl(
+    project,
+    pattern: str,
+    path: str = '',
+    include: Optional[str] = None,
+    max_results: int = GREP_MAX_RESULTS,
+) -> dict:
+    """Search project file contents with a regular expression.
+
+    Returns matches as {file, line, text} entries, capped at max_results.
+    """
+    regex = re.compile(pattern)
+    search_root = resolve_safe_path(project, path) if path else os.path.realpath(project.project_path)
+    if not os.path.isdir(search_root):
+        raise ValueError(f"Search path '{path}' is not a directory in the project")
+
+    project_root = os.path.realpath(project.project_path)
+    matches = []
+    files_scanned = 0
+    truncated = False
+
+    for abs_path, _ in _iter_project_files(search_root):
+        rel_to_project = os.path.relpath(abs_path, project_root)
+        if include and not fnmatch.fnmatch(os.path.basename(abs_path), include) \
+                and not fnmatch.fnmatch(rel_to_project, include):
+            continue
+        try:
+            if os.path.getsize(abs_path) > GREP_MAX_FILE_BYTES:
+                continue
+            with open(abs_path, 'r', encoding='utf-8') as f:
+                text = f.read()
+        except (OSError, UnicodeDecodeError):
+            continue
+
+        files_scanned += 1
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if regex.search(line):
+                snippet = line.strip()
+                if len(snippet) > READ_MAX_LINE_CHARS:
+                    snippet = snippet[:READ_MAX_LINE_CHARS] + '…'
+                matches.append({"file": rel_to_project, "line": lineno, "text": snippet})
+                if len(matches) >= max_results:
+                    truncated = True
+                    break
+        if truncated:
+            break
+
+    return {
+        "matches": matches,
+        "match_count": len(matches),
+        "files_scanned": files_scanned,
+        "truncated": truncated,
+    }
+
+
+def glob_impl(project, pattern: str, max_results: int = GLOB_MAX_RESULTS) -> dict:
+    """Find project files whose relative path matches a glob pattern.
+
+    Supports '**' for recursive matching (e.g. 'frontend/**/*.vue', '*.py').
+    """
+    project_root = os.path.realpath(project.project_path)
+    # fnmatch has no native '**'; translate it to match any path segment run.
+    regex = _glob_to_regex(pattern)
+
+    results = []
+    truncated = False
+    for abs_path, rel_path in _iter_project_files(project_root):
+        rel_posix = rel_path.replace(os.sep, '/')
+        if regex.match(rel_posix) or fnmatch.fnmatch(os.path.basename(abs_path), pattern):
+            results.append(rel_posix)
+            if len(results) >= max_results:
+                truncated = True
+                break
+
+    return {"files": results, "count": len(results), "truncated": truncated}
+
+
+def _glob_to_regex(pattern: str) -> re.Pattern:
+    """Translate a glob pattern with '**' support into a compiled regex."""
+    out = []
+    i = 0
+    while i < len(pattern):
+        c = pattern[i]
+        if c == '*':
+            if pattern[i:i + 2] == '**':
+                out.append('.*')
+                i += 2
+                if i < len(pattern) and pattern[i] == '/':
+                    i += 1
+                continue
+            out.append('[^/]*')
+        elif c == '?':
+            out.append('[^/]')
+        else:
+            out.append(re.escape(c))
+        i += 1
+    return re.compile('^' + ''.join(out) + '$')
+
+
+def set_plan(context, steps: List[PlanStep]) -> dict:
+    """Validate and store the agent's plan on the run context."""
+    valid_statuses = {'pending', 'in_progress', 'completed'}
+    plan = []
+    for step in steps:
+        text = (step.get('step') or '').strip()
+        status = (step.get('status') or 'pending').strip()
+        if not text:
+            continue
+        if status not in valid_statuses:
+            status = 'pending'
+        plan.append({'step': text, 'status': status})
+    context.plan = plan
+    return {"success": True, "steps": len(plan)}
+
+
+# ---------------------------------------------------------------------------
+# Function tools (Agents SDK surface)
+# ---------------------------------------------------------------------------
+
+@function_tool
+def get_project_tree(ctx: RunContextWrapper) -> str:
+    """Get the directory tree of the user's project. Shows all directories and files organised hierarchically.
+
+    Call this first when you need an overview of where views, routers, components, and other files live.
+    """
+    try:
+        project = _get_project(ctx.context)
+        service = ViewFileService(project=project)
+        tree = service.get_directory_tree()
+        return json.dumps(tree, indent=2)
+    except Exception as e:
+        logger.error(f"Error getting project tree: {e}")
+        return _error_result(str(e))
+
+
+@function_tool
+def list_project_files(ctx: RunContextWrapper) -> str:
+    """List all files in the user's project (both frontend and backend). Returns file paths and types."""
+    try:
+        project = _get_project(ctx.context)
+        service = ViewFileService(project=project)
+        files = service.list_all_project_files()
+        file_list = [{"path": f["path"], "type": f.get("type", "unknown")} for f in files]
+        return json.dumps(file_list, indent=2)
+    except Exception as e:
+        logger.error(f"Error listing project files: {e}")
+        return _error_result(str(e))
+
+
+@function_tool
+def glob_files(ctx: RunContextWrapper, pattern: str) -> str:
+    """Find files whose path matches a glob pattern. Faster and cheaper than listing every file.
+
+    Args:
+        pattern: Glob pattern matched against project-relative paths. Supports '**'
+            for recursive matching (e.g. 'frontend/**/*.vue', '**/router/index.ts', '*.py').
+    """
+    try:
+        project = _get_project(ctx.context)
+        return json.dumps(glob_impl(project, pattern))
+    except Exception as e:
+        logger.error(f"Error globbing files with pattern {pattern}: {e}")
+        return _error_result(str(e))
+
+
+@function_tool
+def grep_files(ctx: RunContextWrapper, pattern: str, path: str = "", include: str = "") -> str:
+    """Search file contents across the project with a regular expression. Returns matching lines with file paths and line numbers.
+
+    Use this to find where something is defined or referenced before reading whole files.
+
+    Args:
+        pattern: Regular expression to search for (e.g. 'createRouter', 'class\\s+\\w+View').
+        path: Optional project-relative directory to limit the search (e.g. 'frontend/vuejs/src').
+        include: Optional glob to filter which files are searched (e.g. '*.vue', '*.py').
+    """
+    try:
+        project = _get_project(ctx.context)
+        result = grep_impl(project, pattern, path=path, include=include or None)
+        return json.dumps(result)
+    except re.error as e:
+        return _error_result(f"Invalid regular expression: {e}")
+    except Exception as e:
+        logger.error(f"Error searching files for pattern {pattern}: {e}")
+        return _error_result(str(e))
+
+
+@function_tool
+def read_file(ctx: RunContextWrapper, file_path: str, offset: int = 1, limit: int = READ_DEFAULT_LIMIT) -> str:
+    """Read a file from the user's project. Output is line-numbered like `cat -n` ("N<TAB>content" per line).
+
+    Always read a file before editing it. For large files, read a slice with offset/limit.
+    When copying text for edit_file, strip the leading line numbers and tab.
+
+    Args:
+        file_path: The relative path to the file within the project (e.g. 'frontend/vuejs/src/App.vue').
+        offset: 1-based line number to start reading from (default 1).
+        limit: Maximum number of lines to return (default 2000).
+    """
+    try:
+        project = _get_project(ctx.context)
+        return read_file_impl(project, file_path, offset=offset, limit=limit)
+    except Exception as e:
+        logger.error(f"Error reading file {file_path}: {e}")
+        return _error_result(str(e))
+
+
+@function_tool
+def edit_file(
+    ctx: RunContextWrapper,
+    file_path: str,
+    old_string: str,
+    new_string: str,
+    replace_all: bool = False,
+) -> str:
+    """Make a targeted edit to an existing file by exact string replacement. PREFER this over update_file for small changes — it is safer and cannot clobber unrelated code.
+
+    old_string must match the current file content exactly (including whitespace and
+    indentation) and must be unique in the file unless replace_all is set. Read the
+    file first and copy the exact text (without the line-number prefixes).
+
+    Args:
+        file_path: The relative path to the file within the project.
+        old_string: The exact existing text to replace.
+        new_string: The replacement text.
+        replace_all: Replace every occurrence instead of requiring old_string to be unique.
+    """
+    try:
+        project = _get_project(ctx.context)
+        result = edit_file_impl(project, file_path, old_string, new_string, replace_all)
+        return json.dumps(result)
+    except Exception as e:
+        logger.error(f"Error editing file {file_path}: {e}")
+        return _error_result(str(e))
+
+
+@function_tool
+def update_file(ctx: RunContextWrapper, file_path: str, content: str) -> str:
+    """Overwrite an existing file with entirely new content. Use edit_file for small changes; use this only for full rewrites.
+
+    Args:
+        file_path: The relative path to the file within the project.
+        content: The complete new content for the file.
+    """
+    try:
+        project = _get_project(ctx.context)
+        file_path = normalize_file_path(project, file_path)
+        full_path = resolve_safe_path(project, file_path)
+        service = ViewFileService(project=project)
+        result = service.update_file(file_path, content)
+
+        if not os.path.isfile(full_path):
+            return _error_result(f"update_file appeared to succeed but file not found at {file_path}")
+
+        return json.dumps({"success": True, "path": file_path, "message": result.get("message", "File updated successfully")})
+    except Exception as e:
+        logger.error(f"Error updating file {file_path}: {e}")
+        return _error_result(str(e))
+
+
+@function_tool
+def create_file(ctx: RunContextWrapper, file_path: str, content: str) -> str:
+    """Create a new file in the user's project.
+
+    Args:
+        file_path: The relative path for the new file within the project (e.g. 'frontend/vuejs/src/components/MyComponent.vue').
+        content: The content for the new file.
+    """
+    try:
+        project = _get_project(ctx.context)
+        file_path = normalize_file_path(project, file_path)
+        resolve_safe_path(project, file_path)
+        file_type = infer_file_type(file_path)
+        service = CreateFileService(project=project)
+        result = service.create_file({"name": file_path, "content": content, "type": file_type})
+
+        full_path = os.path.join(project.project_path, file_path)
+        if not os.path.isfile(full_path):
+            return _error_result(f"create_file appeared to succeed but file not found at {file_path}")
+
+        actual_path = result.get("path", file_path)
+        return json.dumps({"success": True, "path": actual_path, "message": f"File created at {actual_path}"})
+    except Exception as e:
+        logger.error(f"Error creating file {file_path}: {e}")
+        return _error_result(str(e))
+
+
+@function_tool
+def delete_file(ctx: RunContextWrapper, file_path: str) -> str:
+    """Delete a file from the user's project.
+
+    Args:
+        file_path: The relative path to the file within the project (e.g. 'frontend/vuejs/src/components/OldComponent.vue').
+    """
+    try:
+        project = _get_project(ctx.context)
+        file_path = normalize_file_path(project, file_path)
+        full_path = resolve_safe_path(project, file_path)
+        service = DeleteFileService(project=project)
+        service.delete_file(file_path)
+
+        if os.path.isfile(full_path):
+            return _error_result(f"delete_file appeared to succeed but file still exists at {file_path}")
+
+        return json.dumps({"success": True, "path": file_path, "message": "File deleted successfully"})
+    except Exception as e:
+        logger.error(f"Error deleting file {file_path}: {e}")
+        return _error_result(str(e))
+
+
+@function_tool
+def create_directory(ctx: RunContextWrapper, dir_path: str) -> str:
+    """Create a new directory in the user's project.
+
+    Args:
+        dir_path: The relative path for the new directory within the project (e.g. 'frontend/vuejs/src/components/NewFeature').
+    """
+    try:
+        project = _get_project(ctx.context)
+        dir_path = normalize_file_path(project, dir_path)
+        resolve_safe_path(project, dir_path)
+        service = DirectoryService(project=project)
+        result = service.create_directory(dir_path)
+        return json.dumps({"success": True, "path": dir_path, "message": result.get("message", "Directory created successfully")})
+    except Exception as e:
+        logger.error(f"Error creating directory {dir_path}: {e}")
+        return _error_result(str(e))
+
+
+@function_tool
+def delete_directory(ctx: RunContextWrapper, dir_path: str) -> str:
+    """Delete a directory from the user's project. This will recursively delete the directory and all its contents.
+
+    Args:
+        dir_path: The relative path to the directory within the project (e.g. 'frontend/vuejs/src/components/OldFeature').
+    """
+    try:
+        project = _get_project(ctx.context)
+        dir_path = normalize_file_path(project, dir_path)
+        resolve_safe_path(project, dir_path)
+        service = DirectoryService(project=project)
+        result = service.delete_directory(dir_path, recursive=True)
+        return json.dumps({"success": True, "path": dir_path, "message": result.get("message", "Directory deleted successfully")})
+    except Exception as e:
+        logger.error(f"Error deleting directory {dir_path}: {e}")
+        return _error_result(str(e))
+
+
+@function_tool
+def update_plan(ctx: RunContextWrapper, steps: List[PlanStep]) -> str:
+    """Create or update your working plan for a multi-step task. The plan is shown live to the user, so keep it current.
+
+    Call this when a task needs 3 or more distinct steps: once up front with all steps
+    ('pending'), then again whenever a step starts ('in_progress') or finishes
+    ('completed'). Exactly one step should be 'in_progress' at a time. Skip planning
+    for trivial single-step requests.
+
+    Args:
+        steps: The full plan as a list of {step, status} objects, where status is
+            'pending', 'in_progress', or 'completed'.
+    """
+    try:
+        result = set_plan(ctx.context, steps)
+        return json.dumps(result)
+    except Exception as e:
+        logger.error(f"Error updating plan: {e}")
+        return _error_result(str(e))
+
+
+# All tools exposed to the coding agent, in the order they appear in its prompt.
+CODING_AGENT_TOOLS = [
+    update_plan,
+    get_project_tree,
+    list_project_files,
+    glob_files,
+    grep_files,
+    read_file,
+    edit_file,
+    update_file,
+    create_file,
+    delete_file,
+    create_directory,
+    delete_directory,
+]

--- a/backend/django/apps/Products/Imagi/Agents/tests.py
+++ b/backend/django/apps/Products/Imagi/Agents/tests.py
@@ -1,2 +1,318 @@
+"""
+Tests for the Agents app harness.
 
-# Create your tests here.
+Covers the coding-agent tool implementations (read/edit/grep/glob, path
+safety, plan tracking), conversation history compaction, and project memory
+loading. The tools are tested through their plain implementation functions so
+no OpenAI calls are made.
+"""
+
+import os
+import shutil
+import tempfile
+from types import SimpleNamespace
+
+from django.test import SimpleTestCase
+
+from apps.Products.Imagi.Agents.services.base_agent import (
+    AgentContext,
+    compact_history,
+    extract_run_metadata,
+)
+from apps.Products.Imagi.Agents.services.coding_agent import (
+    PROJECT_MEMORY_MAX_CHARS,
+    load_project_memory,
+)
+from apps.Products.Imagi.Agents.services.tools import (
+    edit_file_impl,
+    glob_impl,
+    grep_impl,
+    normalize_file_path,
+    read_file_impl,
+    resolve_safe_path,
+    set_plan,
+)
+
+
+class ToolTestBase(SimpleTestCase):
+    """Create a throwaway dual-stack project tree on disk."""
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp(prefix='agents_tools_')
+        self.addCleanup(lambda: shutil.rmtree(self.root, ignore_errors=True))
+        # A minimal Project stand-in: the impls only use .project_path
+        self.project = SimpleNamespace(project_path=self.root)
+
+        self._write('frontend/vuejs/src/App.vue', '<template>\n  <div>App</div>\n</template>\n')
+        self._write(
+            'frontend/vuejs/src/apps/home/router/index.ts',
+            "import { createRouter } from 'vue-router'\n\nconst routes = []\n\nexport default routes\n",
+        )
+        self._write('backend/django/manage.py', "#!/usr/bin/env python\nprint('manage')\n")
+
+    def _write(self, rel_path, content):
+        full = os.path.join(self.root, rel_path)
+        os.makedirs(os.path.dirname(full), exist_ok=True)
+        with open(full, 'w', encoding='utf-8') as f:
+            f.write(content)
+        return full
+
+
+class PathSafetyTests(ToolTestBase):
+    def test_resolve_safe_path_allows_project_files(self):
+        full = resolve_safe_path(self.project, 'frontend/vuejs/src/App.vue')
+        self.assertTrue(full.startswith(os.path.realpath(self.root)))
+
+    def test_resolve_safe_path_blocks_traversal(self):
+        with self.assertRaises(ValueError):
+            resolve_safe_path(self.project, '../outside.txt')
+        with self.assertRaises(ValueError):
+            resolve_safe_path(self.project, 'frontend/../../etc/passwd')
+
+    def test_normalize_adds_frontend_prefix_for_dual_stack(self):
+        self.assertEqual(
+            normalize_file_path(self.project, 'src/apps/home/views/About.vue'),
+            'frontend/vuejs/src/apps/home/views/About.vue',
+        )
+
+    def test_normalize_adds_backend_prefix_for_python(self):
+        self.assertEqual(
+            normalize_file_path(self.project, 'apps/blog/models.py'),
+            'backend/django/apps/blog/models.py',
+        )
+
+    def test_normalize_keeps_prefixed_paths(self):
+        self.assertEqual(
+            normalize_file_path(self.project, 'frontend/vuejs/src/App.vue'),
+            'frontend/vuejs/src/App.vue',
+        )
+
+
+class ReadFileTests(ToolTestBase):
+    def test_read_returns_line_numbered_output(self):
+        out = read_file_impl(self.project, 'frontend/vuejs/src/App.vue')
+        self.assertIn('[file: frontend/vuejs/src/App.vue | lines 1-3 of 3]', out)
+        self.assertIn('1\t<template>', out)
+        self.assertIn('3\t</template>', out)
+
+    def test_read_supports_offset_and_limit(self):
+        self._write('notes.md', '\n'.join(f'line {i}' for i in range(1, 11)))
+        out = read_file_impl(self.project, 'notes.md', offset=4, limit=2)
+        self.assertIn('lines 4-5 of 10', out)
+        self.assertIn('4\tline 4', out)
+        self.assertIn('5\tline 5', out)
+        self.assertNotIn('6\tline 6', out)
+        self.assertIn('more lines below', out)
+
+    def test_read_missing_file_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            read_file_impl(self.project, 'frontend/vuejs/src/Nope.vue')
+
+
+class EditFileTests(ToolTestBase):
+    def test_edit_replaces_unique_string(self):
+        result = edit_file_impl(
+            self.project,
+            'frontend/vuejs/src/App.vue',
+            '<div>App</div>',
+            '<div>Updated</div>',
+        )
+        self.assertTrue(result['success'])
+        self.assertEqual(result['replacements'], 1)
+        with open(os.path.join(self.root, 'frontend/vuejs/src/App.vue')) as f:
+            self.assertIn('<div>Updated</div>', f.read())
+
+    def test_edit_rejects_missing_old_string(self):
+        with self.assertRaises(ValueError) as cm:
+            edit_file_impl(self.project, 'frontend/vuejs/src/App.vue', 'nonexistent', 'x')
+        self.assertIn('not found', str(cm.exception))
+
+    def test_edit_rejects_ambiguous_old_string(self):
+        self._write('dup.txt', 'foo\nfoo\n')
+        with self.assertRaises(ValueError) as cm:
+            edit_file_impl(self.project, 'dup.txt', 'foo', 'bar')
+        self.assertIn('2 times', str(cm.exception))
+
+    def test_edit_replace_all(self):
+        self._write('dup.txt', 'foo\nfoo\n')
+        result = edit_file_impl(self.project, 'dup.txt', 'foo', 'bar', replace_all=True)
+        self.assertEqual(result['replacements'], 2)
+        with open(os.path.join(self.root, 'dup.txt')) as f:
+            self.assertEqual(f.read(), 'bar\nbar\n')
+
+    def test_edit_rejects_identical_strings(self):
+        with self.assertRaises(ValueError):
+            edit_file_impl(self.project, 'frontend/vuejs/src/App.vue', 'same', 'same')
+
+    def test_edit_normalizes_bare_frontend_path(self):
+        result = edit_file_impl(
+            self.project, 'src/App.vue', '<div>App</div>', '<div>Normalized</div>'
+        )
+        self.assertEqual(result['path'], 'frontend/vuejs/src/App.vue')
+
+
+class GrepGlobTests(ToolTestBase):
+    def test_grep_finds_matches_with_line_numbers(self):
+        result = grep_impl(self.project, r'createRouter')
+        self.assertEqual(result['match_count'], 1)
+        match = result['matches'][0]
+        self.assertEqual(match['file'], os.path.join('frontend', 'vuejs', 'src', 'apps', 'home', 'router', 'index.ts'))
+        self.assertEqual(match['line'], 1)
+        self.assertIn('createRouter', match['text'])
+
+    def test_grep_respects_include_filter(self):
+        result = grep_impl(self.project, r'.', include='*.py')
+        files = {m['file'] for m in result['matches']}
+        self.assertTrue(all(f.endswith('.py') for f in files))
+
+    def test_grep_scoped_to_subdirectory(self):
+        result = grep_impl(self.project, r'print', path='backend')
+        self.assertEqual(result['match_count'], 1)
+
+    def test_grep_skips_node_modules(self):
+        self._write('frontend/vuejs/node_modules/pkg/index.js', 'createRouter\n')
+        result = grep_impl(self.project, r'createRouter')
+        self.assertEqual(result['match_count'], 1)
+
+    def test_glob_recursive_pattern(self):
+        result = glob_impl(self.project, 'frontend/**/*.vue')
+        self.assertEqual(result['files'], ['frontend/vuejs/src/App.vue'])
+
+    def test_glob_basename_pattern(self):
+        result = glob_impl(self.project, '*.py')
+        self.assertEqual(result['files'], ['backend/django/manage.py'])
+
+    def test_glob_double_star_segment(self):
+        result = glob_impl(self.project, '**/router/index.ts')
+        self.assertEqual(result['files'], ['frontend/vuejs/src/apps/home/router/index.ts'])
+
+
+class PlanTests(SimpleTestCase):
+    def test_set_plan_stores_validated_steps(self):
+        ctx = AgentContext(user_id=1)
+        result = set_plan(ctx, [
+            {'step': 'Find the router', 'status': 'completed'},
+            {'step': 'Add the route', 'status': 'in_progress'},
+            {'step': 'Create the view', 'status': 'pending'},
+        ])
+        self.assertEqual(result['steps'], 3)
+        self.assertEqual(ctx.plan[1], {'step': 'Add the route', 'status': 'in_progress'})
+
+    def test_set_plan_normalizes_bad_input(self):
+        ctx = AgentContext(user_id=1)
+        set_plan(ctx, [
+            {'step': '  ', 'status': 'pending'},          # dropped: empty step
+            {'step': 'Do work', 'status': 'bogus'},        # status coerced
+        ])
+        self.assertEqual(ctx.plan, [{'step': 'Do work', 'status': 'pending'}])
+
+    def test_set_plan_replaces_previous_plan(self):
+        ctx = AgentContext(user_id=1)
+        set_plan(ctx, [{'step': 'old', 'status': 'pending'}])
+        set_plan(ctx, [{'step': 'new', 'status': 'in_progress'}])
+        self.assertEqual(len(ctx.plan), 1)
+        self.assertEqual(ctx.plan[0]['step'], 'new')
+
+
+class CompactHistoryTests(SimpleTestCase):
+    def test_short_history_unchanged(self):
+        messages = [
+            {'role': 'user', 'content': 'hello'},
+            {'role': 'assistant', 'content': 'hi'},
+        ]
+        self.assertEqual(compact_history(messages, max_chars=1000), messages)
+
+    def test_long_history_is_compacted(self):
+        messages = [
+            {'role': 'user', 'content': f'message number {i} ' + 'x' * 200}
+            for i in range(20)
+        ]
+        compacted = compact_history(messages, max_chars=1000)
+        self.assertLess(len(compacted), len(messages))
+        # First message is the compaction summary
+        self.assertIn('Conversation compacted', compacted[0]['content'])
+        self.assertIn('message number 0', compacted[0]['content'])
+        # Most recent message survives verbatim
+        self.assertEqual(compacted[-1], messages[-1])
+
+    def test_compaction_always_keeps_latest_message(self):
+        messages = [
+            {'role': 'user', 'content': 'a' * 5000},
+            {'role': 'assistant', 'content': 'b' * 5000},
+        ]
+        compacted = compact_history(messages, max_chars=100)
+        self.assertEqual(compacted[-1]['content'], 'b' * 5000)
+
+
+class ExtractRunMetadataTests(SimpleTestCase):
+    def test_extracts_tool_calls_and_changed_files(self):
+        # Shapes mirror the Agents SDK RunItems: ToolCallItem exposes the tool
+        # name on raw_item; ToolCallOutputItem exposes the tool's return value
+        # as .output (type 'tool_call_output_item').
+        items = [
+            SimpleNamespace(type='tool_call_item', raw_item=SimpleNamespace(name='read_file')),
+            SimpleNamespace(type='tool_call_output_item', output='[file: a.vue | lines 1-1 of 1]\n1\tx'),
+            SimpleNamespace(type='tool_call_item', raw_item=SimpleNamespace(name='edit_file')),
+            SimpleNamespace(
+                type='tool_call_output_item',
+                output='{"success": true, "path": "frontend/vuejs/src/App.vue", "replacements": 1}',
+            ),
+            SimpleNamespace(type='message_output_item'),
+        ]
+        metadata = extract_run_metadata(SimpleNamespace(new_items=items))
+        self.assertEqual(metadata['tool_calls'], ['read_file', 'edit_file'])
+        self.assertEqual(metadata['files_changed'], ['frontend/vuejs/src/App.vue'])
+
+    def test_deduplicates_changed_files_and_ignores_failures(self):
+        success = '{"success": true, "path": "a.py"}'
+        failure = '{"success": false, "path": "b.py", "error": "nope"}'
+        items = [
+            SimpleNamespace(type='tool_call_output_item', output=success),
+            SimpleNamespace(type='tool_call_output_item', output=success),
+            SimpleNamespace(type='tool_call_output_item', output=failure),
+        ]
+        metadata = extract_run_metadata(SimpleNamespace(new_items=items))
+        self.assertEqual(metadata['files_changed'], ['a.py'])
+
+    def test_handles_empty_result(self):
+        metadata = extract_run_metadata(SimpleNamespace(new_items=[]))
+        self.assertEqual(metadata, {'tool_calls': [], 'files_changed': []})
+
+
+class ProjectMemoryTests(SimpleTestCase):
+    def setUp(self):
+        self.root = tempfile.mkdtemp(prefix='agents_memory_')
+        self.addCleanup(lambda: shutil.rmtree(self.root, ignore_errors=True))
+
+    def _write(self, name, content):
+        with open(os.path.join(self.root, name), 'w', encoding='utf-8') as f:
+            f.write(content)
+
+    def test_returns_none_without_memory_file(self):
+        self.assertIsNone(load_project_memory(self.root))
+        self.assertIsNone(load_project_memory(None))
+        self.assertIsNone(load_project_memory('/nonexistent/path'))
+
+    def test_loads_agents_md(self):
+        self._write('AGENTS.md', 'Always use TypeScript.')
+        memory = load_project_memory(self.root)
+        self.assertIn('AGENTS.md', memory)
+        self.assertIn('Always use TypeScript.', memory)
+
+    def test_agents_md_wins_over_claude_md(self):
+        self._write('AGENTS.md', 'from agents file')
+        self._write('CLAUDE.md', 'from claude file')
+        memory = load_project_memory(self.root)
+        self.assertIn('from agents file', memory)
+        self.assertNotIn('from claude file', memory)
+
+    def test_falls_back_to_claude_md(self):
+        self._write('CLAUDE.md', 'claude instructions')
+        memory = load_project_memory(self.root)
+        self.assertIn('claude instructions', memory)
+
+    def test_truncates_oversized_memory(self):
+        self._write('AGENTS.md', 'y' * (PROJECT_MEMORY_MAX_CHARS + 500))
+        memory = load_project_memory(self.root)
+        self.assertIn('[truncated]', memory)
+        self.assertLess(len(memory), PROJECT_MEMORY_MAX_CHARS + 200)

--- a/frontend/vuejs/src/apps/products/imagi/services/agentService.ts
+++ b/frontend/vuejs/src/apps/products/imagi/services/agentService.ts
@@ -342,6 +342,8 @@ export const AgentService = {
         response: response.data.response,
         conversation_id: response.data.conversation_id,
         files_changed: response.data.files_changed || [],
+        tool_calls: response.data.tool_calls || [],
+        plan: response.data.plan || [],
         single_message: response.data.single_message || false,
       }
     } catch (error: any) {
@@ -358,6 +360,8 @@ export const AgentService = {
       return {
         response: errorDetails || this.formatError(error),
         files_changed: [],
+        tool_calls: [],
+        plan: [],
       }
     }
   },

--- a/frontend/vuejs/src/apps/products/imagi/types/services.ts
+++ b/frontend/vuejs/src/apps/products/imagi/types/services.ts
@@ -275,12 +275,24 @@ export interface ChatResponse {
 }
 
 /**
+ * One step of the agent's working plan, maintained via its update_plan tool
+ */
+export interface AgentPlanStep {
+  step: string;
+  status: 'pending' | 'in_progress' | 'completed';
+}
+
+/**
  * Agent mode response interface (coding agent that can chat + edit files)
  */
 export interface AgentResponse {
   response: string;
   conversation_id?: string;
   files_changed?: string[];
+  /** Names of the tools the agent called during the run, in order */
+  tool_calls?: string[];
+  /** The agent's working plan for multi-step tasks */
+  plan?: AgentPlanStep[];
   single_message?: boolean;
 }
 


### PR DESCRIPTION
Rework the coding-agent harness in the Agents service around the tool
surface and working loop used by modern coding agents (Claude Code,
OpenAI Codex CLI):

- New tools module (services/tools.py):
  * grep_files / glob_files for content and path search before reading
  * edit_file: targeted exact-string replacement with uniqueness checks,
    replacing full-file rewrites for small changes
  * read_file: line-numbered output with offset/limit for large files
  * update_plan: Codex-style step list stored on the run context and
    surfaced live to the workspace UI
  * All file tools resolve paths through a traversal-safe resolver so the
    agent can never touch files outside the user's project
- Harness core (base_agent.py):
  * process_chat/process_agent unified into one _run loop with per-mode
    max_turns caps
  * Automatic history compaction: long conversations are summarized into
    a budgeted context instead of growing unbounded
  * extract_run_metadata returns tool_calls + files_changed; also fixes
    the item-type check ('tool_call_output_item') so files_changed
    actually populates
- Project memory: AGENTS.md / CLAUDE.md at the user's project root is
  loaded into the coding agent's instructions each run
- Rewritten system prompt around a plan -> discover -> read -> edit ->
  verify loop with targeted-edit rules
- API + frontend: agent responses now include plan and tool_calls,
  passed through AgentService and typed in AgentResponse
- Tests: 35 unit tests covering the tool implementations, path safety,
  plan validation, compaction, run metadata, and project memory

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014TLybRRQACmAEXqMym79Qp