### PR TITLE
Add on-device viewport diagnostics overlay (?debug=1)

### DIFF
--- a/frontend/vuejs/src/main.ts
+++ b/frontend/vuejs/src/main.ts
@@ -8,6 +8,7 @@ import { library } from '@fortawesome/fontawesome-svg-core'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { validationPlugin } from '@/apps/auth/plugins/validation'
 import config from '@/shared/config'
+import { initViewportDebug } from '@/shared/debug/viewportDebug'
 
 // Import Tailwind styles
 import 'tailwindcss/tailwind.css'
@@ -77,6 +78,9 @@ app.mount('#app')
 // via the console or `document.documentElement.dataset.build`.
 console.info(`Imagi build: ${__BUILD_TIME__}`)
 document.documentElement.dataset.build = __BUILD_TIME__
+
+// On-device diagnostics for the iPad render glitch — enable with ?debug=1.
+initViewportDebug()
 
 // iOS/iPadOS WebKit can restore a page (back-swipe bfcache) with stale
 // compositing/viewport state — content renders clipped or offset until the

--- a/frontend/vuejs/src/shared/debug/viewportDebug.ts
+++ b/frontend/vuejs/src/shared/debug/viewportDebug.ts
@@ -1,0 +1,66 @@
+/**
+ * On-device viewport diagnostics for the intermittent iPad render glitch.
+ *
+ * Enable by visiting any page with ?debug=1 (persists via localStorage);
+ * disable with ?debug=0. Renders a small always-on-top readout of the
+ * numbers that distinguish the possible failure modes:
+ *
+ * - scrollY stuck > 0            → a real scroll-position bug
+ * - visualViewport offset != 0   → layout/visual viewport desync (WebKit)
+ * - all numbers normal while the
+ *   screen looks wrong           → stale compositor tiles (pure paint bug)
+ *
+ * Deliberately framework-free so it works even if the app wedges.
+ */
+export function initViewportDebug(): void {
+  const params = new URLSearchParams(window.location.search)
+  const flag = params.get('debug')
+  if (flag === '1') localStorage.setItem('imagi-debug', '1')
+  if (flag === '0') localStorage.removeItem('imagi-debug')
+  if (localStorage.getItem('imagi-debug') !== '1') return
+
+  const el = document.createElement('div')
+  el.id = 'imagi-debug'
+  el.style.cssText = [
+    'position:fixed', 'left:8px', 'bottom:8px', 'z-index:2147483647',
+    'font:11px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace',
+    'background:rgba(0,0,0,0.82)', 'color:#7CFC9A', 'padding:8px 10px',
+    'border-radius:8px', 'pointer-events:none', 'white-space:pre',
+    'max-width:92vw', 'overflow:hidden',
+  ].join(';')
+  document.body.appendChild(el)
+
+  const fmt = (n: number | undefined) => (n === undefined ? '?' : Math.round(n * 10) / 10)
+
+  const render = () => {
+    const vv = window.visualViewport
+    const nav = document.querySelector('nav')
+    const h1 = document.querySelector('h1')
+    const doc = document.scrollingElement
+    el.textContent = [
+      `build  ${document.documentElement.dataset.build ?? '?'}`,
+      `scrollY ${fmt(window.scrollY)}  docTop ${fmt(doc?.scrollTop)}`,
+      `inner  ${window.innerWidth}x${window.innerHeight}  docH ${fmt(doc?.scrollHeight)}`,
+      `vv     off ${fmt(vv?.offsetTop)},${fmt(vv?.offsetLeft)}  h ${fmt(vv?.height)}  scale ${fmt(vv?.scale)}`,
+      `nav    top ${fmt(nav?.getBoundingClientRect().top)}  h1 top ${fmt(h1?.getBoundingClientRect().top)}`,
+    ].join('\n')
+  }
+
+  let scheduled = false
+  const schedule = () => {
+    if (scheduled) return
+    scheduled = true
+    requestAnimationFrame(() => {
+      scheduled = false
+      render()
+    })
+  }
+
+  window.addEventListener('scroll', schedule, { passive: true })
+  window.addEventListener('resize', schedule)
+  window.visualViewport?.addEventListener('resize', schedule)
+  window.visualViewport?.addEventListener('scroll', schedule)
+  document.addEventListener('visibilitychange', schedule)
+  setInterval(schedule, 1000)
+  render()
+}


### PR DESCRIPTION
## Why

The iPad render glitch survives both the sticky-navbar conversion (#35) and the iOS backdrop-blur removal (#36), confirmed on build `2026-07-12T10:15:28Z` via the new `/version.txt`. Rather than another blind hypothesis, this adds instrumentation so the glitch can be measured on the affected device the moment it happens.

## What

A tiny framework-free diagnostics overlay (`src/shared/debug/viewportDebug.ts`):

- **Enable**: open any page with `?debug=1` (persists via localStorage across pages/reloads). **Disable**: `?debug=0`.
- Shows a live readout pinned to the bottom-left: build time, `window.scrollY` / `scrollingElement.scrollTop`, window size vs document height, `visualViewport` offset/height/scale, and the current on-screen positions of the navbar and the page title.
- Updates on scroll/resize/visualViewport changes plus a 1s heartbeat; deliberately plain DOM so it keeps working even if the app misbehaves.

## How this pins the bug

When the glitch is visible, the numbers distinguish the three possible failure modes:

| Reading while glitched | Diagnosis |
|---|---|
| `scrollY` stuck > 0 | real scroll-position bug |
| `vv off` ≠ 0 or `scale` ≠ 1 | layout/visual viewport desync |
| all numbers normal but screen looks wrong | stale compositor tiles (pure paint bug) |

## Verification

Playwright: overlay appears with `?debug=1`, persists across SPA navigation, reports correct values, and disappears with `?debug=0`. Type-check and production build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYUPVqjNvxPVKbiYhHPsH9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYUPVqjNvxPVKbiYhHPsH9)_