### PR TITLE
Refine build workspace agents panel and chat UI

### DIFF
--- a/frontend/vuejs/src/apps/imagi/build/components/molecules/sidebar/AgentInstanceCard.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/molecules/sidebar/AgentInstanceCard.vue
@@ -11,7 +11,6 @@
   >
     <!-- Title row -->
     <div class="flex items-start gap-2">
-      <i class="fas fa-robot text-purple-500 dark:text-purple-400 text-[10px] mt-0.5 shrink-0"></i>
       <div class="flex-1 min-w-0">
         <input
           v-if="isEditing"
@@ -30,15 +29,7 @@
         >
           {{ instance.title || 'Untitled instance' }}
         </div>
-        <div
-          class="text-[11px] text-gray-500 dark:text-white/50 mt-0.5 line-clamp-2 leading-snug"
-          :title="instance.lastMessagePreview"
-        >
-          {{ instance.lastMessagePreview || 'No messages yet' }}
-        </div>
-        <div class="flex items-center gap-1.5 mt-1.5 text-[10px] text-gray-400 dark:text-white/40">
-          <span>{{ instance.selectedModelId || '—' }}</span>
-          <span aria-hidden="true">·</span>
+        <div class="flex items-center gap-1.5 mt-1 text-[10px] text-gray-400 dark:text-white/40">
           <span>{{ relativeTime(instance.updatedAt) }}</span>
           <span v-if="instance.isProcessing" class="ml-1 flex items-center gap-1 text-indigo-500 dark:text-indigo-300">
             <i class="fas fa-circle-notch fa-spin text-[9px]"></i>
@@ -48,47 +39,45 @@
       </div>
 
       <!-- Actions -->
-      <div
-        class="shrink-0 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity flex items-center gap-0.5"
-        @click.stop
-      >
+      <div ref="menuRef" class="relative shrink-0" @click.stop>
         <button
-          class="w-6 h-6 flex items-center justify-center rounded hover:bg-gray-200 dark:hover:bg-white/[0.08] text-gray-500 dark:text-white/60"
-          title="Rename"
-          @click.stop="startRename"
+          :class="[
+            'w-6 h-6 flex items-center justify-center rounded transition-opacity hover:bg-gray-200 dark:hover:bg-white/[0.08] text-gray-500 dark:text-white/60',
+            menuOpen ? 'opacity-100 bg-gray-200 dark:bg-white/[0.08]' : 'opacity-0 group-hover:opacity-100 focus:opacity-100'
+          ]"
+          title="Options"
+          @click.stop="toggleMenu"
         >
-          <i class="fas fa-pen text-[9px]"></i>
+          <i class="fas fa-ellipsis-h text-[10px]"></i>
         </button>
-        <button
-          v-if="!isArchived"
-          class="w-6 h-6 flex items-center justify-center rounded hover:bg-gray-200 dark:hover:bg-white/[0.08] text-gray-500 dark:text-white/60"
-          title="Archive"
-          @click.stop="emit('archive')"
+        <div
+          v-if="menuOpen"
+          class="absolute right-0 top-full mt-1 z-50 min-w-[130px] rounded-md border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-[#161616] shadow-lg py-1"
         >
-          <i class="fas fa-archive text-[9px]"></i>
-        </button>
-        <button
-          v-else
-          class="w-6 h-6 flex items-center justify-center rounded hover:bg-gray-200 dark:hover:bg-white/[0.08] text-gray-500 dark:text-white/60"
-          title="Unarchive"
-          @click.stop="emit('unarchive')"
-        >
-          <i class="fas fa-box-open text-[9px]"></i>
-        </button>
-        <button
-          class="w-6 h-6 flex items-center justify-center rounded hover:bg-red-100 dark:hover:bg-red-500/20 text-gray-500 dark:text-white/60 hover:text-red-600 dark:hover:text-red-400"
-          title="Delete"
-          @click.stop="emit('delete')"
-        >
-          <i class="fas fa-trash text-[9px]"></i>
-        </button>
+          <button class="menu-item" @click.stop="onRename">
+            <i class="fas fa-pen menu-item-icon"></i>
+            <span>Rename</span>
+          </button>
+          <button v-if="!isArchived" class="menu-item" @click.stop="onArchive">
+            <i class="fas fa-archive menu-item-icon"></i>
+            <span>Archive</span>
+          </button>
+          <button v-else class="menu-item" @click.stop="onUnarchive">
+            <i class="fas fa-box-open menu-item-icon"></i>
+            <span>Unarchive</span>
+          </button>
+          <button class="menu-item menu-item--danger" @click.stop="onDelete">
+            <i class="fas fa-trash menu-item-icon"></i>
+            <span>Delete</span>
+          </button>
+        </div>
       </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, nextTick } from 'vue'
+import { ref, nextTick, onMounted, onBeforeUnmount } from 'vue'
 import type { AgentInstance } from '../../../types/services'
 
 const props = defineProps<{
@@ -108,6 +97,46 @@ const emit = defineEmits<{
 const isEditing = ref(false)
 const draftTitle = ref('')
 const titleInput = ref<HTMLInputElement | null>(null)
+
+const menuOpen = ref(false)
+const menuRef = ref<HTMLElement | null>(null)
+
+function toggleMenu() {
+  menuOpen.value = !menuOpen.value
+}
+
+function closeMenu() {
+  menuOpen.value = false
+}
+
+function onRename() {
+  closeMenu()
+  startRename()
+}
+
+function onArchive() {
+  closeMenu()
+  emit('archive')
+}
+
+function onUnarchive() {
+  closeMenu()
+  emit('unarchive')
+}
+
+function onDelete() {
+  closeMenu()
+  emit('delete')
+}
+
+function handleDocumentClick(event: MouseEvent) {
+  if (menuOpen.value && menuRef.value && !menuRef.value.contains(event.target as Node)) {
+    closeMenu()
+  }
+}
+
+onMounted(() => document.addEventListener('mousedown', handleDocumentClick))
+onBeforeUnmount(() => document.removeEventListener('mousedown', handleDocumentClick))
 
 async function startRename() {
   draftTitle.value = props.instance.title || ''
@@ -136,20 +165,69 @@ function relativeTime(iso: string): string {
   const diff = Date.now() - date.getTime()
   const mins = Math.floor(diff / 60000)
   if (mins < 1) return 'now'
-  if (mins < 60) return `${mins}m`
+  if (mins < 60) return `${mins}m ago`
   const hrs = Math.floor(mins / 60)
-  if (hrs < 24) return `${hrs}h`
+  if (hrs < 24) return `${hrs}h ago`
   const days = Math.floor(hrs / 24)
-  if (days < 7) return `${days}d`
+  if (days < 7) return `${days}d ago`
   return date.toLocaleDateString()
 }
 </script>
 
 <style scoped>
-.line-clamp-2 {
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+.menu-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.375rem 0.625rem;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  text-align: left;
+  color: rgb(55, 65, 81);
+  transition: background-color 0.15s ease;
+}
+
+.menu-item:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+.dark .menu-item {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.dark .menu-item:hover {
+  background-color: rgba(255, 255, 255, 0.06);
+}
+
+.menu-item--danger {
+  color: rgb(220, 38, 38);
+}
+
+.dark .menu-item--danger {
+  color: rgb(248, 113, 113);
+}
+
+.menu-item--danger:hover {
+  background-color: rgba(239, 68, 68, 0.1);
+}
+
+.dark .menu-item--danger:hover {
+  background-color: rgba(239, 68, 68, 0.15);
+}
+
+.menu-item-icon {
+  width: 0.875rem;
+  font-size: 0.625rem;
+  text-align: center;
+  color: rgba(107, 114, 128, 0.9);
+}
+
+.menu-item--danger .menu-item-icon {
+  color: inherit;
+}
+
+.dark .menu-item-icon {
+  color: rgba(255, 255, 255, 0.45);
 }
 </style>

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/AgentManagerPanel.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/AgentManagerPanel.vue
@@ -8,12 +8,41 @@
       @cancel="confirmModal.handleCancel"
     />
     <!-- Header -->
-    <div class="shrink-0 px-3 py-3 border-b border-gray-200 dark:border-white/[0.08] flex items-center justify-between">
-      <div class="flex items-center gap-2">
-        <i class="fas fa-layer-group text-xs text-gray-500 dark:text-white/50"></i>
-        <span class="text-xs font-semibold uppercase tracking-wider text-gray-600 dark:text-white/70">
-          Agents
-        </span>
+    <div class="shrink-0 px-2 py-2 border-b border-gray-200 dark:border-white/[0.08] flex items-center justify-between">
+      <div class="flex items-center gap-0.5">
+        <!-- Collapse -->
+        <div class="relative group">
+          <button
+            class="flex items-center justify-center w-7 h-7 rounded-md text-gray-600 dark:text-white/70 hover:bg-gray-100 dark:hover:bg-white/[0.08] hover:text-gray-900 dark:hover:text-white transition-colors"
+            @click="emit('collapse')"
+          >
+            <i class="fas fa-chevron-left text-xs"></i>
+          </button>
+          <div
+            class="pointer-events-none absolute left-0 top-full mt-1.5 z-50 whitespace-nowrap rounded-md bg-gray-900 dark:bg-white/95 px-2 py-1 text-[11px] font-medium text-white dark:text-gray-900 shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-150"
+          >
+            Collapse
+          </div>
+        </div>
+        <!-- Search -->
+        <div class="relative group">
+          <button
+            :class="[
+              'flex items-center justify-center w-7 h-7 rounded-md transition-colors',
+              showSearch
+                ? 'bg-gray-100 dark:bg-white/[0.08] text-gray-900 dark:text-white'
+                : 'text-gray-600 dark:text-white/70 hover:bg-gray-100 dark:hover:bg-white/[0.08] hover:text-gray-900 dark:hover:text-white'
+            ]"
+            @click="toggleSearch"
+          >
+            <i class="fas fa-search text-xs"></i>
+          </button>
+          <div
+            class="pointer-events-none absolute left-0 top-full mt-1.5 z-50 whitespace-nowrap rounded-md bg-gray-900 dark:bg-white/95 px-2 py-1 text-[11px] font-medium text-white dark:text-gray-900 shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-150"
+          >
+            Search chats
+          </div>
+        </div>
       </div>
       <div class="relative group">
         <button
@@ -30,11 +59,41 @@
       </div>
     </div>
 
+    <!-- Search input -->
+    <div v-if="showSearch" class="shrink-0 px-2 py-2 border-b border-gray-200 dark:border-white/[0.08]">
+      <div class="flex items-center gap-2 rounded-md bg-gray-100 dark:bg-white/[0.05] px-2 py-1.5">
+        <i class="fas fa-search text-[11px] text-gray-400 dark:text-white/40 shrink-0"></i>
+        <input
+          ref="searchInput"
+          v-model="searchQuery"
+          type="text"
+          placeholder="Search chats"
+          class="flex-1 min-w-0 bg-transparent text-xs text-gray-900 dark:text-white/90 placeholder-gray-400 dark:placeholder-white/30 outline-none"
+          @keydown.escape="closeSearch"
+        />
+        <button
+          v-if="searchQuery"
+          class="shrink-0 text-gray-400 hover:text-gray-600 dark:text-white/40 dark:hover:text-white/70 transition-colors"
+          @click="searchQuery = ''"
+        >
+          <i class="fas fa-times text-[11px]"></i>
+        </button>
+      </div>
+    </div>
+
     <!-- Instances list -->
     <div class="flex-1 min-h-0 overflow-y-auto px-2 py-2 space-y-1">
       <!-- Loading state -->
       <div v-if="store.instancesLoading && store.instances.length === 0" class="text-xs text-gray-400 dark:text-white/40 px-2 py-4 text-center">
         Loading...
+      </div>
+
+      <!-- No search results -->
+      <div
+        v-else-if="showSearch && searchQuery.trim() && !hasResults"
+        class="text-xs text-gray-400 dark:text-white/40 px-2 py-4 text-center"
+      >
+        No chats match "{{ searchQuery.trim() }}"
       </div>
 
       <!-- Active instances -->
@@ -82,19 +141,54 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, nextTick } from 'vue'
+import type { AgentInstance } from '../../../types/services'
 import { useAgentStore } from '../../../stores/agentStore'
 import { useConfirm } from '../../../composables/useConfirm'
 import InstanceCard from '../../molecules/sidebar/AgentInstanceCard.vue'
 import ConfirmModal from '../modals/ConfirmModal.vue'
+
+const emit = defineEmits<{
+  (e: 'collapse'): void
+}>()
 
 const store = useAgentStore()
 const showArchived = ref(false)
 const confirmModal = useConfirm()
 const { confirm } = confirmModal
 
-const activeInstances = computed(() => store.activeInstances)
-const archivedInstances = computed(() => store.archivedInstances)
+const showSearch = ref(false)
+const searchQuery = ref('')
+const searchInput = ref<HTMLInputElement | null>(null)
+
+function filterBySearch(list: AgentInstance[]): AgentInstance[] {
+  const q = searchQuery.value.trim().toLowerCase()
+  if (!q) return list
+  return list.filter(
+    i =>
+      (i.title || '').toLowerCase().includes(q) ||
+      (i.lastMessagePreview || '').toLowerCase().includes(q)
+  )
+}
+
+const activeInstances = computed(() => filterBySearch(store.activeInstances))
+const archivedInstances = computed(() => filterBySearch(store.archivedInstances))
+const hasResults = computed(() => activeInstances.value.length > 0 || archivedInstances.value.length > 0)
+
+async function toggleSearch() {
+  showSearch.value = !showSearch.value
+  if (showSearch.value) {
+    await nextTick()
+    searchInput.value?.focus()
+  } else {
+    searchQuery.value = ''
+  }
+}
+
+function closeSearch() {
+  showSearch.value = false
+  searchQuery.value = ''
+}
 
 async function handleCreate() {
   await store.createInstance()

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
@@ -2,21 +2,34 @@
   <div v-if="!isCollapsed" class="flex flex-col h-full bg-white dark:bg-[#0a0a0a] border-r border-gray-200 dark:border-white/[0.08] transition-colors duration-300">
     <!-- Header: manager toggle + instance title -->
     <div class="shrink-0 flex items-center gap-2 px-3 py-2 border-b border-gray-200 dark:border-white/[0.08]">
-      <div class="relative group">
+      <div v-if="!isManagerOpen" class="relative group">
         <button
           class="flex items-center justify-center w-8 h-8 rounded-md text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-dark-800/70 hover:text-gray-900 dark:hover:text-white transition-colors duration-200"
           @click="$emit('toggleManager')"
         >
-          <i :class="['fas text-sm transition-transform duration-300', isManagerOpen ? 'fa-chevron-left' : 'fa-chevron-right']"></i>
+          <i class="fas fa-chevron-right text-sm"></i>
         </button>
         <div
           class="pointer-events-none absolute left-0 top-full mt-1.5 z-50 whitespace-nowrap rounded-md bg-gray-900 dark:bg-white/95 px-2 py-1 text-[11px] font-medium text-white dark:text-gray-900 shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-150"
         >
-          {{ isManagerOpen ? 'Hide agent manager' : 'Show agent manager' }}
+          Show agent manager
         </div>
       </div>
       <div class="flex-1 min-w-0 text-xs font-semibold text-gray-700 dark:text-white/80 truncate">
         {{ activeInstance?.title || 'New instance' }}
+      </div>
+      <div v-if="onCollapseSidebar" class="relative group shrink-0">
+        <button
+          class="flex items-center justify-center w-8 h-8 rounded-md text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-dark-800/70 hover:text-gray-900 dark:hover:text-white transition-colors duration-200"
+          @click="onCollapseSidebar()"
+        >
+          <i class="fas fa-chevron-left text-sm"></i>
+        </button>
+        <div
+          class="pointer-events-none absolute right-0 top-full mt-1.5 z-50 whitespace-nowrap rounded-md bg-gray-900 dark:bg-white/95 px-2 py-1 text-[11px] font-medium text-white dark:text-gray-900 shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-150"
+        >
+          Collapse sidebar
+        </div>
       </div>
     </div>
 
@@ -31,8 +44,8 @@
     </div>
 
     <!-- Chat Input Section (fixed at bottom) -->
-    <div class="shrink-0 border-t border-gray-200 dark:border-white/[0.08] bg-white dark:bg-[#0a0a0a] transition-colors duration-300">
-      <div class="p-4">
+    <div class="shrink-0 bg-white dark:bg-[#0a0a0a] transition-colors duration-300">
+      <div class="px-2 pt-1 pb-3">
         <!-- Input shell: textarea on top, controls toolbar below -->
         <div class="chat-input-shell rounded-xl bg-gray-50 dark:bg-white/[0.03] border border-gray-200 dark:border-white/[0.06]">
           <textarea
@@ -48,9 +61,9 @@
             style="min-height: 92px; max-height: 240px;"
           ></textarea>
 
-          <!-- Controls toolbar: dropdowns wrap on the left, send stays pinned right -->
-          <div class="flex items-end justify-between gap-2 px-2 pb-2 pt-1">
-            <div class="flex flex-wrap items-center gap-1.5 min-w-0">
+          <!-- Controls toolbar: model + reasoning side by side on the left, send pinned right -->
+          <div class="flex items-center justify-between gap-2 px-2 pb-2 pt-1">
+            <div class="flex flex-nowrap items-center gap-1.5 min-w-0">
               <!-- Model Dropdown -->
               <div class="dropdown-wrapper" title="Model">
                 <i class="fas fa-microchip dropdown-icon"></i>
@@ -127,6 +140,7 @@ const props = defineProps<{
   onModelSelect: (modelId: string) => Promise<void>
   onEffortSelect: (effort: ReasoningEffort) => Promise<void>
   onExamplePrompt: (example: string) => void
+  onCollapseSidebar?: () => void
   isCollapsed?: boolean
   isManagerOpen?: boolean
 }>()
@@ -307,6 +321,7 @@ async function handleEffortSelect(effort: ReasoningEffort) {
   padding: 0.3rem 1.5rem 0.3rem 0.6rem;
   border-radius: 0.5rem;
   cursor: pointer;
+  text-overflow: ellipsis;
   appearance: none;
   -webkit-appearance: none;
   -moz-appearance: none;

--- a/frontend/vuejs/src/apps/imagi/build/layouts/BuilderLayout.vue
+++ b/frontend/vuejs/src/apps/imagi/build/layouts/BuilderLayout.vue
@@ -4,9 +4,10 @@
     :navigation-items="navigationItems"
     :wide="!extraWide"
     :extra-wide="extraWide"
+    compact-top
   >
-    <template #sidebar-content="{ isSidebarCollapsed }">
-      <slot name="sidebar-content" :collapsed="isSidebarCollapsed"></slot>
+    <template #sidebar-content="{ isSidebarCollapsed, toggleSidebar }">
+      <slot name="sidebar-content" :collapsed="isSidebarCollapsed" :toggle-sidebar="toggleSidebar"></slot>
     </template>
     
     <!-- Pass through any navbar-right content from parent -->

--- a/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
+++ b/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
@@ -13,11 +13,12 @@
       :extra-wide="isManagerOpen"
     >
       <!-- Sidebar Content: Agent Manager + Active Instance Chat -->
-      <template #sidebar-content="{ collapsed }">
+      <template #sidebar-content="{ collapsed, toggleSidebar }">
         <div v-if="!collapsed" class="flex h-full">
           <AgentManagerPanel
             v-if="isManagerOpen"
-            class="w-64 shrink-0"
+            class="w-56 shrink-0"
+            @collapse="toggleManager"
           />
           <BuilderSidebarChat
             class="flex-1 min-w-0"
@@ -26,6 +27,7 @@
             :on-model-select="handleModelSelect"
             :on-effort-select="handleEffortSelect"
             :on-example-prompt="handleExamplePrompt"
+            :on-collapse-sidebar="toggleSidebar"
             :is-collapsed="false"
             :is-manager-open="isManagerOpen"
             @toggle-manager="toggleManager"

--- a/frontend/vuejs/src/shared/layouts/DashboardLayout.vue
+++ b/frontend/vuejs/src/shared/layouts/DashboardLayout.vue
@@ -16,7 +16,11 @@
         ]"
       >
         <!-- Logo and Brand -->
-        <div class="flex-shrink-0 h-16 flex items-center justify-end px-4">
+        <div
+          v-if="!compactTop || isSidebarCollapsed"
+          class="flex-shrink-0 flex items-center justify-end"
+          :class="compactTop ? 'h-10 px-2' : 'h-16 px-4'"
+        >
           <!-- Collapse/Expand Button -->
           <button 
             @click="toggleSidebar"
@@ -64,7 +68,7 @@
 
         <!-- Custom Sidebar Content -->
         <div class="flex-1 overflow-hidden" :class="{ 'opacity-0 pointer-events-none': isSidebarCollapsed }">
-          <slot name="sidebar-content" :isSidebarCollapsed="isSidebarCollapsed"></slot>
+          <slot name="sidebar-content" :isSidebarCollapsed="isSidebarCollapsed" :toggleSidebar="toggleSidebar"></slot>
         </div>
 
         <!-- Bottom Actions -->
@@ -133,10 +137,12 @@ const props = defineProps<{
   storageKey?: string
   wide?: boolean
   extraWide?: boolean
+  compactTop?: boolean
 }>()
 
 const wide = computed(() => !!props.wide)
 const extraWide = computed(() => !!props.extraWide)
+const compactTop = computed(() => !!props.compactTop)
 
 const route = useRoute()
 const router = useRouter()


### PR DESCRIPTION
## What changed

UI polish for the Magi build workspace — the agents sidebar and the agent-instance chat.

### Agent instance cards
- Removed the mode icon, the message-preview description line, and the model label.
- Kept a descriptive title and added a relative "last used" timestamp (e.g. `2h ago`).
- Consolidated the separate rename / archive / delete buttons into a single `⋯` hover dropdown (Rename, Archive/Unarchive, Delete), with click-outside to close.

### Agents panel header
- Added a collapse arrow (top-left) and a search control that filters chats live by title / message preview, with a "no results" state and clear/close.
- Tightened the top bar so the controls sit closer to the top-left corner.

### Layout
- Added an opt-in `compact-top` prop to the shared `DashboardLayout` (docs layout unaffected) so the builder sidebar sits flush at the top with no dead space.
- Exposed the sidebar toggle to the `sidebar-content` slot so the whole-sidebar collapse arrow now lives in the **chat header** (top-right, level with New instance). The collapsed rail still provides the expand affordance.
- Narrowed the agent list panel (`w-64` → `w-56`) to give the chat input more room without widening the overall sidebar.

### Chat input
- Removed the separator line above the input box.
- Let the input box span nearly the full width of the agent instance (kept a small even side margin) while keeping its distinct box styling.
- Ensured the model / reasoning-effort / send toolbar fits on one row with no overlap in both the manager-open and manager-collapsed states.

## Notes for reviewers
- Changes are scoped to `src/apps/imagi/build/**` plus one shared-layout tweak (`DashboardLayout.vue`) that is guarded behind the new `compact-top` prop and an additional slot prop, so existing consumers (docs) are unaffected.
- `npm run type-check` passes.
- Verified interactively in the dev server: search filtering, the kebab menu actions, both collapse arrows (agent-manager panel and whole-sidebar) with expand round-trips, and toolbar spacing in open/collapsed states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)