### PR TITLE
Hand scroll restoration back to the browser; remove all scroll interventions

### DIFF
--- a/frontend/vuejs/src/main.ts
+++ b/frontend/vuejs/src/main.ts
@@ -82,15 +82,9 @@ document.documentElement.dataset.build = __BUILD_TIME__
 // On-device diagnostics for the iPad render glitch — enable with ?debug=1.
 initViewportDebug()
 
-// iOS/iPadOS WebKit can restore a page (back-swipe bfcache) with stale
-// compositing/viewport state — content renders clipped or offset until the
-// engine re-composites (the same glitch a tab switch clears). Nudging the
-// scroll position on restore forces that re-composite immediately.
-window.addEventListener('pageshow', (event) => {
-  if (event.persisted) {
-    requestAnimationFrame(() => {
-      window.scrollTo(window.scrollX, window.scrollY + 1)
-      window.scrollTo(window.scrollX, Math.max(0, window.scrollY - 1))
-    })
-  }
-})
+// NOTE: no scroll "nudges" on pageshow/tab-restore — deliberately. A
+// programmatic scroll issued while iPad Chrome is mid tab-restore or mid
+// toolbar animation is a prime suspect for wedging the browser's native
+// scroll inset (scroll floor stuck at the toolbar height, ~132px, page top
+// unreachable until the tab is re-activated). Page JS cannot undo that
+// state once wedged, so nothing here may scroll during restore transitions.

--- a/frontend/vuejs/src/router/index.ts
+++ b/frontend/vuejs/src/router/index.ts
@@ -24,58 +24,33 @@ const router = createRouter({
   ],
   scrollBehavior(to, from, savedPosition) {
     if (savedPosition) {
-      lastNavRestoredPosition = true
       return savedPosition
     }
-    lastNavRestoredPosition = false
     return { left: 0, top: 0 }
   }
 })
 
-// Set by scrollBehavior; read by the toolbar-inset guard below so it never
-// fights a legitimate back/forward position restore.
-let lastNavRestoredPosition = false
-
-// The router owns scroll restoration (scrollBehavior above). Left on 'auto',
-// Safari also restores scroll natively on back/forward — racing the SPA render
-// and landing pages on stale offsets with the top of the page cut off.
+// SCROLL HANDLING POLICY — keep it minimal and standard.
+//
+// iPad Chrome (WebKit) can wedge its NATIVE scroll inset: the scroll floor
+// gets stuck at the toolbar height (~132px) and the page top becomes
+// unreachable — for touch AND programmatic scrolling alike — until the tab
+// is re-activated. On-device probing proved page JS cannot heal that state
+// (overflow/height/geometry rebuilds all fail), so the only page-level lever
+// is avoiding the trigger: interfering with the browser's own scroll
+// management around loads, tab restores, and toolbar animations.
+//
+// vue-router silently sets history.scrollRestoration = 'manual' whenever
+// scrollBehavior is defined. Set it back to 'auto' so the BROWSER owns
+// scroll restoration on load/tab-restore/back-forward — the phases where the
+// native inset wedges. scrollBehavior still applies its positions after
+// render (last write wins), so in-app navigation behavior is unchanged.
+//
+// Also deliberately absent: pageshow/visibility scroll "nudges" and
+// post-navigation scroll verification/retries. The single scrollBehavior
+// scroll above is the only programmatic scroll in the app.
 if (typeof window !== 'undefined' && 'scrollRestoration' in window.history) {
-  window.history.scrollRestoration = 'manual'
-}
-
-// iPadOS WebKit "stale toolbar inset" guard. When the browser's collapsible
-// toolbar animates during a navigation, WebKit sometimes keeps a phantom
-// scroll inset equal to the toolbar height (~130px): every scroll — touch and
-// programmatic alike — clamps to that floor, so the top of the page becomes
-// unreachable until the engine rebuilds its scroll geometry (a tab switch
-// does this, and so does toggling overflow on the root element).
-// After each to-top navigation, verify the top was actually reached; if the
-// engine clamped us and the user hasn't scrolled on their own, rebuild and
-// retry once.
-if (typeof window !== 'undefined') {
-  let userScrolled = false
-  const markUserScroll = () => {
-    userScrolled = true
-  }
-  window.addEventListener('touchstart', markUserScroll, { passive: true })
-  window.addEventListener('wheel', markUserScroll, { passive: true })
-
-  router.afterEach((to, from) => {
-    if (from.name === undefined) return // initial load, nothing to verify
-    userScrolled = false
-    setTimeout(() => {
-      // Only heal a small non-zero offset the user didn't create — that is
-      // the phantom-inset signature, never a legitimate resting position.
-      if (lastNavRestoredPosition || userScrolled) return
-      if (window.scrollY === 0 || window.scrollY > 200) return
-      const de = document.documentElement
-      de.style.overflow = 'hidden'
-      requestAnimationFrame(() => {
-        de.style.overflow = ''
-        window.scrollTo(0, 0)
-      })
-    }, 350)
-  })
+  window.history.scrollRestoration = 'auto'
 }
 
 export default router

--- a/frontend/vuejs/src/shared/debug/viewportDebug.ts
+++ b/frontend/vuejs/src/shared/debug/viewportDebug.ts
@@ -63,7 +63,32 @@ export function initViewportDebug(): void {
     document.body.style.minHeight = ''
     window.scrollTo(0, 0)
     await settle()
-    btn.textContent = atTop() ? '⤒ healed via height' : `⤒ still stuck at ${Math.round(window.scrollY)}`
+    if (atTop()) {
+      btn.textContent = '⤒ healed via height'
+      return
+    }
+    // Strategy 3: iOS-style body scroll lock toggle (position:fixed detaches
+    // scrolling at a different level than overflow on the root)
+    const bs = document.body.style
+    bs.position = 'fixed'
+    bs.top = '0'
+    bs.left = '0'
+    bs.right = '0'
+    await new Promise(requestAnimationFrame)
+    bs.position = ''
+    bs.top = ''
+    bs.left = ''
+    bs.right = ''
+    window.scrollTo(0, 0)
+    await settle()
+    if (atTop()) {
+      btn.textContent = '⤒ healed via body-lock'
+      return
+    }
+    // Strategy 4: scrollIntoView may take a different native scroll path
+    document.querySelector('nav')?.scrollIntoView({ block: 'start' })
+    await settle()
+    btn.textContent = atTop() ? '⤒ healed via sIV' : `⤒ still stuck at ${Math.round(window.scrollY)}`
   })
   box.appendChild(el)
   box.appendChild(btn)
@@ -102,4 +127,24 @@ export function initViewportDebug(): void {
   document.addEventListener('visibilitychange', schedule)
   setInterval(schedule, 1000)
   render()
+
+  // Wedge-at-load detector: on a FRESH navigation (not reload/back-forward,
+  // where the browser legitimately restores a position), the page must rest
+  // at the top. If it rests at a small offset without any user input and a
+  // scroll-to-top cannot clear it, the native inset is wedged — flag it.
+  let touched = false
+  window.addEventListener('touchstart', () => { touched = true }, { passive: true, once: true })
+  const navType = (performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming | undefined)?.type
+  if (navType === 'navigate') {
+    setTimeout(() => {
+      if (touched || window.scrollY === 0 || window.scrollY > 200) return
+      window.scrollTo(0, 0)
+      setTimeout(() => {
+        if (!touched && window.scrollY > 0) {
+          box.style.background = 'rgba(120,0,0,0.88)'
+          el.textContent = `⚠ WEDGED AT LOAD (floor ${Math.round(window.scrollY)})\n` + el.textContent
+        }
+      }, 300)
+    }, 1500)
+  }
 }


### PR DESCRIPTION
## What the latest on-device probe proved

With the wedge active, the escalating "force top" probe reported **`still stuck at 132`** — `window.scrollTo(0,0)`, an `overflow:hidden` toggle on the root element, and a document-height perturbation all failed to get below the 132px floor. The phantom inset therefore lives in the **browser's native scroll view**, below anything page JavaScript can reach. Once wedged, only tab re-activation clears it.

## Consequence: prevention is the only page-level lever

Programmatic scrolls issued while iPad Chrome is mid tab-restore or mid toolbar-animation are the prime candidates for creating the wedge. This PR strips the app down to a single programmatic scroll (the router's `scrollBehavior`):

- **Remove the `pageshow` bfcache scroll nudge** — it fires during tab restore, the exact transition the user's tab-switch workaround exercises constantly; it may have been re-arming the wedge.
- **Remove the post-navigation clamp-detection guard** — proven unable to heal a real wedge, and its delayed `scrollTo` lands mid toolbar animation.
- **Set `history.scrollRestoration` back to `'auto'`** — it turns out vue-router silently forces `'manual'` whenever `scrollBehavior` is defined, taking load/restore scrolling away from the browser. Hand it back so Chrome owns the phases where its inset accounting wedges. `scrollBehavior` still applies its positions after render, so in-app navigation UX is unchanged.

## Debug overlay upgrades

- Probe escalates through two more strategies (iOS body scroll-lock toggle, `scrollIntoView`) and reports which, if any, beats the clamp.
- New **wedge-at-load detector**: on a fresh navigation resting at a small unclearable offset with no user input, the overlay turns red with `⚠ WEDGED AT LOAD` — pinning down *when* the wedge is created.

## Verification

Playwright: `scrollRestoration` is `auto`; SPA navigations land at top; back/forward restores positions; no false wedge flag on healthy loads; probe reports `ok` when healthy. Type-check and production build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYUPVqjNvxPVKbiYhHPsH9

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYUPVqjNvxPVKbiYhHPsH9)_