### PR TITLE
Auto-heal iPad WebKit stale toolbar inset that clamps scrolling

### DIFF
--- a/frontend/vuejs/src/router/index.ts
+++ b/frontend/vuejs/src/router/index.ts
@@ -24,17 +24,58 @@ const router = createRouter({
   ],
   scrollBehavior(to, from, savedPosition) {
     if (savedPosition) {
+      lastNavRestoredPosition = true
       return savedPosition
     }
+    lastNavRestoredPosition = false
     return { left: 0, top: 0 }
   }
 })
+
+// Set by scrollBehavior; read by the toolbar-inset guard below so it never
+// fights a legitimate back/forward position restore.
+let lastNavRestoredPosition = false
 
 // The router owns scroll restoration (scrollBehavior above). Left on 'auto',
 // Safari also restores scroll natively on back/forward — racing the SPA render
 // and landing pages on stale offsets with the top of the page cut off.
 if (typeof window !== 'undefined' && 'scrollRestoration' in window.history) {
   window.history.scrollRestoration = 'manual'
+}
+
+// iPadOS WebKit "stale toolbar inset" guard. When the browser's collapsible
+// toolbar animates during a navigation, WebKit sometimes keeps a phantom
+// scroll inset equal to the toolbar height (~130px): every scroll — touch and
+// programmatic alike — clamps to that floor, so the top of the page becomes
+// unreachable until the engine rebuilds its scroll geometry (a tab switch
+// does this, and so does toggling overflow on the root element).
+// After each to-top navigation, verify the top was actually reached; if the
+// engine clamped us and the user hasn't scrolled on their own, rebuild and
+// retry once.
+if (typeof window !== 'undefined') {
+  let userScrolled = false
+  const markUserScroll = () => {
+    userScrolled = true
+  }
+  window.addEventListener('touchstart', markUserScroll, { passive: true })
+  window.addEventListener('wheel', markUserScroll, { passive: true })
+
+  router.afterEach((to, from) => {
+    if (from.name === undefined) return // initial load, nothing to verify
+    userScrolled = false
+    setTimeout(() => {
+      // Only heal a small non-zero offset the user didn't create — that is
+      // the phantom-inset signature, never a legitimate resting position.
+      if (lastNavRestoredPosition || userScrolled) return
+      if (window.scrollY === 0 || window.scrollY > 200) return
+      const de = document.documentElement
+      de.style.overflow = 'hidden'
+      requestAnimationFrame(() => {
+        de.style.overflow = ''
+        window.scrollTo(0, 0)
+      })
+    }, 350)
+  })
 }
 
 export default router

--- a/frontend/vuejs/src/shared/debug/viewportDebug.ts
+++ b/frontend/vuejs/src/shared/debug/viewportDebug.ts
@@ -36,11 +36,34 @@ export function initViewportDebug(): void {
   btn.textContent = '⤒ force top'
   btn.style.cssText =
     'pointer-events:auto;margin-top:6px;font:inherit;color:#0a0a0a;background:#7CFC9A;border:0;border-radius:6px;padding:4px 8px'
-  btn.addEventListener('click', () => {
+  btn.addEventListener('click', async () => {
+    const settle = () => new Promise((r) => setTimeout(r, 250))
+    const atTop = () => window.scrollY === 0
+
     window.scrollTo(0, 0)
-    setTimeout(() => {
-      btn.textContent = window.scrollY === 0 ? '⤒ force top — ok' : `⤒ force top — stuck at ${Math.round(window.scrollY)}`
-    }, 350)
+    await settle()
+    if (atTop()) {
+      btn.textContent = '⤒ force top — ok'
+      return
+    }
+    // Strategy 1: rebuild scroll geometry via overflow toggle on <html>
+    const de = document.documentElement
+    de.style.overflow = 'hidden'
+    await new Promise(requestAnimationFrame)
+    de.style.overflow = ''
+    window.scrollTo(0, 0)
+    await settle()
+    if (atTop()) {
+      btn.textContent = '⤒ healed via overflow'
+      return
+    }
+    // Strategy 2: perturb document height to force geometry recompute
+    document.body.style.minHeight = `${document.body.scrollHeight + 2}px`
+    await new Promise(requestAnimationFrame)
+    document.body.style.minHeight = ''
+    window.scrollTo(0, 0)
+    await settle()
+    btn.textContent = atTop() ? '⤒ healed via height' : `⤒ still stuck at ${Math.round(window.scrollY)}`
   })
   box.appendChild(el)
   box.appendChild(btn)


### PR DESCRIPTION
## Diagnosis — mechanism now fully pinned

Second on-device capture (debug overlay, build `10:30:01Z`) in the glitched state:

```
scrollY 132  docTop 132       ← scroll floor at exactly 132px
vv off 0,0  scale 1           ← viewport clean
⤒ force top — stuck at 132    ← even window.scrollTo(0,0) cannot beat it
```

Key geometry: iPad screen height **834pt**, page viewport **702pt** → browser chrome = **132pt = the scroll floor, to the pixel**. WebKit is retaining a phantom scroll inset equal to its collapsible toolbar height after the toolbar show/hide animation. It's an engine-level clamp on *both* touch and programmatic scrolling, and it persists until WebKit rebuilds scroll geometry — which a tab switch (or overflow toggle on the root element) forces. This explains every observed symptom, including why prior CSS-level fixes couldn't touch it.

## Workaround

- **Router guard (auto-heal)**: after each to-top navigation, verify the top was actually reached. If the page rests at a small offset (0 < y ≤ 200) that the user didn't create (no touch/wheel since the navigation) and that isn't a back/forward position restore, toggle `overflow: hidden` on `<html>` for one frame — rebuilding WebKit's scroll geometry — and scroll to top again.
- **Debug overlay**: the "⤒ force top" probe now escalates through rebuild strategies (plain scroll → overflow toggle → height perturbation) and reports which one beat the clamp (`healed via overflow` / `healed via height` / `still stuck`), so the workaround can be validated on the affected device and mid-scroll occurrences can be recovered manually.

## Verification (Playwright, production build)

- Fresh navigations land at the top and stay there (guard is a no-op)
- A simulated 132px phantom offset injected after navigation is auto-healed to 0
- A deliberate user scroll immediately after navigation is never yanked back
- Back/forward navigation restores small saved positions (~150px) untouched
- Type-check and production build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYUPVqjNvxPVKbiYhHPsH9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYUPVqjNvxPVKbiYhHPsH9)_