### PR TITLE
Fix Railway deploy crash: make Build initial migration safe against pre-existing tables

### DIFF
--- a/backend/django/apps/Imagi/Build/migrations/0002_remove_stale_migration_records.py
+++ b/backend/django/apps/Imagi/Build/migrations/0002_remove_stale_migration_records.py
@@ -1,0 +1,29 @@
+"""
+Remove stale django_migrations rows left behind by the old Agents and
+Builder apps, which were merged into Build. The apps no longer exist, so
+their migration records are dead weight. Safe to run anywhere: databases
+that never had those apps simply delete zero rows.
+"""
+
+from django.db import migrations
+
+OLD_APP_LABELS = ('Agents', 'Builder')
+
+
+def remove_stale_records(apps, schema_editor):
+    with schema_editor.connection.cursor() as cursor:
+        cursor.execute(
+            'DELETE FROM django_migrations WHERE app IN (%s, %s)',
+            OLD_APP_LABELS,
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('Build', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(remove_stale_records, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
## Problem

Railway deploys crash at container startup: `python manage.py migrate` fails with

```
psycopg2.errors.DuplicateTable: relation "Agents_agentconversation" already exists
```

so gunicorn never starts and every healthcheck fails.

The recent backend restructure merged the old `Agents` and `Builder` apps into the new `Build` app, which keeps the old tables via `db_table` overrides (`Agents_*`, `Builder_*`). Since `Build` is a brand-new app label, Django has no record of its initial migration being applied and re-issues `CREATE TABLE` for tables already present in the production database.

## Changes

- **`Build/migrations/0001_initial.py`** — wraps all `CreateModel` operations in `migrations.SeparateDatabaseAndState` (state-only, no DDL), followed by a guarded `RunPython` step that creates each table only if it's missing. Production records the migration without touching the schema; fresh databases still get the full set of tables.
- **`Build/migrations/0002_remove_stale_migration_records.py`** — data migration that deletes the leftover `Agents` and `Builder` rows from `django_migrations`. Idempotent: databases that never had those apps delete zero rows.

## Verification

Tested locally against both scenarios:

1. **Fresh database** — `migrate` creates all seven `Agents_*`/`Builder_*` tables.
2. **Production simulation** (tables exist, no `Build` row in `django_migrations`) — `Applying Build.0001_initial... OK`, the exact case that previously raised `DuplicateTable`. Stale `Agents`/`Builder` records were removed by 0002 while Build's own records stayed intact.
3. `makemigrations --check` reports no model/migration drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Ru7MpsTtYeJkgBivLNzXD

---
_Generated by [Claude Code](https://claude.ai/code/session_015Ru7MpsTtYeJkgBivLNzXD)_