### PR TITLE
Fix intermittent iOS/iPad scroll trapping by keeping the window as the sole scroller

### DIFF
--- a/frontend/vuejs/src/assets/main.css
+++ b/frontend/vuejs/src/assets/main.css
@@ -10,7 +10,15 @@
 html {
   /* Prevent iOS Safari from inflating text when the toolbar state changes. */
   -webkit-text-size-adjust: 100%;
-  scrollbar-width: thin;
+}
+
+/* Firefox-only thin scrollbars. Chrome 121+ also understands scrollbar-width
+   and, when set, ignores the ::-webkit-scrollbar styling below — so only
+   apply it where the webkit pseudo-elements don't exist. */
+@supports not selector(::-webkit-scrollbar) {
+  html {
+    scrollbar-width: thin;
+  }
 }
 
 /* Thin, unobtrusive scrollbars (WebKit browsers). */

--- a/frontend/vuejs/src/assets/main.css
+++ b/frontend/vuejs/src/assets/main.css
@@ -1,0 +1,59 @@
+/*
+ * Global document styles.
+ *
+ * The window/body is the single scroll container for the whole app — no layout
+ * component may introduce a full-page nested scroller (see BaseLayout.vue).
+ * These rules replace the scrollbar/focus utilities that used to live on the
+ * old BaseLayout `overflow-auto` wrapper.
+ */
+
+html {
+  /* Prevent iOS Safari from inflating text when the toolbar state changes. */
+  -webkit-text-size-adjust: 100%;
+  scrollbar-width: thin;
+}
+
+/* Thin, unobtrusive scrollbars (WebKit browsers). */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #d4d4d4; /* gray-300 */
+  border-radius: 0.25rem;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #9ca3af; /* gray-400 */
+}
+
+.dark ::-webkit-scrollbar-thumb {
+  background: #262626; /* dark-700 */
+}
+
+.dark ::-webkit-scrollbar-thumb:hover {
+  background: #404040; /* dark-600 */
+}
+
+/* Consistent keyboard-focus outline across the app. */
+:focus-visible {
+  outline: 2px solid #3b82f6; /* primary-500 */
+  outline-offset: 2px;
+}
+
+/*
+ * On iOS/iPadOS Safari 100vh is the LARGE viewport (toolbar hidden), so
+ * `min-h-screen` sections overflow and jump while the toolbar collapses.
+ * Prefer the dynamic viewport unit where supported so full-height sections
+ * track the visible viewport instead.
+ */
+@supports (min-height: 100dvh) {
+  .min-h-screen {
+    min-height: 100dvh;
+  }
+}

--- a/frontend/vuejs/src/main.ts
+++ b/frontend/vuejs/src/main.ts
@@ -11,6 +11,9 @@ import config from '@/shared/config'
 
 // Import Tailwind styles
 import 'tailwindcss/tailwind.css'
+// Global document styles (single window scroller, scrollbars, focus, dvh fixes).
+// Must come after Tailwind so its .min-h-screen dvh override wins the cascade.
+import '@/assets/main.css'
 
 // Import Font Awesome icons
 import {

--- a/frontend/vuejs/src/router/index.ts
+++ b/frontend/vuejs/src/router/index.ts
@@ -26,8 +26,15 @@ const router = createRouter({
     if (savedPosition) {
       return savedPosition
     }
-    return { top: 0 }
+    return { left: 0, top: 0 }
   }
 })
+
+// The router owns scroll restoration (scrollBehavior above). Left on 'auto',
+// Safari also restores scroll natively on back/forward — racing the SPA render
+// and landing pages on stale offsets with the top of the page cut off.
+if (typeof window !== 'undefined' && 'scrollRestoration' in window.history) {
+  window.history.scrollRestoration = 'manual'
+}
 
 export default router

--- a/frontend/vuejs/src/shared/layouts/BaseLayout.vue
+++ b/frontend/vuejs/src/shared/layouts/BaseLayout.vue
@@ -1,16 +1,13 @@
-<!-- Base layout - Root wrapper for all layouts -->
+<!-- Base layout - Root wrapper for all layouts.
+     IMPORTANT: keep this free of overflow/scroll styles. The window must remain
+     the ONLY scroll container. A nested full-page `overflow-auto` wrapper makes
+     Safari (especially iPadOS/iOS) scroll the wrapper instead of the window,
+     which breaks scroll-to-top on navigation (pages appear pre-scrolled with
+     the hero clipped under the navbar) and traps touch scrolling mid-page.
+     Scrollbar and focus-visible styling lives in src/assets/main.css. -->
 <template>
   <div class="flex flex-col min-h-screen bg-white dark:bg-[#0a0a0a] transition-colors duration-300">
-    <!-- Custom scrollbar and focus styles using arbitrary values -->
-    <div class="overflow-auto
-                [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar]:h-2
-                [&::-webkit-scrollbar-track]:bg-transparent
-                [&::-webkit-scrollbar-thumb]:bg-gray-300 dark:[&::-webkit-scrollbar-thumb]:bg-dark-700 [&::-webkit-scrollbar-thumb]:rounded
-                [&::-webkit-scrollbar-thumb:hover]:bg-gray-400 dark:[&::-webkit-scrollbar-thumb:hover]:bg-dark-600
-                [&_*:focus-visible]:outline-2 [&_*:focus-visible]:outline-primary-500 [&_*:focus-visible]:outline-offset-2
-                [scrollbar-width]:thin">
-      <slot></slot>
-    </div>
+    <slot></slot>
   </div>
 </template>
 


### PR DESCRIPTION
BaseLayout nested the whole app inside an overflow-auto div within a
min-h-screen flex column. Safari resolves that wrapper's height against
the parent's min-height, so pages intermittently scrolled inside the
wrapper instead of the window: the router's scroll-to-top became a no-op
(new pages appeared pre-scrolled with the hero clipped under the fixed
navbar) and touch scrolling could no longer reach the top of the page.

- Remove the nested overflow-auto wrapper; move its scrollbar and
  focus-visible styling to a new global stylesheet (src/assets/main.css)
- Set history.scrollRestoration to manual so Safari's native scroll
  restoration stops racing the router's scrollBehavior on back/forward
- Prefer 100dvh over 100vh for min-h-screen where supported so
  full-height sections track the visible viewport on iOS instead of
  jumping when the Safari toolbar collapses

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YYUPVqjNvxPVKbiYhHPsH9