### PR TITLE
Disable navbar backdrop-blur on iOS WebKit and add deploy build stamp

### DIFF
--- a/frontend/vuejs/Dockerfile
+++ b/frontend/vuejs/Dockerfile
@@ -8,6 +8,8 @@ RUN npm ci
 
 COPY frontend/vuejs/ .
 RUN npm run build-only
+# Deploy identification: exposes the build time at /version.txt
+RUN date -u +"%Y-%m-%dT%H:%M:%SZ" > dist/version.txt
 
 ## Production stage
 FROM nginx:stable-alpine

--- a/frontend/vuejs/env.d.ts
+++ b/frontend/vuejs/env.d.ts
@@ -1,5 +1,8 @@
 /// <reference types="vite/client" />
 
+// Injected at build time via vite.config.ts `define`.
+declare const __BUILD_TIME__: string
+
 declare module '*.vue' {
   import type { DefineComponent } from 'vue'
   const component: DefineComponent<{}, {}, any>

--- a/frontend/vuejs/nginx.conf
+++ b/frontend/vuejs/nginx.conf
@@ -34,6 +34,11 @@ server {
         add_header Cache-Control "no-cache, no-store, must-revalidate";
     }
 
+    # Never cache the deploy marker — it must always reflect the live build
+    location = /version.txt {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+    }
+
     gzip on;
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml image/svg+xml;
     gzip_min_length 1024;

--- a/frontend/vuejs/src/assets/main.css
+++ b/frontend/vuejs/src/assets/main.css
@@ -55,6 +55,28 @@ html {
 }
 
 /*
+ * iOS/iPadOS WebKit (every browser on iPad/iPhone, Chrome included) has
+ * long-standing compositing bugs with backdrop-filter on pinned bars: the
+ * page intermittently renders from stale tiles at a wrong viewport offset —
+ * content looks squished/clipped under the navbar until the engine
+ * re-composites (e.g. after a tab switch). `-webkit-touch-callout` only
+ * exists on iOS WebKit, so this @supports gate targets exactly those
+ * devices: drop the blur there and compensate with a near-opaque background.
+ * Desktop browsers keep the blurred translucent bar.
+ */
+@supports (-webkit-touch-callout: none) {
+  .crisp-nav {
+    -webkit-backdrop-filter: none;
+    backdrop-filter: none;
+    background-color: rgba(255, 255, 255, 0.97);
+  }
+
+  .dark .crisp-nav {
+    background-color: rgba(10, 10, 10, 0.97);
+  }
+}
+
+/*
  * On iOS/iPadOS Safari 100vh is the LARGE viewport (toolbar hidden), so
  * `min-h-screen` sections overflow and jump while the toolbar collapses.
  * Prefer the dynamic viewport unit where supported so full-height sections

--- a/frontend/vuejs/src/main.ts
+++ b/frontend/vuejs/src/main.ts
@@ -73,6 +73,11 @@ app.component('font-awesome-icon', FontAwesomeIcon)
 // Mount app
 app.mount('#app')
 
+// Deploy identification: check the running bundle's build time from any device
+// via the console or `document.documentElement.dataset.build`.
+console.info(`Imagi build: ${__BUILD_TIME__}`)
+document.documentElement.dataset.build = __BUILD_TIME__
+
 // iOS/iPadOS WebKit can restore a page (back-swipe bfcache) with stale
 // compositing/viewport state — content renders clipped or offset until the
 // engine re-composites (the same glitch a tab switch clears). Nudging the

--- a/frontend/vuejs/src/shared/components/organisms/navigation/BaseNavbar.vue
+++ b/frontend/vuejs/src/shared/components/organisms/navigation/BaseNavbar.vue
@@ -73,10 +73,4 @@ nav {
   position: relative;
   z-index: 10;
 }
-
-@supports (backdrop-filter: blur(20px)) {
-  nav {
-    backdrop-filter: blur(20px);
-  }
-}
 </style>

--- a/frontend/vuejs/vite.config.ts
+++ b/frontend/vuejs/vite.config.ts
@@ -6,6 +6,11 @@ export default defineConfig({
   plugins: [
     vue(),
   ],
+  define: {
+    // Build timestamp, surfaced via console + <html data-build> so a deployed
+    // bundle can be identified from any device (see also /version.txt).
+    __BUILD_TIME__: JSON.stringify(new Date().toISOString()),
+  },
   server: {
     // Honor a harness/CI-assigned PORT, else default to 5173.
     // strictPort is false so Vite auto-increments (5174, 5175, …) when the


### PR DESCRIPTION
## Problem

The iPad rendering glitch persists after PR #35 (sticky navbar): pages still intermittently render squished/clipped under the navbar, and switching to another tab and back still heals it. That recovery signature — a re-composite fixes everything without scrolling — combined with the sticky conversion not resolving it, points at the `backdrop-filter` itself. iOS/iPadOS WebKit (the engine in **every** iPad browser, Chrome included) has long-standing compositing bugs where a blurred pinned bar causes the page to paint from stale tiles at a wrong viewport offset.

## Fix

- **Drop the navbar's backdrop blur on iOS WebKit only**, gated behind `@supports (-webkit-touch-callout: none)` — a property that exists solely on iOS/iPadOS WebKit. The bar gets a near-opaque background there instead (97% opacity), so the design change on iPad is subtle. Desktop browsers keep the frosted translucent look, verified unchanged.
- Remove `BaseNavbar`'s redundant scoped `backdrop-filter` override so the global rule wins the cascade.

## Deploy verification (new)

To stop guessing which build a device is running:

- `__BUILD_TIME__` is injected at build time, logged to the console (`Imagi build: …`), and stamped on `<html data-build>`
- The Docker image writes **`/version.txt`** at build time, served with `no-cache` — open `https://<your-domain>/version.txt` on any device to see exactly when the live build was made

## Verification

Playwright checks at desktop/iPad/iPhone viewports all pass: navbar sticky and pinned, blur retained on non-iOS engines, hero spacing pixel-identical, scroll reaches exact top, build stamp present. Type-check and production build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYUPVqjNvxPVKbiYhHPsH9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYUPVqjNvxPVKbiYhHPsH9)_