### PR TITLE
Fix stale backend DNS in frontend nginx after Railway redeploys

### DIFF
--- a/frontend/vuejs/Dockerfile
+++ b/frontend/vuejs/Dockerfile
@@ -14,6 +14,8 @@ FROM nginx:stable-alpine
 
 COPY --from=builder /app/dist /usr/share/nginx/html
 COPY frontend/vuejs/nginx.conf /etc/nginx/conf.d/default.conf
+COPY frontend/vuejs/docker-entrypoint.d/10-set-resolver.sh /docker-entrypoint.d/10-set-resolver.sh
+RUN chmod +x /docker-entrypoint.d/10-set-resolver.sh
 
 EXPOSE 80
 

--- a/frontend/vuejs/docker-entrypoint.d/10-set-resolver.sh
+++ b/frontend/vuejs/docker-entrypoint.d/10-set-resolver.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Generate an nginx resolver config from the container's DNS settings.
+# Required because nginx.conf uses a variable in proxy_pass, which makes
+# nginx re-resolve backend.railway.internal per request instead of caching
+# the IP at startup (Railway assigns a new private IP on every redeploy).
+set -e
+
+ns=$(awk '/^nameserver/ {print $2; exit}' /etc/resolv.conf)
+
+# Bracket IPv6 addresses for nginx (Railway's private DNS is IPv6)
+case "$ns" in
+  *:*) ns="[$ns]" ;;
+esac
+
+echo "resolver $ns valid=10s;" > /etc/nginx/conf.d/00-resolver.conf
+echo "10-set-resolver.sh: using resolver $ns"

--- a/frontend/vuejs/nginx.conf
+++ b/frontend/vuejs/nginx.conf
@@ -5,9 +5,13 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # Proxy API requests to Django backend via Railway private network
+    # Proxy API requests to Django backend via Railway private network.
+    # Using a variable forces nginx to re-resolve the hostname per request
+    # (honoring the resolver's TTL) instead of caching the IP at startup —
+    # Railway assigns a new private IP on every backend redeploy.
     location /api/ {
-        proxy_pass http://backend.railway.internal:8000;
+        set $backend_upstream "http://backend.railway.internal:8000";
+        proxy_pass $backend_upstream;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Problem

Every push to main triggers a Railway redeploy of both services, and afterwards the frontend can't reach the backend over the private network (health check fails) until the frontend is manually redeployed.

**Root cause:** `nginx.conf` used a literal hostname in `proxy_pass`, so nginx resolved `backend.railway.internal` once at startup and cached the IP forever. Railway assigns a new private IPv6 address to the backend container on every redeploy, leaving the frontend proxying to a dead IP.

## Fix

- **`nginx.conf`** — move the upstream into a variable (`set $backend_upstream ...; proxy_pass $backend_upstream;`). With a variable, nginx re-resolves the hostname per request (honoring the resolver TTL) instead of caching at startup.
- **`docker-entrypoint.d/10-set-resolver.sh`** (new) — variable-based `proxy_pass` requires a `resolver` directive. This startup script reads the DNS server from the container's `/etc/resolv.conf` and writes `resolver <addr> valid=10s;` into `conf.d`, avoiding a hardcoded Railway DNS address. The nginx base image runs `/docker-entrypoint.d/*.sh` automatically before starting.
- **`Dockerfile`** — copies the script into the image.

## Notes for reviewer

- This also fixes the deploy-order race: if the frontend boots before the backend's DNS record exists, requests recover as soon as DNS resolves — no restart needed.
- Proxy behavior is otherwise unchanged: `proxy_pass` without a URI part forwards the original request URI exactly as before.
- Real verification happens on the Railway deploy of this PR — after it lands, subsequent pushes should no longer need a manual frontend redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)