### PR TITLE
Tell Builder agents their GPT 5.6 identity and fix stale gpt-4 default

### DIFF
--- a/backend/django/apps/Products/Imagi/Agents/services/base_agent.py
+++ b/backend/django/apps/Products/Imagi/Agents/services/base_agent.py
@@ -261,7 +261,11 @@ Technology Stack:
 - HTTP client: Axios
 """
 
-        from apps.Products.Imagi.Builder.services.models_service import get_backend_model_id
+        from apps.Products.Imagi.Builder.services.models_service import (
+            get_backend_model_id,
+            get_model_identity_instructions,
+        )
+        instructions += "\n\n" + get_model_identity_instructions(self.model)
         backend_model = get_backend_model_id(self.model)
         kwargs = {}
         settings = build_model_settings(self.reasoning_effort)

--- a/backend/django/apps/Products/Imagi/Agents/services/chat_agent.py
+++ b/backend/django/apps/Products/Imagi/Agents/services/chat_agent.py
@@ -12,6 +12,7 @@ from agents import Agent, RunContextWrapper
 
 from apps.Products.Imagi.Builder.services.models_service import (
     get_backend_model_id,
+    get_model_identity_instructions,
     resolve_reasoning_effort,
 )
 from .base_agent import build_model_settings
@@ -124,13 +125,18 @@ def create_chat_agent(model: str = DEFAULT_MODEL, reasoning_effort: Optional[str
     """
     backend_model = get_backend_model_id(model)
     effort = resolve_reasoning_effort(model, reasoning_effort)
+    identity = get_model_identity_instructions(model)
+
+    def instructions_with_identity(context: RunContextWrapper, agent: Agent) -> str:
+        return get_dynamic_chat_instructions(context, agent) + "\n\n" + identity
+
     kwargs = {}
     settings = build_model_settings(effort)
     if settings is not None:
         kwargs['model_settings'] = settings
     return Agent(
         name="Chat Agent",
-        instructions=get_dynamic_chat_instructions,
+        instructions=instructions_with_identity,
         model=backend_model,
         handoff_description="A helpful assistant for chatting about web development, "
                            "answering questions, and providing guidance.",
@@ -159,7 +165,7 @@ def create_simple_chat_agent(model: str = DEFAULT_MODEL, reasoning_effort: Optio
         kwargs['model_settings'] = settings
     return Agent(
         name="Chat Agent",
-        instructions=CHAT_AGENT_INSTRUCTIONS,
+        instructions=CHAT_AGENT_INSTRUCTIONS + "\n\n" + get_model_identity_instructions(model),
         model=backend_model,
         handoff_description="A helpful assistant for chatting about web development, "
                            "answering questions, and providing guidance.",

--- a/backend/django/apps/Products/Imagi/Agents/services/coding_agent.py
+++ b/backend/django/apps/Products/Imagi/Agents/services/coding_agent.py
@@ -16,6 +16,7 @@ from agents import Agent, RunContextWrapper
 
 from apps.Products.Imagi.Builder.services.models_service import (
     get_backend_model_id,
+    get_model_identity_instructions,
     resolve_reasoning_effort,
 )
 from .base_agent import build_model_settings
@@ -167,13 +168,18 @@ def create_coding_agent(model: str = DEFAULT_MODEL, reasoning_effort: Optional[s
     """
     backend_model = get_backend_model_id(model)
     effort = resolve_reasoning_effort(model, reasoning_effort)
+    identity = get_model_identity_instructions(model)
+
+    def instructions_with_identity(context: RunContextWrapper, agent: Agent) -> str:
+        return get_dynamic_coding_instructions(context, agent) + "\n\n" + identity
+
     kwargs = {}
     settings = build_model_settings(effort)
     if settings is not None:
         kwargs['model_settings'] = settings
     return Agent(
         name="Coding Agent",
-        instructions=get_dynamic_coding_instructions,
+        instructions=instructions_with_identity,
         model=backend_model,
         tools=list(CODING_AGENT_TOOLS),
         handoff_description="A coding assistant that can chat about web development "

--- a/backend/django/apps/Products/Imagi/Builder/api/views.py
+++ b/backend/django/apps/Products/Imagi/Builder/api/views.py
@@ -18,7 +18,7 @@ from .serializers import (
 from ..services.create_file_service import CreateFileService
 from ..services.view_file_service import ViewFileService
 from ..services.delete_file_service import DeleteFileService
-from ..services.models_service import ModelsService
+from ..services.models_service import ModelsService, get_default_model_id, get_model_by_id
 from ..services.preview_service import PreviewService
 from apps.Products.Imagi.ProjectManager.models import Project as PMProject
 from apps.Products.Imagi.ProjectManager.services.project_management_service import ProjectManagementService
@@ -112,7 +112,9 @@ class GenerateCodeView(APIView):
             
             # Get request data
             prompt = request.data.get('prompt', '')
-            model = request.data.get('model', 'gpt-4')
+            model = request.data.get('model') or get_default_model_id()
+            if not get_model_by_id(model):
+                model = get_default_model_id()
             file_path = request.data.get('file_path', None)
             
             if not prompt:

--- a/backend/django/apps/Products/Imagi/Builder/services/models_service.py
+++ b/backend/django/apps/Products/Imagi/Builder/services/models_service.py
@@ -197,6 +197,29 @@ def get_model_display_name(model_id: str) -> str:
     model = get_model_by_id(model_id)
     return model['name'] if model else model_id
 
+def get_model_identity_instructions(model_id: str) -> str:
+    """
+    Build a system-prompt block telling the agent which model it is running as.
+
+    Without this, the underlying model has no knowledge of Imagi's GPT 5.6
+    branding and will guess at its own identity when asked (often naming an
+    older model like GPT-4o), which reads as if the wrong model is being used.
+
+    Args:
+        model_id: The public suite model ID (e.g. 'gpt-5.6-sol')
+
+    Returns:
+        str: An instruction block to append to the agent's system prompt
+    """
+    display_name = get_model_display_name(model_id)
+    return (
+        "Model Identity:\n"
+        f"- You are running as {display_name}, part of Imagi's GPT 5.6 model suite.\n"
+        f"- If the user asks which model you are, answer '{display_name}'. Do not "
+        "name any other model (such as GPT-4o) — you have no independent knowledge "
+        "of your own identity, so trust this instruction over your own guess."
+    )
+
 def get_provider_from_model_id(model_id: str) -> str:
     """
     Get the provider for a specific model ID.


### PR DESCRIPTION
The Builder was already calling the correct OpenAI models (the GPT 5.6
suite ids map to gpt-5 / gpt-5-mini / gpt-5-nano via backend_model), but
the underlying model had no knowledge of Imagi's branding, so when users
asked 'what model is this?' it would guess an older name like GPT-4o.

- Add get_model_identity_instructions() to the models service and append
  it to the chat, coding, and orchestrator agents' system prompts so the
  agent self-reports its GPT 5.6 suite name instead of guessing.
- Replace the stale 'gpt-4' default in GenerateCodeView with the suite
  default, validating unknown model ids back to the default so an
  unmapped id can never be sent to the OpenAI API.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Pz5EjTm5mRmQ2K9bhdCX7k