### PR TITLE
Replace fixed navbar with sticky to stop iPad WebKit render desync

### DIFF
--- a/frontend/vuejs/src/main.ts
+++ b/frontend/vuejs/src/main.ts
@@ -72,3 +72,16 @@ app.component('font-awesome-icon', FontAwesomeIcon)
 
 // Mount app
 app.mount('#app')
+
+// iOS/iPadOS WebKit can restore a page (back-swipe bfcache) with stale
+// compositing/viewport state — content renders clipped or offset until the
+// engine re-composites (the same glitch a tab switch clears). Nudging the
+// scroll position on restore forces that re-composite immediately.
+window.addEventListener('pageshow', (event) => {
+  if (event.persisted) {
+    requestAnimationFrame(() => {
+      window.scrollTo(window.scrollX, window.scrollY + 1)
+      window.scrollTo(window.scrollX, Math.max(0, window.scrollY - 1))
+    })
+  }
+})

--- a/frontend/vuejs/src/shared/components/organisms/navigation/BaseNavbar.vue
+++ b/frontend/vuejs/src/shared/components/organisms/navigation/BaseNavbar.vue
@@ -1,5 +1,11 @@
+<!-- Sticky (not fixed) on purpose: iPadOS/iOS WebKit intermittently renders
+     position:fixed elements with backdrop-filter at stale viewport offsets
+     (content appears squished/clipped under the bar until the tab is
+     re-activated). Sticky participates in layout and is immune. The negative
+     bottom margin cancels the bar's flow height so content still slides
+     underneath it, exactly like the old fixed overlay. -->
 <template>
-  <nav class="crisp-nav fixed w-full z-50 bg-white/80 dark:bg-[#0a0a0a]/80 backdrop-blur-xl border-b border-gray-200/80 dark:border-white/[0.08] transition-colors duration-300">
+  <nav class="crisp-nav sticky top-0 -mb-14 w-full z-50 bg-white/80 dark:bg-[#0a0a0a]/80 backdrop-blur-xl border-b border-gray-200/80 dark:border-white/[0.08] transition-colors duration-300">
     <div class="relative px-6 sm:px-8 lg:px-12" :class="fluid ? 'w-full' : 'max-w-7xl mx-auto'">
       <div class="relative flex items-center h-14">
         <!-- Left section -->
@@ -49,6 +55,9 @@ defineProps({
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
   box-shadow: 0 1px 0 0 rgba(15, 23, 42, 0.02);
+  /* Promote to a compositing layer so WebKit repaints the blurred bar
+     correctly during scroll instead of reusing stale tiles. */
+  transform: translateZ(0);
 }
 
 :global(.dark) .crisp-nav {

--- a/frontend/vuejs/src/shared/layouts/DashboardLayout.vue
+++ b/frontend/vuejs/src/shared/layouts/DashboardLayout.vue
@@ -80,8 +80,10 @@
         :class="[isSidebarCollapsed ? 'ml-16' : (extraWide ? 'ml-[36rem]' : (wide ? 'ml-80' : 'ml-72'))]"
       >
         <!-- Navbar -->
+        <!-- !fixed/!mb-0 override BaseNavbar's sticky -mb-14 default: this bar is
+             offset by the sidebar via left-*, which needs viewport positioning. -->
         <BaseNavbar
-          class="fixed top-0 right-0 z-20 bg-white/80 dark:bg-dark-900/80 backdrop-blur-md border-b border-gray-200 dark:border-dark-800/70 shadow-sm"
+          class="!fixed !mb-0 top-0 right-0 z-20 bg-white/80 dark:bg-dark-900/80 backdrop-blur-md border-b border-gray-200 dark:border-dark-800/70 shadow-sm"
           :class="[isSidebarCollapsed ? 'left-16' : (extraWide ? 'left-[36rem]' : (wide ? 'left-80' : 'left-72'))]"
         >
           <template #left>


### PR DESCRIPTION
## Problem

On iPad (Safari and Chrome — both WebKit), pages intermittently render "squished": the spacing between the navbar and the hero title disappears, the top of the page can't be reached by scrolling, and content looks clipped. Switching to another browser tab and back instantly fixes it **without scrolling** — the tell-tale signature of a WebKit compositing/viewport desync rather than a real scroll offset. Tab reactivation forces WebKit to rebuild its compositing layers, which is exactly what heals the known iPadOS bug where a `position: fixed` header with `backdrop-filter` causes the page to render at a stale viewport offset.

## Fix

- **`BaseNavbar`: `position: fixed` → `position: sticky`** with a negative bottom margin that cancels the bar's flow height, so content still slides underneath the translucent blurred bar exactly like before. Sticky elements participate in layout and never need viewport re-anchoring, making them immune to this WebKit bug.
- **Promote the blurred bar to its own compositing layer** (`transform: translateZ(0)`) so WebKit repaints it during scroll instead of reusing stale tiles.
- **`DashboardLayout`** (docs/builder pages): explicitly keeps its sidebar-offset navbar `!fixed !mb-0` — behavior unchanged there.
- **`main.ts`**: on back/forward-cache restore (iOS back-swipe), nudge the scroll position by 1px to force the same re-composite a tab switch triggers.

## Verification

Playwright checks against the production build at desktop (1440×900), iPad (820×1180, touch), and iPhone (393×852, touch) viewports, on `/`, `/imagi/projects`, and `/docs` — all passing:

- Navbar is sticky, sits at the very top, and stays pinned while scrolling
- Hero/title spacing is pixel-identical to the previous fixed layout
- Scroll reaches the exact top (y=0) after scrolling down
- SPA route changes land at the top of the new page
- No horizontal overflow at any viewport
- Docs (DashboardLayout) navbar still renders `position: fixed` with `margin-bottom: 0`

Screenshots confirmed no visual regression at the top of the page and while scrolled. Type-check and production build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYUPVqjNvxPVKbiYhHPsH9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYUPVqjNvxPVKbiYhHPsH9)_