### PR TITLE
Remove 100dvh min-height override that corrupted iPad scroll bounds

### DIFF
--- a/frontend/vuejs/src/assets/main.css
+++ b/frontend/vuejs/src/assets/main.css
@@ -77,13 +77,10 @@ html {
 }
 
 /*
- * On iOS/iPadOS Safari 100vh is the LARGE viewport (toolbar hidden), so
- * `min-h-screen` sections overflow and jump while the toolbar collapses.
- * Prefer the dynamic viewport unit where supported so full-height sections
- * track the visible viewport instead.
+ * Deliberately NO dvh override for min-h-screen. 100dvh resizes every
+ * min-h-screen element WHILE the user scrolls (the iOS toolbar collapse
+ * changes the dynamic viewport), and that mid-scroll document-height pulsing
+ * corrupts WebKit's scroll bounds on iPad — the page gets stuck ~130px from
+ * the top until the engine rebuilds its geometry (e.g. on a tab switch).
+ * The static 100vh behind Tailwind's min-h-screen is stable during scroll.
  */
-@supports (min-height: 100dvh) {
-  .min-h-screen {
-    min-height: 100dvh;
-  }
-}

--- a/frontend/vuejs/src/shared/debug/viewportDebug.ts
+++ b/frontend/vuejs/src/shared/debug/viewportDebug.ts
@@ -19,16 +19,32 @@ export function initViewportDebug(): void {
   if (flag === '0') localStorage.removeItem('imagi-debug')
   if (localStorage.getItem('imagi-debug') !== '1') return
 
-  const el = document.createElement('div')
-  el.id = 'imagi-debug'
-  el.style.cssText = [
+  const box = document.createElement('div')
+  box.id = 'imagi-debug'
+  box.style.cssText = [
     'position:fixed', 'left:8px', 'bottom:8px', 'z-index:2147483647',
     'font:11px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace',
     'background:rgba(0,0,0,0.82)', 'color:#7CFC9A', 'padding:8px 10px',
     'border-radius:8px', 'pointer-events:none', 'white-space:pre',
     'max-width:92vw', 'overflow:hidden',
   ].join(';')
-  document.body.appendChild(el)
+  const el = document.createElement('div')
+  // "force top" probe: reports whether programmatic scrolling can beat a
+  // stuck scroll floor (gesture scrolling and JS scrolling can differ when
+  // WebKit's scroll bounds are corrupted).
+  const btn = document.createElement('button')
+  btn.textContent = '⤒ force top'
+  btn.style.cssText =
+    'pointer-events:auto;margin-top:6px;font:inherit;color:#0a0a0a;background:#7CFC9A;border:0;border-radius:6px;padding:4px 8px'
+  btn.addEventListener('click', () => {
+    window.scrollTo(0, 0)
+    setTimeout(() => {
+      btn.textContent = window.scrollY === 0 ? '⤒ force top — ok' : `⤒ force top — stuck at ${Math.round(window.scrollY)}`
+    }, 350)
+  })
+  box.appendChild(el)
+  box.appendChild(btn)
+  document.body.appendChild(box)
 
   const fmt = (n: number | undefined) => (n === undefined ? '?' : Math.round(n * 10) / 10)
 


### PR DESCRIPTION
## Diagnosis (from on-device measurements)

The debug overlay (#37) captured the glitch in the act on iPad Chrome:

```
scrollY 132   docTop 132     ← window genuinely scrolled, stuck at a 132px floor
vv      off 0,0  scale 1     ← visual viewport clean: no zoom, no desync
nav     top 0    h1 top 61   ← sticky navbar fine; title 132px higher than normal
```

So the failure mode is a **corrupted scroll boundary** — WebKit believes y=132 is the top of the page — not a paint bug or viewport desync. 132px matches the iPad Chrome collapsible-toolbar delta, and a tab switch heals it because the engine rebuilds its scroll geometry on tab activation.

## Root cause

The `@supports (min-height: 100dvh) { .min-h-screen { min-height: 100dvh } }` override (shipped in #34, alongside the original nested-scroll-container fix) made every `min-h-screen` element **resize while the user scrolls**: `100dvh` tracks the dynamic viewport, which changes as the browser toolbar collapses/expands mid-scroll. That document-height pulsing during scroll is what wedges WebKit's scroll bounds. Because it shipped in the same PR as the original fix, the symptom appeared to "persist" across all subsequent fixes — it had actually changed owners.

## Fix

- Remove the dvh override entirely, restoring the stable `100vh` that `min-h-screen` always had (document height no longer changes during scroll), with a comment explaining why no dvh override should be reintroduced.
- Debug overlay: add a **"⤒ force top" probe button** that attempts `window.scrollTo(0, 0)` and reports whether it beat the floor — if any residue of the bug remains, this distinguishes gesture-only clamping from full scroll-bound corruption.

## Verification

- `min-h-screen` resolves to `100vh` again (checked computed style in the built bundle; `100dvh` absent from the compiled CSS)
- Probe button scrolls to exact top and reports "ok"
- Full scroll round-trips still reach exact top across desktop/iPad/iPhone viewports
- Type-check and production build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYUPVqjNvxPVKbiYhHPsH9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYUPVqjNvxPVKbiYhHPsH9)_