### PR TITLE
Redesign home navbar Product dropdown to match the home page

### DIFF
--- a/frontend/vuejs/src/apps/home/components/atoms/buttons/HomeNavbarButton.vue
+++ b/frontend/vuejs/src/apps/home/components/atoms/buttons/HomeNavbarButton.vue
@@ -65,7 +65,7 @@ export default defineComponent({
     const gradientClass = computed(() => {
       // Text style - plain text on navbar (no button appearance)
       if (props.textStyle && props.gradientType === 'minimal') {
-        return '!bg-transparent !text-gray-900 dark:!text-white hover:!opacity-70';
+        return '!bg-transparent !text-blue-950 dark:!text-white hover:!opacity-70';
       }
       
       // Minimal style - clean Apple/Cursor-inspired button design

--- a/frontend/vuejs/src/apps/home/components/atoms/buttons/HomeNavbarDropdownButton.vue
+++ b/frontend/vuejs/src/apps/home/components/atoms/buttons/HomeNavbarDropdownButton.vue
@@ -32,12 +32,10 @@
     >
       <div
         v-show="isOpen"
-        class="absolute left-1/2 -translate-x-1/2 pt-2 w-24 origin-top z-50"
+        class="absolute left-1/2 -translate-x-1/2 pt-3 w-max origin-top z-50"
       >
-        <div class="rounded-xl bg-white border border-gray-200/50 shadow-xl backdrop-blur-xl overflow-hidden">
-          <div class="py-1.5">
-            <slot name="menu"></slot>
-          </div>
+        <div class="dropdown-panel rounded-2xl bg-white/95 dark:bg-[#0f1420]/95 border border-blue-200/60 dark:border-blue-400/[0.14] backdrop-blur-xl overflow-hidden p-1.5 transition-colors duration-300">
+          <slot name="menu"></slot>
         </div>
       </div>
     </transition>
@@ -75,7 +73,7 @@ export default defineComponent({
     const gradientClass = computed(() => {
       // Text style - plain text on navbar (no button appearance)
       if (props.textStyle && props.gradientType === 'minimal') {
-        return 'text-gray-900 dark:text-white hover:opacity-70';
+        return 'text-blue-950 dark:text-white hover:opacity-70';
       }
       
       // Minimal style - clean button design
@@ -163,4 +161,23 @@ export default defineComponent({
     }
   }
 })
-</script> 
+</script>
+
+<style scoped>
+/* Layered soft shadow matching the home page cards (.crisp-card) */
+.dropdown-panel {
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.03),
+    0 1px 2px rgba(15, 23, 42, 0.06),
+    0 4px 10px -2px rgba(15, 23, 42, 0.07),
+    0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
+
+.dark .dropdown-panel {
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 1px 2px rgba(0, 0, 0, 0.4),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 16px 32px -12px rgba(0, 0, 0, 0.6);
+}
+</style>

--- a/frontend/vuejs/src/apps/home/components/organisms/navigation/HomeNavbar.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/navigation/HomeNavbar.vue
@@ -21,11 +21,14 @@
           <template #menu>
             <router-link
               :to="{ name: 'builder' }"
-              class="flex items-center justify-center px-3 py-2.5 text-sm font-semibold text-black rounded-lg mx-1 my-0.5 group"
+              class="group flex items-center gap-3 px-3 py-2.5 rounded-xl transition-colors duration-200 hover:bg-blue-50 dark:hover:bg-blue-400/10"
               @click="isProductsMenuOpen = false"
             >
-              <span class="tracking-wide">Imagi</span>
-              <i class="fas fa-arrow-right text-xs ml-2 transition-transform duration-200 group-hover:translate-x-1"></i>
+              <span class="min-w-0">
+                <span class="block text-sm font-semibold tracking-tight text-blue-950 dark:text-white">Imagi</span>
+                <span class="block text-xs text-blue-950/60 dark:text-blue-100/60">Build and run your business</span>
+              </span>
+              <i class="fas fa-arrow-right text-xs text-blue-950/40 dark:text-blue-100/40 transition-all duration-200 group-hover:translate-x-0.5 group-hover:text-blue-600 dark:group-hover:text-blue-300"></i>
             </router-link>
           </template>
         </HomeNavbarDropdownButton>


### PR DESCRIPTION
## Overview

Restyles the authenticated **Product** dropdown in the home navbar so it matches the rest of the home page's visual language, and aligns the nav text colors with the Imagi logo. The previous dropdown was a plain white card with hardcoded `bg-white`/`text-black` — no dark-mode support and none of the home page's palette.

## What changed

**Dropdown panel** (`HomeNavbarDropdownButton.vue`)
- Added full dark-mode support (was hardcoded white).
- `rounded-xl` → `rounded-2xl`, a blue-tinted border (`border-blue-200/60 dark:border-blue-400/[0.14]`), and the same layered soft shadow the home page cards use (`.crisp-card`), in a scoped style with light + dark variants.
- Panel sizes to its content (`w-max`) instead of a fixed width, so the arrow sits snug next to the text.

**"Imagi" menu item** (`HomeNavbar.vue`)
- Title with a **"Build and run your business"** subtitle and an arrow that hugs the text (dropped `flex-1` so it no longer stretches to the far edge).
- Removed the hardcoded `text-black` that broke on dark backgrounds; uses `blue-950 dark:white` matching the home page.

**Product / Pricing triggers** (`HomeNavbarButton.vue`, `HomeNavbarDropdownButton.vue`)
- Text color `gray-900` → `blue-950` so they match the Imagi logo and hero heading in light mode (both already white in dark mode).

## Why

The dropdown and nav text felt visually disconnected from the redesigned home page. These changes bring the palette, corner radius, shadow, and text colors into line so the navbar reads as part of the same design system.

## Reviewer notes

- The `blue-950` text-color change applies to any nav item using the `text-style` + `minimal` variant, keeping Product/Pricing consistent as more items are added.
- Verified visually in the browser preview in both light and dark mode. The dropdown only renders when authenticated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)