### PR TITLE
Seed new projects with an AI initial build from the business description

### DIFF
--- a/backend/django/apps/Products/Imagi/ProjectManager/api/serializers.py
+++ b/backend/django/apps/Products/Imagi/ProjectManager/api/serializers.py
@@ -8,8 +8,14 @@ class ProjectSerializer(serializers.ModelSerializer):
         fields = ['id', 'name', 'description', 'created_at', 'updated_at', 'is_active']
         read_only_fields = ['id', 'created_at', 'updated_at']
 
+# The description seeds the initial AI build, so it has to carry enough
+# signal for the agent to work with. Mirrored by the creation form.
+MIN_DESCRIPTION_LENGTH = 20
+
 class ProjectCreateSerializer(serializers.ModelSerializer):
     """Serializer for creating new projects."""
+    description = serializers.CharField(required=True, allow_blank=False)
+
     class Meta:
         model = Project
         fields = ['name', 'description']
@@ -21,6 +27,16 @@ class ProjectCreateSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError("A project with this name already exists.")
         return value
 
+    def validate_description(self, value):
+        """Require a business description substantial enough to seed the initial AI build."""
+        value = value.strip()
+        if len(value) < MIN_DESCRIPTION_LENGTH:
+            raise serializers.ValidationError(
+                "Please describe your business — what it does, who its customers are, "
+                "and how it will sell. Imagi uses this to build the first version of your app."
+            )
+        return value
+
     def create(self, validated_data):
         """Create a new project for the current user."""
         # Don't get user from validated_data since it's passed directly to save()
@@ -28,6 +44,6 @@ class ProjectCreateSerializer(serializers.ModelSerializer):
         project = Project.objects.create(
             user=user,
             name=validated_data['name'],
-            description=validated_data.get('description', '')
+            description=validated_data['description']
         )
         return project

--- a/backend/django/apps/Products/Imagi/ProjectManager/api/views.py
+++ b/backend/django/apps/Products/Imagi/ProjectManager/api/views.py
@@ -4,7 +4,7 @@ from rest_framework import generics, permissions, status
 from rest_framework.response import Response
 from rest_framework.exceptions import NotFound, APIException
 from rest_framework.views import APIView
-from ..services import ProjectCreationService, ProjectManagementService
+from ..services import ProjectCreationService, ProjectManagementService, start_initial_build
 from .serializers import (
     ProjectSerializer,
     ProjectCreateSerializer
@@ -33,6 +33,14 @@ class ProjectCreateView(generics.CreateAPIView):
             project = serializer.save()  # Don't pass user here, handle it in serializer
             service = ProjectCreationService(request.user)
             service.create_project(project)
+
+            # Hand the business name + description to the coding agent as the
+            # first build prompt. Runs in the background; creation succeeds
+            # even if the build can't start.
+            try:
+                start_initial_build(project, request.user)
+            except Exception:
+                logger.exception("Failed to start initial AI build for project %s", project.id)
 
             response_serializer = ProjectSerializer(project)
             return Response(response_serializer.data, status=status.HTTP_201_CREATED)

--- a/backend/django/apps/Products/Imagi/ProjectManager/services/__init__.py
+++ b/backend/django/apps/Products/Imagi/ProjectManager/services/__init__.py
@@ -1,7 +1,9 @@
 from .project_creation_service import ProjectCreationService
 from .project_management_service import ProjectManagementService
+from .initial_build_service import start_initial_build
 
 __all__ = [
     'ProjectCreationService',
     'ProjectManagementService',
+    'start_initial_build',
 ]

--- a/backend/django/apps/Products/Imagi/ProjectManager/services/initial_build_service.py
+++ b/backend/django/apps/Products/Imagi/ProjectManager/services/initial_build_service.py
@@ -1,0 +1,126 @@
+"""
+Initial AI build service.
+
+When a user creates a project (their business), the business name and
+description they provided become the first build prompt for the coding
+agent. The build runs in a background thread so project creation stays
+fast; by the time the user enters build mode the workspace already has a
+tailored starting point instead of the generic scaffold.
+
+Build progress is tracked on the existing Project.generation_status field
+('generating' -> 'completed'/'failed'), and the run is persisted as an
+"Initial build" agent conversation so it shows up in the workspace chat.
+"""
+
+import logging
+import threading
+
+from django.db import close_old_connections
+from django.utils import timezone
+
+logger = logging.getLogger(__name__)
+
+
+def build_initial_prompt(name: str, description: str) -> str:
+    """Compose the first build prompt from the business name and description."""
+    return f"""You are performing the very first build of a brand-new project the user just created on Imagi. Nothing custom has been built yet — the project contains only Imagi's default scaffold (home, auth, and payments apps).
+
+Business name: {name}
+
+Business description (written by the founder):
+{description}
+
+Using this description, build the first version of the business's web application so the founder sees a tailored starting point — not a generic scaffold — when they open the workspace:
+
+1. Rework the home app's landing page around this business: a clear hero (business name and what it does), sections covering its offering and intended customers, and a call to action that matches the sales approach in the description.
+2. Update titles, headings, and placeholder copy that still reference the scaffold so they reflect the business.
+3. If the description clearly calls for one or two more simple pages (for example an About or Pricing page), create them and wire up their routes.
+
+Keep the scope tight: this is a strong starting point, not a finished product. Do not touch the auth or payments apps beyond copy tweaks, and do not invent features the description doesn't support. When you finish, briefly summarize what you built — the founder will read it as the first message in their workspace."""
+
+
+def start_initial_build(project, user) -> bool:
+    """Kick off the initial AI build for a freshly created project.
+
+    Marks the project as 'generating' synchronously (so the status is
+    already correct when the create response returns) and runs the agent
+    in a daemon thread. Returns False when no AI provider is configured.
+    """
+    from apps.Products.Imagi.Agents.services.base_agent import OPENAI_API_KEY
+
+    if not OPENAI_API_KEY:
+        logger.warning(
+            "OPENAI_KEY not configured - skipping initial AI build for project %s",
+            project.pk,
+        )
+        return False
+
+    from ..models import Project
+
+    Project.objects.filter(pk=project.pk).update(generation_status='generating')
+    project.generation_status = 'generating'
+
+    thread = threading.Thread(
+        target=_run_initial_build,
+        args=(project.pk, user.pk),
+        name=f"initial-build-{project.pk}",
+        daemon=True,
+    )
+    thread.start()
+    logger.info("Initial AI build started in background for project %s", project.pk)
+    return True
+
+
+def _run_initial_build(project_id: int, user_id: int) -> None:
+    """Thread body: run the coding agent with the business description prompt."""
+    close_old_connections()
+    from ..models import Project
+
+    try:
+        from django.contrib.auth import get_user_model
+        from apps.Products.Imagi.Agents.services.base_agent import ImagiAgentService
+
+        project = Project.objects.get(pk=project_id)
+        user = get_user_model().objects.get(pk=user_id)
+
+        service = ImagiAgentService()
+        conversation = service.create_conversation(
+            user,
+            service.model,
+            project_id=project_id,
+            mode='agent',
+            title='Initial build',
+        )
+
+        result = service.process_agent(
+            user_input=build_initial_prompt(project.name, project.description),
+            user=user,
+            project_id=project_id,
+            conversation_id=conversation.id,
+        )
+
+        if result.get('success'):
+            Project.objects.filter(pk=project_id).update(
+                generation_status='completed',
+                last_generated_at=timezone.now(),
+            )
+            logger.info(
+                "Initial AI build completed for project %s (files changed: %s)",
+                project_id,
+                result.get('files_changed'),
+            )
+        else:
+            Project.objects.filter(pk=project_id).update(generation_status='failed')
+            logger.error(
+                "Initial AI build failed for project %s: %s",
+                project_id,
+                result.get('error'),
+            )
+    except Exception:
+        logger.exception("Initial AI build crashed for project %s", project_id)
+        try:
+            Project.objects.filter(pk=project_id).update(generation_status='failed')
+        except Exception:
+            pass
+    finally:
+        close_old_connections()

--- a/backend/django/apps/Products/Imagi/ProjectManager/services/project_creation_service.py
+++ b/backend/django/apps/Products/Imagi/ProjectManager/services/project_creation_service.py
@@ -483,10 +483,13 @@ class ProjectCreationService:
             if not manage_py_found:
                 logger.warning(f"manage.py not found in project structure, using project root: {inner_project_dir}")
             
-            # Mark the project as initialized
+            # Mark the project as initialized. The generation_status field is
+            # owned by the initial AI build once one has started ('generating'
+            # -> 'completed'/'failed'), so only claim it when still pending.
             project.is_initialized = True
             project.updated_at = timezone.now()
-            project.generation_status = 'completed'
+            if project.generation_status == 'pending':
+                project.generation_status = 'completed'
             project.save()
             
             logger.info(f"Project {project.name} (ID: {project.id}) successfully initialized")

--- a/backend/django/apps/Products/Imagi/ProjectManager/tests.py
+++ b/backend/django/apps/Products/Imagi/ProjectManager/tests.py
@@ -27,6 +27,13 @@ from apps.Products.Imagi.ProjectManager.services.project_management_service impo
 
 User = get_user_model()
 
+# A business description long enough to pass the create serializer's
+# MIN_DESCRIPTION_LENGTH validation (the description seeds the initial AI build).
+VALID_DESCRIPTION = (
+    'A subscription coffee roastery for remote workers. Customers are '
+    'home-office professionals; we sell direct online with monthly plans.'
+)
+
 # A throwaway PROJECTS_ROOT so the services' os.makedirs() calls never touch
 # the real repository. Created once for the module, removed at teardown.
 _TMP_PROJECTS_ROOT = tempfile.mkdtemp(prefix='imagi_pm_tests_')
@@ -94,10 +101,36 @@ class ProjectCreateSerializerTests(APITestCase):
 
         request = type('R', (), {'user': self.user})()
         serializer = ProjectCreateSerializer(
-            data={'name': 'Existing Project'}, context={'request': request}
+            data={'name': 'Existing Project', 'description': VALID_DESCRIPTION},
+            context={'request': request},
         )
         self.assertFalse(serializer.is_valid())
         self.assertIn('name', serializer.errors)
+
+    def test_missing_description_rejected(self):
+        from apps.Products.Imagi.ProjectManager.api.serializers import (
+            ProjectCreateSerializer,
+        )
+
+        request = type('R', (), {'user': self.user})()
+        serializer = ProjectCreateSerializer(
+            data={'name': 'No Description'}, context={'request': request}
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn('description', serializer.errors)
+
+    def test_short_description_rejected(self):
+        from apps.Products.Imagi.ProjectManager.api.serializers import (
+            ProjectCreateSerializer,
+        )
+
+        request = type('R', (), {'user': self.user})()
+        serializer = ProjectCreateSerializer(
+            data={'name': 'Short Description', 'description': 'too short'},
+            context={'request': request},
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn('description', serializer.errors)
 
 
 @override_settings(PROJECTS_ROOT=_TMP_PROJECTS_ROOT)
@@ -153,28 +186,55 @@ class ProjectManagerAPITests(APITestCase):
         names = [p['name'] for p in resp.data['results']]
         self.assertEqual(names, ['Mine One'])
 
+    @patch('apps.Products.Imagi.ProjectManager.api.views.start_initial_build')
     @patch(
         'apps.Products.Imagi.ProjectManager.api.views.ProjectCreationService.create_project'
     )
-    def test_create_project(self, mock_create):
+    def test_create_project(self, mock_create, mock_build):
         mock_create.side_effect = lambda project: project
         resp = self.client.post(
             reverse('project_manager:project-create'),
-            {'name': 'Brand New App', 'description': 'hello'},
+            {'name': 'Brand New App', 'description': VALID_DESCRIPTION},
         )
         self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
         self.assertEqual(resp.data['name'], 'Brand New App')
-        self.assertTrue(
-            Project.objects.filter(user=self.user, name='Brand New App').exists()
-        )
+        project = Project.objects.get(user=self.user, name='Brand New App')
+        self.assertEqual(project.description, VALID_DESCRIPTION)
         mock_create.assert_called_once()
+        # Creation must hand the new project off to the initial AI build.
+        mock_build.assert_called_once()
+        self.assertEqual(mock_build.call_args.args[0].pk, project.pk)
+        self.assertEqual(mock_build.call_args.args[1], self.user)
+
+    @patch(
+        'apps.Products.Imagi.ProjectManager.api.views.start_initial_build',
+        side_effect=RuntimeError('agent unavailable'),
+    )
+    @patch(
+        'apps.Products.Imagi.ProjectManager.api.views.ProjectCreationService.create_project'
+    )
+    def test_create_succeeds_when_initial_build_kickoff_fails(self, mock_create, mock_build):
+        mock_create.side_effect = lambda project: project
+        resp = self.client.post(
+            reverse('project_manager:project-create'),
+            {'name': 'Resilient App', 'description': VALID_DESCRIPTION},
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
 
     def test_create_duplicate_name_returns_400(self):
         Project.objects.create(user=self.user, name='Taken Name')
         resp = self.client.post(
-            reverse('project_manager:project-create'), {'name': 'Taken Name'}
+            reverse('project_manager:project-create'),
+            {'name': 'Taken Name', 'description': VALID_DESCRIPTION},
         )
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_without_description_returns_400(self):
+        resp = self.client.post(
+            reverse('project_manager:project-create'), {'name': 'No Description'}
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('description', resp.data)
 
     @patch(
         'apps.Products.Imagi.ProjectManager.api.views.ProjectCreationService.create_project'
@@ -185,7 +245,7 @@ class ProjectManagerAPITests(APITestCase):
         mock_create.side_effect = Exception('secret path /srv/imagi/secret')
         resp = self.client.post(
             reverse('project_manager:project-create'),
-            {'name': 'Rollback Me', 'description': ''},
+            {'name': 'Rollback Me', 'description': VALID_DESCRIPTION},
         )
         self.assertEqual(resp.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
         self.assertNotIn('secret path', str(resp.data))
@@ -262,3 +322,80 @@ class ProjectManagerAPITests(APITestCase):
         self.assertTrue(resp.data['success'])
         project.refresh_from_db()
         self.assertTrue(project.is_initialized)
+
+
+@override_settings(PROJECTS_ROOT=_TMP_PROJECTS_ROOT)
+class InitialBuildServiceTests(TestCase):
+    """Tests for the initial AI build kicked off at project creation."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username='owner', password='pw123456')
+        self.project = Project.objects.create(
+            user=self.user, name='Beanline', description=VALID_DESCRIPTION
+        )
+
+    def test_skips_without_api_key(self):
+        from apps.Products.Imagi.ProjectManager.services import initial_build_service
+
+        with patch(
+            'apps.Products.Imagi.Agents.services.base_agent.OPENAI_API_KEY', None
+        ):
+            started = initial_build_service.start_initial_build(self.project, self.user)
+        self.assertFalse(started)
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.generation_status, 'pending')
+
+    def test_marks_generating_and_spawns_thread(self):
+        from apps.Products.Imagi.ProjectManager.services import initial_build_service
+
+        with patch(
+            'apps.Products.Imagi.Agents.services.base_agent.OPENAI_API_KEY', 'test-key'
+        ), patch.object(initial_build_service.threading, 'Thread') as mock_thread:
+            started = initial_build_service.start_initial_build(self.project, self.user)
+        self.assertTrue(started)
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.generation_status, 'generating')
+        mock_thread.assert_called_once()
+        mock_thread.return_value.start.assert_called_once()
+
+    def _run_with_agent_result(self, result):
+        from unittest.mock import Mock
+        from apps.Products.Imagi.ProjectManager.services import initial_build_service
+
+        fake_service = Mock()
+        fake_service.model = 'gpt-5.6-sol'
+        fake_service.create_conversation.return_value = Mock(id=42)
+        fake_service.process_agent.return_value = result
+
+        with patch(
+            'apps.Products.Imagi.Agents.services.base_agent.ImagiAgentService',
+            return_value=fake_service,
+        ):
+            initial_build_service._run_initial_build(self.project.pk, self.user.pk)
+        return fake_service
+
+    def test_run_success_marks_completed_and_prompts_with_business_details(self):
+        fake_service = self._run_with_agent_result(
+            {'success': True, 'files_changed': ['frontend/vuejs/src/apps/home/views/Home.vue']}
+        )
+
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.generation_status, 'completed')
+        self.assertIsNotNone(self.project.last_generated_at)
+
+        # The prompt must carry the business name and description into the agent.
+        prompt = fake_service.process_agent.call_args.kwargs['user_input']
+        self.assertIn('Beanline', prompt)
+        self.assertIn('coffee roastery', prompt)
+        fake_service.create_conversation.assert_called_once_with(
+            self.user,
+            'gpt-5.6-sol',
+            project_id=self.project.pk,
+            mode='agent',
+            title='Initial build',
+        )
+
+    def test_run_failure_marks_failed(self):
+        self._run_with_agent_result({'success': False, 'error': 'model error'})
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.generation_status, 'failed')

--- a/frontend/vuejs/src/apps/products/imagi/components/organisms/hub/ToolCategoryCard.vue
+++ b/frontend/vuejs/src/apps/products/imagi/components/organisms/hub/ToolCategoryCard.vue
@@ -26,7 +26,15 @@
         <i :class="['fas', tool.icon, accent.iconText]" class="text-xl"></i>
       </div>
       <span
-        v-if="tool.status === 'available'"
+        v-if="isBuilding"
+        class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-[11px] font-semibold uppercase tracking-[0.14em] transition-colors duration-300"
+        :class="accent.badge"
+      >
+        <span class="w-3 h-3 rounded-full border-2 border-current border-t-transparent animate-spin"></span>
+        AI building
+      </span>
+      <span
+        v-else-if="tool.status === 'available'"
         class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-[11px] font-semibold uppercase tracking-[0.14em] transition-colors duration-300"
         :class="accent.badge"
       >
@@ -47,7 +55,7 @@
         {{ tool.name }}
       </h3>
       <p class="text-sm text-blue-950/70 dark:text-blue-100/70 leading-snug transition-colors duration-300">
-        {{ tool.tagline }}
+        {{ isBuilding ? 'Imagi is building the first version of your app from your business description…' : tool.tagline }}
       </p>
     </div>
 
@@ -70,9 +78,13 @@ import { accentClasses, type BusinessTool } from '../../../utils/businessTools'
 const props = defineProps<{
   tool: BusinessTool
   projectSlug: string
+  /** The project's generation_status; drives the Build card's "AI building" state. */
+  buildStatus?: 'pending' | 'generating' | 'completed' | 'failed' | null
 }>()
 
 const accent = computed(() => accentClasses[props.tool.accent])
+
+const isBuilding = computed(() => props.tool.id === 'build' && props.buildStatus === 'generating')
 
 const target = computed<RouteLocationRaw>(() => {
   // "Build" points at the real workspace; everything else uses the generic

--- a/frontend/vuejs/src/apps/products/imagi/services/projectService.ts
+++ b/frontend/vuejs/src/apps/products/imagi/services/projectService.ts
@@ -284,6 +284,20 @@ export const ProjectService = {
   },
 
   /**
+   * Fetch a project's status, including the generation_status that tracks
+   * the initial AI build ('pending' | 'generating' | 'completed' | 'failed')
+   */
+  async getProjectStatus(projectId: string): Promise<{
+    id: number
+    name: string
+    is_initialized: boolean
+    generation_status: 'pending' | 'generating' | 'completed' | 'failed'
+  }> {
+    const response = await api.get(`/v1/project-manager/projects/${projectId}/status/`)
+    return response.data
+  },
+
+  /**
    * Format an error object or string into a readable message
    * 
    * @param error - The error to format

--- a/frontend/vuejs/src/apps/products/imagi/views/ProjectHub.vue
+++ b/frontend/vuejs/src/apps/products/imagi/views/ProjectHub.vue
@@ -77,6 +77,7 @@
                   :key="tool.id"
                   :tool="tool"
                   :project-slug="projectSlug"
+                  :build-status="buildStatus"
                 />
               </div>
             </section>
@@ -88,9 +89,10 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 import { DefaultLayout } from '@/shared/layouts'
 import { useProjectStore } from '../stores/projectStore'
+import { ProjectService } from '../services/projectService'
 import { useAuthStore } from '@/shared/stores/auth'
 import { ToolCategoryCard } from '../components/organisms/hub'
 import { businessTools } from '../utils/businessTools'
@@ -135,4 +137,56 @@ onMounted(loadProject)
 
 // Reload if the route param changes (navigating between projects).
 watch(() => props.projectName, loadProject)
+
+// --- Initial AI build status ---
+// Right after creation the backend runs the coding agent against the business
+// description in the background. Poll the status endpoint while that build is
+// in progress so the Build card can show it, and stop as soon as it settles.
+const BUILD_STATUS_POLL_MS = 5000
+const buildStatus = ref<'pending' | 'generating' | 'completed' | 'failed' | null>(null)
+let buildStatusTimer: ReturnType<typeof setInterval> | null = null
+
+function stopBuildStatusPolling() {
+  if (buildStatusTimer) {
+    clearInterval(buildStatusTimer)
+    buildStatusTimer = null
+  }
+}
+
+async function refreshBuildStatus() {
+  const projectId = project.value?.id
+  if (!projectId) return
+  try {
+    const status = await ProjectService.getProjectStatus(String(projectId))
+    buildStatus.value = status.generation_status
+    if (status.generation_status !== 'generating') {
+      stopBuildStatusPolling()
+    }
+  } catch (error) {
+    console.debug('Failed to fetch build status:', error)
+    stopBuildStatusPolling()
+  }
+}
+
+function startBuildStatusPolling() {
+  stopBuildStatusPolling()
+  refreshBuildStatus()
+  buildStatusTimer = setInterval(refreshBuildStatus, BUILD_STATUS_POLL_MS)
+}
+
+// (Re)start polling whenever the hub resolves a project.
+watch(
+  () => project.value?.id,
+  (projectId) => {
+    buildStatus.value = null
+    if (projectId) {
+      startBuildStatusPolling()
+    } else {
+      stopBuildStatusPolling()
+    }
+  },
+  { immediate: true }
+)
+
+onBeforeUnmount(stopBuildStatusPolling)
 </script>

--- a/frontend/vuejs/src/apps/products/imagi/views/Projects.vue
+++ b/frontend/vuejs/src/apps/products/imagi/views/Projects.vue
@@ -75,32 +75,35 @@
                 <div class="mb-5 flex-shrink-0">
                   <p class="inline-flex items-center px-3 py-1 rounded-full border border-blue-200/70 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 text-xs font-semibold text-blue-700 dark:text-blue-300 uppercase tracking-[0.18em] mb-3 transition-colors duration-300">New Project</p>
                   <h2 class="text-2xl font-semibold text-blue-950 dark:text-white mb-2 transition-colors duration-300">Create a Project</h2>
-                  <p class="text-sm text-blue-950/70 dark:text-blue-100/70 transition-colors duration-300">Start a new business — build your product, then sell, market, and run it.</p>
+                  <p class="text-sm text-blue-950/70 dark:text-blue-100/70 transition-colors duration-300">Start a new business — describe it, and Imagi builds the first version of your app.</p>
                 </div>
 
                 <!-- Create Form -->
                 <div class="flex-1 flex flex-col space-y-4 min-h-0">
-                  <!-- Project Name Input -->
+                  <!-- Business Name Input -->
                   <div class="flex-shrink-0">
-                    <label class="block text-sm font-medium text-blue-950/80 dark:text-blue-100/80 mb-2 transition-colors duration-300">Project Name</label>
+                    <label class="block text-sm font-medium text-blue-950/80 dark:text-blue-100/80 mb-2 transition-colors duration-300">Business Name</label>
                     <input
                       v-model="newProjectName"
                       type="text"
-                      placeholder="Enter project name..."
+                      placeholder="Enter your business name..."
                       class="w-full px-4 py-3 bg-white dark:bg-white/[0.04] border border-blue-200/70 dark:border-white/[0.12] focus:border-blue-400 dark:focus:border-blue-300/50 rounded-xl text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-white/40 transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed"
                       style="outline: none !important;"
                       :disabled="isCreating"
                     >
                   </div>
 
-                  <!-- Project Description Input -->
+                  <!-- Business Description Input -->
                   <div class="flex-1 flex flex-col min-h-0">
-                    <label class="block text-sm font-medium text-blue-950/80 dark:text-blue-100/80 mb-2 flex-shrink-0 transition-colors duration-300">
-                      Description <span class="text-blue-950/40 dark:text-white/40">(optional)</span>
+                    <label class="block text-sm font-medium text-blue-950/80 dark:text-blue-100/80 mb-1 flex-shrink-0 transition-colors duration-300">
+                      Business Description
                     </label>
+                    <p class="text-xs text-blue-950/50 dark:text-blue-100/50 mb-2 flex-shrink-0 transition-colors duration-300">
+                      Imagi's AI uses this to build the first version of your app.
+                    </p>
                     <textarea
                       v-model="newProjectDescription"
-                      placeholder="Brief description of your project..."
+                      placeholder="What does your business do? Who are its customers? What does the market look like, and how will you sell?"
                       class="w-full flex-1 min-h-[80px] px-4 py-3 bg-white dark:bg-white/[0.04] border border-blue-200/70 dark:border-white/[0.12] focus:border-blue-400 dark:focus:border-blue-300/50 rounded-xl text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-white/40 transition-all duration-300 resize-none disabled:opacity-50 disabled:cursor-not-allowed"
                       style="outline: none !important;"
                       :disabled="isCreating"
@@ -111,7 +114,7 @@
                   <div class="flex-shrink-0 pt-1">
                     <button
                       @click="createProject"
-                      :disabled="!newProjectName?.trim() || isCreating"
+                      :disabled="!canCreate || isCreating"
                       class="btn-3d btn-accent group relative w-full inline-flex items-center justify-center gap-3 px-8 py-3.5 text-blue-950 rounded-full font-medium text-base overflow-hidden border border-white/60 dark:border-white/30 disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       <span class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/70 to-transparent"></span>
@@ -288,6 +291,15 @@ const { confirm } = confirmModal
 const newProjectName = ref('')
 const newProjectDescription = ref('')
 const isCreating = ref(false)
+
+// The description seeds the initial AI build, so require enough signal to
+// work with. Keep in sync with MIN_DESCRIPTION_LENGTH on the backend
+// (ProjectManager/api/serializers.py).
+const MIN_DESCRIPTION_LENGTH = 20
+const canCreate = computed(() =>
+  Boolean(newProjectName.value.trim()) &&
+  newProjectDescription.value.trim().length >= MIN_DESCRIPTION_LENGTH
+)
 const isInitializing = ref(true)
 const deletedProjectMessage = ref('')
 let deleteMessageTimeout: ReturnType<typeof setTimeout> | null = null
@@ -377,15 +389,24 @@ async function createProject() {
     return
   }
   
-  // Validate project name
+  // Validate business name
   if (!newProjectName.value.trim()) {
     showNotification({
-      message: 'Project name cannot be empty',
+      message: 'Business name cannot be empty',
       type: 'error'
     })
     return
   }
-  
+
+  // Validate business description — it seeds the initial AI build
+  if (newProjectDescription.value.trim().length < MIN_DESCRIPTION_LENGTH) {
+    showNotification({
+      message: 'Please describe your business — what it does, who its customers are, and how it will sell. Imagi uses this to build the first version of your app.',
+      type: 'error'
+    })
+    return
+  }
+
   isCreating.value = true
   
   try {


### PR DESCRIPTION
Project creation now asks for a business name and a required business
description (what it does, who its customers are, market and sales
approach). On create, the backend hands the name + description to the
coding agent as the first build prompt and runs it in a background
thread, so the workspace already has a tailored starting point (and an
"Initial build" conversation) when the user enters build mode.

- Creation form: "Business Name" label, required description with
  guiding placeholder and helper text; button gated on both fields
- ProjectCreateSerializer: description required, min 20 chars
- New initial_build_service: marks generation_status 'generating',
  runs process_agent in a daemon thread, records completed/failed and
  last_generated_at; skipped cleanly when OPENAI_KEY is unset
- initialize_project no longer clobbers a status owned by a running
  initial build
- Tests for the new validation, kickoff wiring, and build service

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011SwDnfjYUWzHK3VXv33P9G