### PR TITLE
Align build workspace design with home, about, and projects pages

### DIFF
--- a/frontend/vuejs/src/apps/imagi/build/components/atoms/inputs/SearchInput.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/atoms/inputs/SearchInput.vue
@@ -11,7 +11,7 @@
         :class="inputClass"
         :placeholder="placeholder"
       >
-      <i v-if="!isProject" class="fas fa-search absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"></i>
+      <i v-if="!isProject" class="fas fa-search absolute left-3 top-1/2 -translate-y-1/2 text-blue-950/40 dark:text-white/40"></i>
     </div>
   </div>
 </template>
@@ -34,8 +34,8 @@ const wrapperClass = computed(() => isProject.value ? 'relative group flex-1 max
 
 const inputClass = computed(() =>
   isProject.value
-    ? 'relative z-10 w-full pl-11 pr-4 py-3 bg-white/[0.03] border border-white/[0.08] focus:border-violet-400/50 hover:border-white/[0.12] rounded-xl text-white/90 placeholder-white/30 transition-all duration-300 backdrop-blur-sm hover:bg-white/[0.05] focus:bg-white/[0.05] focus:shadow-lg focus:shadow-violet-500/20 outline-none'
-    : 'w-full px-4 py-2 pl-10 bg-white/[0.03] border border-white/[0.08] focus:border-violet-400/50 rounded-xl text-white/90 placeholder-white/30 focus:ring-2 focus:ring-violet-500/20 transition-all duration-200 outline-none'
+    ? 'relative z-10 w-full pl-11 pr-4 py-3 bg-white dark:bg-white/[0.04] border border-blue-200/70 dark:border-white/[0.12] focus:border-blue-400 dark:focus:border-blue-300/50 hover:border-blue-300 dark:hover:border-white/[0.18] rounded-xl text-blue-950 dark:text-white/90 placeholder-blue-950/40 dark:placeholder-white/30 transition-all duration-300 backdrop-blur-sm hover:bg-blue-50/50 dark:hover:bg-white/[0.05] focus:bg-white dark:focus:bg-white/[0.05] focus:shadow-lg focus:shadow-blue-500/20 outline-none'
+    : 'w-full px-4 py-2 pl-10 bg-white dark:bg-white/[0.04] border border-blue-200/70 dark:border-white/[0.12] focus:border-blue-400 dark:focus:border-blue-300/50 rounded-xl text-blue-950 dark:text-white/90 placeholder-blue-950/40 dark:placeholder-white/30 focus:ring-2 focus:ring-blue-500/20 transition-all duration-200 outline-none'
 )
 
 defineEmits(['update:modelValue']);

--- a/frontend/vuejs/src/apps/imagi/build/components/molecules/display/AccountBalanceDisplay.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/molecules/display/AccountBalanceDisplay.vue
@@ -139,10 +139,10 @@ onBeforeUnmount(() => {
 
 .text-wrap { display: flex; flex-direction: column; gap: 0.125rem; min-width: 5.5rem; }
 .label-row { display: flex; align-items: center; gap: 0.3rem; }
-.label { font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: rgba(0, 0, 0, 0.5); font-weight: 600; }
+.label { font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: rgba(23, 37, 84, 0.55); font-weight: 600; }
 .value-row { display: flex; align-items: center; gap: 0.25rem; }
 .value {
-  color: rgba(0, 0, 0, 0.9);
+  color: rgb(23, 37, 84);
   font-weight: 700;
   font-size: 1rem;
   line-height: 1;

--- a/frontend/vuejs/src/apps/imagi/build/components/molecules/sidebar/AgentInstanceCard.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/molecules/sidebar/AgentInstanceCard.vue
@@ -3,8 +3,8 @@
     :class="[
       'group relative rounded-lg border px-2.5 py-2 cursor-pointer transition-all duration-200',
       isActive
-        ? 'border-indigo-400 dark:border-indigo-500/60 bg-indigo-50/70 dark:bg-indigo-500/[0.08] shadow-sm'
-        : 'border-gray-200 dark:border-white/[0.06] bg-gray-50/50 hover:bg-gray-100 dark:bg-white/[0.02] dark:hover:bg-white/[0.05]',
+        ? 'border-blue-300 dark:border-blue-400/50 bg-blue-50/80 dark:bg-blue-400/[0.08] shadow-sm'
+        : 'border-blue-100 dark:border-white/[0.06] bg-blue-50/40 hover:bg-blue-50 dark:bg-white/[0.02] dark:hover:bg-white/[0.05]',
       isArchived ? 'opacity-75' : ''
     ]"
     @click="emit('select')"
@@ -17,7 +17,7 @@
           ref="titleInput"
           v-model="draftTitle"
           type="text"
-          class="w-full bg-transparent text-xs font-semibold text-gray-900 dark:text-white/90 border-b border-indigo-400 outline-none"
+          class="w-full bg-transparent text-xs font-semibold text-blue-950 dark:text-white/90 border-b border-blue-400 outline-none"
           @click.stop
           @keydown.enter.prevent="commitRename"
           @keydown.escape="cancelRename"
@@ -25,13 +25,13 @@
         />
         <div
           v-else
-          class="text-xs font-semibold text-gray-900 dark:text-white/90 truncate"
+          class="text-xs font-semibold text-blue-950 dark:text-white/90 truncate"
         >
           {{ instance.title || 'Untitled instance' }}
         </div>
-        <div class="flex items-center gap-1.5 mt-1 text-[10px] text-gray-400 dark:text-white/40">
+        <div class="flex items-center gap-1.5 mt-1 text-[10px] text-blue-950/40 dark:text-white/40">
           <span>{{ relativeTime(instance.updatedAt) }}</span>
-          <span v-if="instance.isProcessing" class="ml-1 flex items-center gap-1 text-indigo-500 dark:text-indigo-300">
+          <span v-if="instance.isProcessing" class="ml-1 flex items-center gap-1 text-blue-600 dark:text-blue-300">
             <i class="fas fa-circle-notch fa-spin text-[9px]"></i>
             <span>running</span>
           </span>
@@ -42,8 +42,8 @@
       <div ref="menuRef" class="relative shrink-0" @click.stop>
         <button
           :class="[
-            'w-6 h-6 flex items-center justify-center rounded transition-opacity hover:bg-gray-200 dark:hover:bg-white/[0.08] text-gray-500 dark:text-white/60',
-            menuOpen ? 'opacity-100 bg-gray-200 dark:bg-white/[0.08]' : 'opacity-0 group-hover:opacity-100 focus:opacity-100'
+            'w-6 h-6 flex items-center justify-center rounded transition-opacity hover:bg-blue-100 dark:hover:bg-white/[0.08] text-blue-950/50 dark:text-white/60',
+            menuOpen ? 'opacity-100 bg-blue-100 dark:bg-white/[0.08]' : 'opacity-0 group-hover:opacity-100 focus:opacity-100'
           ]"
           title="Options"
           @click.stop="toggleMenu"
@@ -52,7 +52,7 @@
         </button>
         <div
           v-if="menuOpen"
-          class="absolute right-0 top-full mt-1 z-50 min-w-[130px] rounded-md border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-[#161616] shadow-lg py-1"
+          class="absolute right-0 top-full mt-1 z-50 min-w-[130px] rounded-md border border-blue-100 dark:border-white/[0.08] bg-white dark:bg-[#161616] shadow-lg py-1"
         >
           <button class="menu-item" @click.stop="onRename">
             <i class="fas fa-pen menu-item-icon"></i>
@@ -184,12 +184,12 @@ function relativeTime(iso: string): string {
   font-size: 0.6875rem;
   font-weight: 500;
   text-align: left;
-  color: rgb(55, 65, 81);
+  color: rgb(23, 37, 84);
   transition: background-color 0.15s ease;
 }
 
 .menu-item:hover {
-  background-color: rgba(0, 0, 0, 0.05);
+  background-color: rgba(59, 130, 246, 0.08);
 }
 
 .dark .menu-item {
@@ -220,7 +220,7 @@ function relativeTime(iso: string): string {
   width: 0.875rem;
   font-size: 0.625rem;
   text-align: center;
-  color: rgba(107, 114, 128, 0.9);
+  color: rgba(37, 99, 235, 0.75);
 }
 
 .menu-item--danger .menu-item-icon {

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/chat/ChatConversation.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/chat/ChatConversation.vue
@@ -15,8 +15,8 @@
               class="message-block message-user"
               :class="{ 'animate-message-in': message.isNew }" 
               :style="message.isNew ? { 'animation-delay': `${index * 0.05}s` } : {}">
-              <div class="message-label text-gray-500 dark:text-gray-400">You</div>
-              <div class="message-content text-gray-900 dark:text-white">
+              <div class="message-label text-blue-950/50 dark:text-blue-100/50">You</div>
+              <div class="message-content text-blue-950 dark:text-white">
                 <p class="whitespace-pre-wrap break-words text-sm leading-relaxed">{{ message.content }}</p>
               </div>
             </div>
@@ -26,7 +26,7 @@
               class="message-block message-assistant"
               :class="{ 'animate-message-in': message.isNew }" 
               :style="message.isNew ? { 'animation-delay': `${index * 0.05}s` } : {}">
-              <div class="message-label text-gray-500 dark:text-gray-400">Imagi</div>
+              <div class="message-label text-blue-700/70 dark:text-blue-300/70">Imagi</div>
               <div class="message-content">
                 <div 
                   class="prose prose-gray dark:prose-invert max-w-none prose-p:my-2 prose-headings:mb-3 prose-headings:mt-4 leading-relaxed text-sm"
@@ -41,7 +41,7 @@
               class="flex justify-center my-4" 
               :class="{ 'animate-fade-in': message.isNew }" 
               :style="message.isNew ? { 'animation-delay': `${index * 0.05}s` } : {}">
-              <span class="text-xs text-gray-400 dark:text-gray-500 px-3 py-1">{{ message.content }}</span>
+              <span class="text-xs text-blue-950/40 dark:text-blue-100/40 px-3 py-1">{{ message.content }}</span>
             </div>
             
             <!-- Other message types -->
@@ -49,13 +49,13 @@
               class="flex justify-center my-4" 
               :class="{ 'animate-message-in': message.isNew }" 
               :style="message.isNew ? { 'animation-delay': `${index * 0.05}s` } : {}">
-              <span class="text-xs text-gray-400 dark:text-gray-500 px-3 py-1">{{ message.content }}</span>
+              <span class="text-xs text-blue-950/40 dark:text-blue-100/40 px-3 py-1">{{ message.content }}</span>
             </div>
           </template>
           
           <!-- "AI is typing" indicator -->
           <div v-if="props.isProcessing" class="message-block message-assistant animate-fade-in">
-            <div class="message-label text-gray-500 dark:text-gray-400">Imagi</div>
+            <div class="message-label text-blue-700/70 dark:text-blue-300/70">Imagi</div>
             <div class="message-content">
               <div class="flex items-center gap-3">
                 <div class="typing-indicator">
@@ -63,7 +63,7 @@
                   <span></span>
                   <span></span>
                 </div>
-                <span class="text-sm text-gray-500 dark:text-gray-400">Working...</span>
+                <span class="text-sm text-blue-950/50 dark:text-blue-100/50">Working...</span>
               </div>
             </div>
           </div>
@@ -249,15 +249,15 @@ const copyToClipboard = (code: string) => {
 }
 
 .dark .message-user {
-  background-color: #000000;
+  background-color: #0a0a0a;
 }
 
 .message-assistant {
-  background-color: #f8fafc;
+  background-color: #f2f7ff;
 }
 
 .dark .message-assistant {
-  background-color: #1a1a1a;
+  background-color: #101722;
 }
 
 .message-label {
@@ -277,16 +277,16 @@ const copyToClipboard = (code: string) => {
 .prose {
   font-size: 0.875rem;
   line-height: 1.6;
-  color: theme('colors.gray.900');
+  color: theme('colors.blue.950');
 }
 
 .dark .prose {
-  color: theme('colors.gray.100');
+  color: rgba(219, 234, 254, 0.85);
 }
 
 .prose pre {
-  background: theme('colors.gray.100');
-  border: 1px solid theme('colors.gray.200');
+  background: theme('colors.blue.50');
+  border: 1px solid rgba(191, 219, 254, 0.7);
   border-radius: 0.5rem;
   padding: 1rem;
   margin: 1rem 0;
@@ -299,18 +299,18 @@ const copyToClipboard = (code: string) => {
 }
 
 .prose code {
-  color: theme('colors.gray.800');
-  background: theme('colors.gray.100');
+  color: theme('colors.orange.700');
+  background: theme('colors.orange.50');
   padding: 0.125rem 0.375rem;
   border-radius: 0.375rem;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  border: 1px solid theme('colors.gray.200');
+  border: 1px solid rgba(254, 215, 170, 0.7);
 }
 
 .dark .prose code {
-  color: theme('colors.amber.300');
-  background: rgba(31, 41, 55, 0.7);
-  border: 1px solid rgba(251, 191, 36, 0.2);
+  color: theme('colors.orange.300');
+  background: rgba(251, 146, 60, 0.1);
+  border: 1px solid rgba(251, 146, 60, 0.2);
 }
 
 .prose p {
@@ -325,11 +325,11 @@ const copyToClipboard = (code: string) => {
   margin-top: 1.5rem;
   margin-bottom: 0.75rem;
   font-weight: 600;
-  color: theme('colors.gray.900');
+  color: theme('colors.blue.950');
 }
 
 .dark .prose h1, .dark .prose h2, .dark .prose h3, .dark .prose h4 {
-  color: theme('colors.gray.100');
+  color: theme('colors.white');
 }
 
 .prose ul, .prose ol {
@@ -410,14 +410,14 @@ const copyToClipboard = (code: string) => {
 .typing-indicator span {
   height: 5px;
   width: 5px;
-  background: theme('colors.gray.400');
+  background: theme('colors.blue.400');
   display: block;
   border-radius: 50%;
   animation: typing 1.4s infinite ease-in-out both;
 }
 
 .dark .typing-indicator span {
-  background: theme('colors.gray.500');
+  background: theme('colors.blue.300');
 }
 
 .typing-indicator span:nth-child(1) {
@@ -450,14 +450,14 @@ const copyToClipboard = (code: string) => {
 .prose-invert h4,
 .prose-invert h5,
 .prose-invert h6 {
-  color: theme('colors.gray.100');
+  color: theme('colors.white');
   font-weight: 600;
   margin-top: 1.5rem;
   margin-bottom: 0.75rem;
 }
 
 .prose-invert p {
-  color: theme('colors.gray.300');
+  color: rgba(219, 234, 254, 0.8);
   line-height: 1.6;
   margin-bottom: 0.75rem;
 }
@@ -472,17 +472,17 @@ const copyToClipboard = (code: string) => {
 }
 
 .prose-invert code {
-  color: theme('colors.amber.300');
-  background-color: rgba(31, 41, 55, 0.7);
+  color: theme('colors.orange.300');
+  background-color: rgba(251, 146, 60, 0.1);
   padding: 0.2rem 0.4rem;
   border-radius: 0.375rem;
   font-size: 0.875rem;
-  border: 1px solid rgba(251, 191, 36, 0.2);
+  border: 1px solid rgba(251, 146, 60, 0.2);
 }
 
 .prose-invert blockquote {
-  color: theme('colors.gray.400');
-  border-left-color: theme('colors.gray.600');
+  color: rgba(191, 219, 254, 0.7);
+  border-left-color: rgba(59, 130, 246, 0.5);
   border-left-width: 4px;
   padding-left: 1rem;
   font-style: italic;
@@ -491,7 +491,7 @@ const copyToClipboard = (code: string) => {
 
 .prose-invert ul,
 .prose-invert ol {
-  color: theme('colors.gray.300');
+  color: rgba(219, 234, 254, 0.8);
   margin-left: 1.5rem;
   margin-bottom: 1rem;
 }
@@ -502,13 +502,13 @@ const copyToClipboard = (code: string) => {
 }
 
 .prose-invert a {
-  color: theme('colors.gray.400');
+  color: theme('colors.blue.300');
   text-decoration: underline;
-  text-decoration-color: rgba(156, 163, 175, 0.4);
+  text-decoration-color: rgba(147, 197, 253, 0.4);
 }
 
 .prose-invert a:hover {
-  color: theme('colors.gray.300');
-  text-decoration-color: rgba(209, 213, 219, 0.6);
+  color: theme('colors.blue.200');
+  text-decoration-color: rgba(191, 219, 254, 0.6);
 }
 </style> 

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/chat/ChatMessagesList.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/chat/ChatMessagesList.vue
@@ -17,24 +17,24 @@
       >
         <!-- User Message -->
         <div v-if="message.role === 'user'">
-          <div class="message-label text-gray-500 dark:text-gray-400">You</div>
-          <div class="message-content text-gray-900 dark:text-white">
+          <div class="message-label text-blue-950/50 dark:text-blue-100/50">You</div>
+          <div class="message-content text-blue-950 dark:text-white">
             <p class="whitespace-pre-wrap text-sm leading-relaxed">{{ message.content }}</p>
           </div>
         </div>
         
         <!-- Assistant Message -->
         <div v-else>
-          <div class="message-label text-gray-500 dark:text-gray-400">Imagi</div>
-          <div class="message-content text-gray-900 dark:text-white">
+          <div class="message-label text-blue-700/70 dark:text-blue-300/70">Imagi</div>
+          <div class="message-content text-blue-950 dark:text-white">
             <p class="whitespace-pre-wrap text-sm leading-relaxed">{{ message.content }}</p>
-            
+
             <!-- Code Block if exists -->
-            <div 
-              v-if="message.code" 
-              class="mt-3 p-3 bg-gray-100 dark:bg-gray-900 rounded-md overflow-x-auto"
+            <div
+              v-if="message.code"
+              class="mt-3 p-3 bg-blue-50 dark:bg-slate-900/80 border border-blue-200/70 dark:border-white/10 rounded-md overflow-x-auto"
             >
-              <pre class="text-sm text-gray-800 dark:text-gray-300"><code>{{ message.code }}</code></pre>
+              <pre class="text-sm text-blue-950/90 dark:text-blue-100/80"><code>{{ message.code }}</code></pre>
             </div>
           </div>
         </div>
@@ -43,7 +43,7 @@
     
     <!-- Loading Indicator -->
     <div v-if="isLoading" class="message-block message-assistant">
-      <div class="message-label text-gray-500 dark:text-gray-400">Imagi</div>
+      <div class="message-label text-blue-700/70 dark:text-blue-300/70">Imagi</div>
       <div class="message-content">
         <div class="typing-indicator">
           <span></span>
@@ -93,15 +93,15 @@ onUpdated(() => {
 }
 
 .dark .message-user {
-  background-color: #000000;
+  background-color: #0a0a0a;
 }
 
 .message-assistant {
-  background-color: #f8fafc;
+  background-color: #f2f7ff;
 }
 
 .dark .message-assistant {
-  background-color: #1a1a1a;
+  background-color: #101722;
 }
 
 .message-label {
@@ -138,14 +138,14 @@ onUpdated(() => {
 .typing-indicator span {
   height: 5px;
   width: 5px;
-  background: #9ca3af;
+  background: #60a5fa;
   display: block;
   border-radius: 50%;
   animation: typing 1.4s infinite ease-in-out both;
 }
 
 .dark .typing-indicator span {
-  background: #6b7280;
+  background: #93c5fd;
 }
 
 .typing-indicator span:nth-child(1) {

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/modals/ConfirmModal.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/modals/ConfirmModal.vue
@@ -37,7 +37,7 @@
               <!-- Close button -->
               <button
                 type="button"
-                class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 p-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800/50 transition-all flex-shrink-0"
+                class="text-blue-950/40 hover:text-blue-950/70 p-1 rounded-lg hover:bg-blue-50 transition-all flex-shrink-0"
                 @click="handleCancel"
                 aria-label="Close"
               >
@@ -47,7 +47,7 @@
           </div>
 
           <!-- Footer / Actions -->
-          <div class="px-6 py-4 bg-gray-50 dark:bg-gray-900/40 flex items-center justify-end gap-3">
+          <div class="px-6 py-4 bg-blue-50/60 flex items-center justify-end gap-3">
             <button
               type="button"
               class="px-5 py-2.5 text-sm font-medium rounded-lg border transition-all duration-200"
@@ -134,7 +134,7 @@ const modalClasses = computed(() => {
     case 'success':
       return `${baseClasses} border-green-200 dark:border-green-300`
     default:
-      return `${baseClasses} border-gray-200 dark:border-gray-300`
+      return `${baseClasses} border-blue-200 dark:border-blue-300`
   }
 })
 
@@ -147,7 +147,7 @@ const headerClasses = computed(() => {
     case 'success':
       return 'border-green-100 dark:border-green-200/50 bg-green-50/50 dark:bg-green-50/30'
     default:
-      return 'border-gray-100 dark:border-gray-200/50 bg-gray-50/50 dark:bg-gray-50/30'
+      return 'border-blue-100 dark:border-blue-200/50 bg-blue-50/50 dark:bg-blue-50/30'
   }
 })
 
@@ -160,7 +160,7 @@ const iconContainerClasses = computed(() => {
     case 'success':
       return 'bg-green-100 dark:bg-green-100 border border-green-200 dark:border-green-300'
     default:
-      return 'bg-gray-100 dark:bg-gray-100 border border-gray-200 dark:border-gray-300'
+      return 'bg-blue-100 dark:bg-blue-100 border border-blue-200 dark:border-blue-300'
   }
 })
 
@@ -173,20 +173,20 @@ const iconClasses = computed(() => {
     case 'success':
       return 'fas fa-check-circle text-green-600 dark:text-green-600'
     default:
-      return 'fas fa-info-circle text-gray-600 dark:text-gray-600'
+      return 'fas fa-info-circle text-blue-600 dark:text-blue-600'
   }
 })
 
 const titleClasses = computed(() => {
-  return 'text-gray-900 dark:text-gray-900'
+  return 'text-blue-950 dark:text-blue-950'
 })
 
 const messageClasses = computed(() => {
-  return 'text-gray-700 dark:text-gray-700'
+  return 'text-blue-950/70 dark:text-blue-950/70'
 })
 
 const cancelButtonClasses = computed(() => {
-  return 'bg-white dark:bg-white border-gray-200 dark:border-gray-300 text-gray-700 dark:text-gray-700 hover:bg-gray-50 dark:hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed'
+  return 'bg-white dark:bg-white border-blue-200 dark:border-blue-200 text-blue-950/70 dark:text-blue-950/70 hover:bg-blue-50 dark:hover:bg-blue-50 disabled:opacity-50 disabled:cursor-not-allowed'
 })
 
 const confirmButtonClasses = computed(() => {
@@ -198,7 +198,7 @@ const confirmButtonClasses = computed(() => {
     case 'success':
       return 'bg-green-600 dark:bg-green-600 border-green-700 dark:border-green-700 text-white hover:bg-green-700 dark:hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed'
     default:
-      return 'bg-gray-900 dark:bg-gray-900 border-gray-900 dark:border-gray-900 text-white hover:bg-gray-800 dark:hover:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed'
+      return 'bg-blue-600 dark:bg-blue-600 border-blue-700 dark:border-blue-700 text-white hover:bg-blue-700 dark:hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed'
   }
 })
 

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/AgentManagerPanel.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/AgentManagerPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col h-full bg-white dark:bg-[#0a0a0a] border-r border-gray-200 dark:border-white/[0.08] transition-colors duration-300">
+  <div class="flex flex-col h-full bg-white dark:bg-[#0a0a0a] border-r border-blue-100 dark:border-white/[0.08] transition-colors duration-300">
     <!-- Confirm Modal (uses Teleport to body) -->
     <ConfirmModal
       :is-open="confirmModal.isModalOpen.value"
@@ -8,18 +8,18 @@
       @cancel="confirmModal.handleCancel"
     />
     <!-- Header -->
-    <div class="shrink-0 px-2 py-2 border-b border-gray-200 dark:border-white/[0.08] flex items-center justify-between">
+    <div class="shrink-0 px-2 py-2 border-b border-blue-100 dark:border-white/[0.08] flex items-center justify-between">
       <div class="flex items-center gap-0.5">
         <!-- Collapse -->
         <div class="relative group">
           <button
-            class="flex items-center justify-center w-7 h-7 rounded-md text-gray-600 dark:text-white/70 hover:bg-gray-100 dark:hover:bg-white/[0.08] hover:text-gray-900 dark:hover:text-white transition-colors"
+            class="flex items-center justify-center w-7 h-7 rounded-md text-blue-950/60 dark:text-white/70 hover:bg-blue-50 dark:hover:bg-white/[0.08] hover:text-blue-950 dark:hover:text-white transition-colors"
             @click="emit('collapse')"
           >
             <i class="fas fa-chevron-left text-xs"></i>
           </button>
           <div
-            class="pointer-events-none absolute left-0 top-full mt-1.5 z-50 whitespace-nowrap rounded-md bg-gray-900 dark:bg-white/95 px-2 py-1 text-[11px] font-medium text-white dark:text-gray-900 shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-150"
+            class="pointer-events-none absolute left-0 top-full mt-1.5 z-50 whitespace-nowrap rounded-md bg-blue-950 dark:bg-white/95 px-2 py-1 text-[11px] font-medium text-white dark:text-blue-950 shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-150"
           >
             Collapse
           </div>
@@ -30,15 +30,15 @@
             :class="[
               'flex items-center justify-center w-7 h-7 rounded-md transition-colors',
               showSearch
-                ? 'bg-gray-100 dark:bg-white/[0.08] text-gray-900 dark:text-white'
-                : 'text-gray-600 dark:text-white/70 hover:bg-gray-100 dark:hover:bg-white/[0.08] hover:text-gray-900 dark:hover:text-white'
+                ? 'bg-blue-50 dark:bg-white/[0.08] text-blue-950 dark:text-white'
+                : 'text-blue-950/60 dark:text-white/70 hover:bg-blue-50 dark:hover:bg-white/[0.08] hover:text-blue-950 dark:hover:text-white'
             ]"
             @click="toggleSearch"
           >
             <i class="fas fa-search text-xs"></i>
           </button>
           <div
-            class="pointer-events-none absolute left-0 top-full mt-1.5 z-50 whitespace-nowrap rounded-md bg-gray-900 dark:bg-white/95 px-2 py-1 text-[11px] font-medium text-white dark:text-gray-900 shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-150"
+            class="pointer-events-none absolute left-0 top-full mt-1.5 z-50 whitespace-nowrap rounded-md bg-blue-950 dark:bg-white/95 px-2 py-1 text-[11px] font-medium text-white dark:text-blue-950 shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-150"
           >
             Search chats
           </div>
@@ -46,13 +46,13 @@
       </div>
       <div class="relative group">
         <button
-          class="flex items-center justify-center w-7 h-7 rounded-md bg-gray-100 hover:bg-gray-200 dark:bg-white/[0.05] dark:hover:bg-white/[0.1] text-gray-700 dark:text-white/80 transition-colors"
+          class="flex items-center justify-center w-7 h-7 rounded-md bg-blue-50 hover:bg-blue-100 dark:bg-white/[0.05] dark:hover:bg-white/[0.1] text-blue-700 dark:text-white/80 transition-colors"
           @click="handleCreate"
         >
           <i class="fas fa-plus text-xs"></i>
         </button>
         <div
-          class="pointer-events-none absolute right-0 top-full mt-1.5 z-50 whitespace-nowrap rounded-md bg-gray-900 dark:bg-white/95 px-2 py-1 text-[11px] font-medium text-white dark:text-gray-900 shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-150"
+          class="pointer-events-none absolute right-0 top-full mt-1.5 z-50 whitespace-nowrap rounded-md bg-blue-950 dark:bg-white/95 px-2 py-1 text-[11px] font-medium text-white dark:text-blue-950 shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-150"
         >
           New agent instance
         </div>
@@ -60,20 +60,20 @@
     </div>
 
     <!-- Search input -->
-    <div v-if="showSearch" class="shrink-0 px-2 py-2 border-b border-gray-200 dark:border-white/[0.08]">
-      <div class="flex items-center gap-2 rounded-md bg-gray-100 dark:bg-white/[0.05] px-2 py-1.5">
-        <i class="fas fa-search text-[11px] text-gray-400 dark:text-white/40 shrink-0"></i>
+    <div v-if="showSearch" class="shrink-0 px-2 py-2 border-b border-blue-100 dark:border-white/[0.08]">
+      <div class="flex items-center gap-2 rounded-md bg-blue-50 dark:bg-white/[0.05] px-2 py-1.5">
+        <i class="fas fa-search text-[11px] text-blue-950/40 dark:text-white/40 shrink-0"></i>
         <input
           ref="searchInput"
           v-model="searchQuery"
           type="text"
           placeholder="Search chats"
-          class="flex-1 min-w-0 bg-transparent text-xs text-gray-900 dark:text-white/90 placeholder-gray-400 dark:placeholder-white/30 outline-none"
+          class="flex-1 min-w-0 bg-transparent text-xs text-blue-950 dark:text-white/90 placeholder-blue-950/40 dark:placeholder-white/30 outline-none"
           @keydown.escape="closeSearch"
         />
         <button
           v-if="searchQuery"
-          class="shrink-0 text-gray-400 hover:text-gray-600 dark:text-white/40 dark:hover:text-white/70 transition-colors"
+          class="shrink-0 text-blue-950/40 hover:text-blue-950/70 dark:text-white/40 dark:hover:text-white/70 transition-colors"
           @click="searchQuery = ''"
         >
           <i class="fas fa-times text-[11px]"></i>
@@ -84,21 +84,21 @@
     <!-- Instances list -->
     <div class="flex-1 min-h-0 overflow-y-auto px-2 py-2 space-y-1">
       <!-- Loading state -->
-      <div v-if="store.instancesLoading && store.instances.length === 0" class="text-xs text-gray-400 dark:text-white/40 px-2 py-4 text-center">
+      <div v-if="store.instancesLoading && store.instances.length === 0" class="text-xs text-blue-950/40 dark:text-white/40 px-2 py-4 text-center">
         Loading...
       </div>
 
       <!-- No search results -->
       <div
         v-else-if="showSearch && searchQuery.trim() && !hasResults"
-        class="text-xs text-gray-400 dark:text-white/40 px-2 py-4 text-center"
+        class="text-xs text-blue-950/40 dark:text-white/40 px-2 py-4 text-center"
       >
         No chats match "{{ searchQuery.trim() }}"
       </div>
 
       <!-- Active instances -->
       <template v-if="activeInstances.length > 0">
-        <div class="text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-white/40 px-2 py-1">
+        <div class="text-[10px] font-semibold uppercase tracking-wider text-blue-950/40 dark:text-white/40 px-2 py-1">
           Active
         </div>
         <InstanceCard
@@ -116,7 +116,7 @@
       <!-- Archived / past instances -->
       <template v-if="archivedInstances.length > 0">
         <button
-          class="w-full flex items-center justify-between px-2 py-2 mt-3 text-[10px] font-semibold uppercase tracking-wider text-gray-400 dark:text-white/40 hover:text-gray-600 dark:hover:text-white/70 transition-colors"
+          class="w-full flex items-center justify-between px-2 py-2 mt-3 text-[10px] font-semibold uppercase tracking-wider text-blue-950/40 dark:text-white/40 hover:text-blue-950/70 dark:hover:text-white/70 transition-colors"
           @click="showArchived = !showArchived"
         >
           <span>Past ({{ archivedInstances.length }})</span>

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
@@ -1,32 +1,32 @@
 <template>
-  <div v-if="!isCollapsed" class="flex flex-col h-full bg-white dark:bg-[#0a0a0a] border-r border-gray-200 dark:border-white/[0.08] transition-colors duration-300">
+  <div v-if="!isCollapsed" class="flex flex-col h-full bg-white dark:bg-[#0a0a0a] border-r border-blue-100 dark:border-white/[0.08] transition-colors duration-300">
     <!-- Header: manager toggle + instance title -->
-    <div class="shrink-0 flex items-center gap-2 px-3 py-2 border-b border-gray-200 dark:border-white/[0.08]">
+    <div class="shrink-0 flex items-center gap-2 px-3 py-2 border-b border-blue-100 dark:border-white/[0.08]">
       <div v-if="!isManagerOpen" class="relative group">
         <button
-          class="flex items-center justify-center w-8 h-8 rounded-md text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-dark-800/70 hover:text-gray-900 dark:hover:text-white transition-colors duration-200"
+          class="flex items-center justify-center w-8 h-8 rounded-md text-blue-950/60 dark:text-white/60 hover:bg-blue-50 dark:hover:bg-white/[0.08] hover:text-blue-950 dark:hover:text-white transition-colors duration-200"
           @click="$emit('toggleManager')"
         >
           <i class="fas fa-chevron-right text-sm"></i>
         </button>
         <div
-          class="pointer-events-none absolute left-0 top-full mt-1.5 z-50 whitespace-nowrap rounded-md bg-gray-900 dark:bg-white/95 px-2 py-1 text-[11px] font-medium text-white dark:text-gray-900 shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-150"
+          class="pointer-events-none absolute left-0 top-full mt-1.5 z-50 whitespace-nowrap rounded-md bg-blue-950 dark:bg-white/95 px-2 py-1 text-[11px] font-medium text-white dark:text-blue-950 shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-150"
         >
           Show agent manager
         </div>
       </div>
-      <div class="flex-1 min-w-0 text-xs font-semibold text-gray-700 dark:text-white/80 truncate">
+      <div class="flex-1 min-w-0 text-xs font-semibold text-blue-950/80 dark:text-white/80 truncate">
         {{ activeInstance?.title || 'New instance' }}
       </div>
       <div v-if="onCollapseSidebar" class="relative group shrink-0">
         <button
-          class="flex items-center justify-center w-8 h-8 rounded-md text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-dark-800/70 hover:text-gray-900 dark:hover:text-white transition-colors duration-200"
+          class="flex items-center justify-center w-8 h-8 rounded-md text-blue-950/60 dark:text-white/60 hover:bg-blue-50 dark:hover:bg-white/[0.08] hover:text-blue-950 dark:hover:text-white transition-colors duration-200"
           @click="onCollapseSidebar()"
         >
           <i class="fas fa-chevron-left text-sm"></i>
         </button>
         <div
-          class="pointer-events-none absolute right-0 top-full mt-1.5 z-50 whitespace-nowrap rounded-md bg-gray-900 dark:bg-white/95 px-2 py-1 text-[11px] font-medium text-white dark:text-gray-900 shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-150"
+          class="pointer-events-none absolute right-0 top-full mt-1.5 z-50 whitespace-nowrap rounded-md bg-blue-950 dark:bg-white/95 px-2 py-1 text-[11px] font-medium text-white dark:text-blue-950 shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-150"
         >
           Collapse sidebar
         </div>
@@ -47,7 +47,7 @@
     <div class="shrink-0 bg-white dark:bg-[#0a0a0a] transition-colors duration-300">
       <div class="px-2 pt-1 pb-3">
         <!-- Input shell: textarea on top, controls toolbar below -->
-        <div class="chat-input-shell rounded-xl bg-gray-50 dark:bg-white/[0.03] border border-gray-200 dark:border-white/[0.06]">
+        <div class="chat-input-shell rounded-xl bg-blue-50/50 dark:bg-white/[0.03] border border-blue-200/70 dark:border-white/[0.08]">
           <textarea
             ref="promptTextarea"
             v-model="prompt"
@@ -57,7 +57,7 @@
             @input="autoResizeTextarea"
             :disabled="!activeInstance || activeInstance.isProcessing"
             rows="4"
-            class="chat-textarea w-full bg-transparent text-gray-900 dark:text-white/90 placeholder-gray-400 dark:placeholder-white/30 text-sm px-3 pt-3 pb-1 resize-none leading-relaxed"
+            class="chat-textarea w-full bg-transparent text-blue-950 dark:text-white/90 placeholder-blue-950/40 dark:placeholder-white/30 text-sm px-3 pt-3 pb-1 resize-none leading-relaxed"
             style="min-height: 92px; max-height: 240px;"
           ></textarea>
 
@@ -110,10 +110,10 @@
               @click="handlePrompt"
               :disabled="!prompt.trim() || !activeInstance || activeInstance.isProcessing"
               aria-label="Send message"
-              class="btn-3d flex shrink-0 items-center justify-center w-9 h-9 rounded-full transition-all duration-300"
+              class="btn-send flex shrink-0 items-center justify-center w-9 h-9 rounded-full transition-all duration-300"
               :class="prompt.trim() && activeInstance && !activeInstance.isProcessing
-                ? 'bg-gradient-to-b from-gray-800 via-gray-900 to-gray-950 dark:from-white dark:via-gray-50 dark:to-gray-100 text-white dark:text-gray-900 border border-gray-700/50 dark:border-gray-300/50 shadow-lg hover:shadow-xl'
-                : 'bg-gradient-to-b from-gray-200 via-gray-100 to-gray-50 dark:from-white/[0.08] dark:via-white/[0.05] dark:to-white/[0.03] text-gray-400 dark:text-white/40 cursor-not-allowed border border-gray-300/70 dark:border-white/[0.12] shadow-sm'"
+                ? 'btn-send--active text-blue-950 border border-white/60 dark:border-white/30 shadow-lg hover:shadow-xl'
+                : 'bg-blue-100/60 dark:bg-white/[0.05] text-blue-950/40 dark:text-white/40 cursor-not-allowed border border-blue-200/70 dark:border-white/[0.12] shadow-sm'"
             >
               <i v-if="activeInstance?.isProcessing" class="fas fa-circle-notch fa-spin text-sm"></i>
               <i v-else class="fas fa-arrow-up text-sm"></i>
@@ -267,13 +267,13 @@ async function handleEffortSelect(effort: ReasoningEffort) {
 }
 
 .chat-input-shell:focus-within {
-  border-color: rgba(99, 102, 241, 0.55);
-  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+  border-color: rgba(59, 130, 246, 0.55);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
 }
 
 .dark .chat-input-shell:focus-within {
-  border-color: rgba(129, 140, 248, 0.5);
-  box-shadow: 0 0 0 3px rgba(129, 140, 248, 0.18);
+  border-color: rgba(147, 197, 253, 0.5);
+  box-shadow: 0 0 0 3px rgba(147, 197, 253, 0.18);
 }
 
 /* Dropdown wrapper provides room for leading icon */
@@ -314,8 +314,8 @@ async function handleEffortSelect(effort: ReasoningEffort) {
   background-position: right 0.55rem center;
   background-size: 0.85em;
   background-color: rgba(255, 255, 255, 0.9);
-  border: 1px solid rgba(209, 213, 219, 0.8);
-  color: rgb(55, 65, 81);
+  border: 1px solid rgba(191, 219, 254, 0.9);
+  color: rgb(23, 37, 84);
   font-weight: 600;
   letter-spacing: 0.01em;
   padding: 0.3rem 1.5rem 0.3rem 0.6rem;
@@ -347,11 +347,11 @@ async function handleEffortSelect(effort: ReasoningEffort) {
 }
 
 .dropdown-select:hover {
-  background-color: rgba(255, 255, 255, 1);
-  border-color: rgba(156, 163, 175, 0.9);
-  color: rgb(17, 24, 39);
+  background-color: rgba(239, 246, 255, 1);
+  border-color: rgba(147, 197, 253, 0.95);
+  color: rgb(23, 37, 84);
   box-shadow:
-    0 2px 6px rgba(0, 0, 0, 0.08),
+    0 2px 6px rgba(30, 58, 138, 0.08),
     inset 0 1px 0 rgba(255, 255, 255, 0.7);
 }
 
@@ -366,18 +366,18 @@ async function handleEffortSelect(effort: ReasoningEffort) {
 
 .dropdown-select:focus,
 .dropdown-select:focus-visible {
-  border-color: rgba(99, 102, 241, 0.55);
+  border-color: rgba(59, 130, 246, 0.55);
   box-shadow:
-    0 0 0 3px rgba(99, 102, 241, 0.15),
+    0 0 0 3px rgba(59, 130, 246, 0.15),
     inset 0 1px 0 rgba(255, 255, 255, 0.6);
   outline: none;
 }
 
 .dark .dropdown-select:focus,
 .dark .dropdown-select:focus-visible {
-  border-color: rgba(129, 140, 248, 0.5);
+  border-color: rgba(147, 197, 253, 0.5);
   box-shadow:
-    0 0 0 3px rgba(129, 140, 248, 0.18),
+    0 0 0 3px rgba(147, 197, 253, 0.18),
     inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
@@ -423,38 +423,28 @@ textarea:active {
   transition: none !important;
 }
 
-/* 3D Printed Button Effect - matching homepage */
-.btn-3d {
-  transform: translateZ(0);
-  box-shadow: 
-    /* Tight shadow for immediate depth */
-    0 2px 3px -1px rgba(0, 0, 0, 0.4),
-    /* Medium shadow for body lift */
-    0 6px 12px -3px rgba(0, 0, 0, 0.35),
-    /* Large diffuse shadow */
-    0 16px 32px -8px rgba(0, 0, 0, 0.3),
-    0 24px 48px -12px rgba(0, 0, 0, 0.2),
-    /* Bottom edge thickness */
-    0 3px 0 -1px rgba(0, 0, 0, 0.5),
-    /* Inset highlights */
-    inset 0 2px 4px 0 rgba(255, 255, 255, 0.2),
-    inset 0 -4px 8px -2px rgba(0, 0, 0, 0.3);
+/* Baby-blue send button - matching the site's primary "Start Building" button */
+.btn-send {
+  transform: translateY(0) translateZ(0);
 }
 
-.dark .btn-3d {
-  box-shadow: 
-    /* Tight shadow for immediate depth */
-    0 2px 3px -1px rgba(0, 0, 0, 0.1),
-    /* Medium shadow for body lift */
-    0 6px 12px -3px rgba(0, 0, 0, 0.1),
-    /* Large diffuse shadow */
-    0 16px 32px -8px rgba(0, 0, 0, 0.1),
-    0 24px 48px -12px rgba(0, 0, 0, 0.08),
-    /* Bottom edge thickness */
-    0 3px 0 -1px rgba(0, 0, 0, 0.15),
-    /* Inset highlights */
-    inset 0 3px 6px 0 rgba(255, 255, 255, 0.9),
-    inset 0 -4px 8px -2px rgba(0, 0, 0, 0.08);
+.btn-send--active {
+  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
+  box-shadow:
+    0 1px 2px rgba(30, 58, 138, 0.14),
+    0 4px 10px -2px rgba(30, 58, 138, 0.16),
+    0 10px 20px -6px rgba(30, 58, 138, 0.18),
+    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
+    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.12);
+}
+
+.dark .btn-send--active {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 10px 20px -6px rgba(0, 0, 0, 0.5),
+    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
+    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.18);
 }
 
 /* Refined minimal scrollbar - matching homepage */

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspaceBackground.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspaceBackground.vue
@@ -2,22 +2,22 @@
   <!-- Premium Background System - Matching Home Landing Page -->
   <div class="fixed inset-0 pointer-events-none overflow-hidden">
     <!-- Base gradient mesh -->
-    <div class="absolute inset-0 bg-[radial-gradient(ellipse_120%_80%_at_50%_-20%,rgba(120,119,198,0.15),transparent_50%)]"></div>
-    <div class="absolute inset-0 bg-[radial-gradient(ellipse_80%_50%_at_80%_50%,rgba(78,68,206,0.08),transparent_40%)]"></div>
-    <div class="absolute inset-0 bg-[radial-gradient(ellipse_60%_40%_at_10%_80%,rgba(167,139,250,0.06),transparent_35%)]"></div>
-    
+    <div class="absolute inset-0 bg-[radial-gradient(ellipse_120%_80%_at_50%_-20%,rgba(59,130,246,0.12),transparent_50%)]"></div>
+    <div class="absolute inset-0 bg-[radial-gradient(ellipse_80%_50%_at_80%_50%,rgba(37,99,235,0.07),transparent_40%)]"></div>
+    <div class="absolute inset-0 bg-[radial-gradient(ellipse_60%_40%_at_10%_80%,rgba(251,146,60,0.05),transparent_35%)]"></div>
+
     <!-- Subtle grain texture -->
     <div class="absolute inset-0 opacity-[0.015]" style="background-image: url('data:image/svg+xml,%3Csvg viewBox=%220 0 256 256%22 xmlns=%22http://www.w3.org/2000/svg%22%3E%3Cfilter id=%22noise%22%3E%3CfeTurbulence type=%22fractalNoise%22 baseFrequency=%220.8%22 numOctaves=%224%22 stitchTiles=%22stitch%22/%3E%3C/filter%3E%3Crect width=%22100%25%22 height=%22100%25%22 filter=%22url(%23noise)%22/%3E%3C/svg%3E');"></div>
-    
+
     <!-- Animated aurora effect -->
     <div class="absolute top-0 left-1/4 right-1/4 h-[600px] opacity-30">
-      <div class="absolute inset-0 bg-gradient-to-b from-violet-500/20 via-fuchsia-500/10 to-transparent blur-[100px] animate-aurora"></div>
+      <div class="absolute inset-0 bg-gradient-to-b from-blue-500/20 via-sky-400/10 to-transparent blur-[100px] animate-aurora"></div>
     </div>
-    
+
     <!-- Floating orbs -->
-    <div class="absolute top-[20%] right-[10%] w-[500px] h-[500px] rounded-full bg-gradient-to-br from-indigo-600/8 to-violet-600/4 blur-[120px] animate-float-slow"></div>
-    <div class="absolute bottom-[10%] left-[5%] w-[400px] h-[400px] rounded-full bg-gradient-to-tr from-fuchsia-600/6 to-purple-600/3 blur-[100px] animate-float-delayed"></div>
-    <div class="absolute top-[60%] right-[30%] w-[300px] h-[300px] rounded-full bg-gradient-to-bl from-amber-500/4 to-orange-500/2 blur-[80px] animate-float-reverse"></div>
+    <div class="absolute top-[20%] right-[10%] w-[500px] h-[500px] rounded-full bg-gradient-to-br from-blue-600/10 to-sky-500/[0.04] blur-[120px] animate-float-slow"></div>
+    <div class="absolute bottom-[10%] left-[5%] w-[400px] h-[400px] rounded-full bg-gradient-to-tr from-blue-500/[0.07] to-indigo-500/[0.03] blur-[100px] animate-float-delayed"></div>
+    <div class="absolute top-[60%] right-[30%] w-[300px] h-[300px] rounded-full bg-gradient-to-bl from-amber-500/[0.05] to-orange-500/[0.03] blur-[80px] animate-float-reverse"></div>
   </div>
 </template>
 

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspaceError.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspaceError.vue
@@ -4,7 +4,7 @@
       <!-- Clean Error Container -->
       <div class="relative max-w-xl w-full transition-all duration-300">
         <!-- Clean Error Card -->
-        <div class="relative rounded-2xl border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] shadow-lg overflow-hidden transition-all duration-300">
+        <div class="crisp-card relative rounded-2xl border border-blue-200/70 dark:border-blue-300/[0.16] bg-white dark:bg-white/[0.05] overflow-hidden transition-all duration-300">
           <div class="relative p-8">
             <!-- Error Icon -->
             <div class="w-16 h-16 bg-red-50 dark:bg-red-900/10 border border-red-200 dark:border-red-800/30 rounded-2xl flex items-center justify-center mx-auto mb-6 transition-colors duration-300">
@@ -12,21 +12,23 @@
             </div>
 
             <!-- Error Content -->
-            <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mb-4 transition-colors duration-300">Something went wrong</h2>
-            <p class="text-gray-600 dark:text-white/60 mb-8 leading-relaxed transition-colors duration-300">{{ error }}</p>
+            <h2 class="text-2xl font-semibold text-blue-950 dark:text-white mb-4 transition-colors duration-300">Something went wrong</h2>
+            <p class="text-blue-950/70 dark:text-blue-100/70 mb-8 leading-relaxed transition-colors duration-300">{{ error }}</p>
 
             <!-- Action Buttons -->
             <div class="flex flex-col sm:flex-row gap-4 justify-center">
               <router-link
                 to="/imagi/projects"
-                class="inline-flex items-center justify-center px-6 py-3 rounded-xl border border-gray-200 dark:border-white/[0.08] bg-gradient-to-b from-gray-800 via-gray-900 to-gray-950 dark:from-white dark:via-gray-50 dark:to-gray-100 text-white dark:text-gray-900 shadow-lg hover:shadow-xl transition-all duration-300 font-semibold"
+                class="btn-3d btn-accent group relative inline-flex items-center justify-center px-6 py-3 rounded-full text-blue-950 border border-white/60 dark:border-white/30 font-semibold overflow-hidden"
               >
-                <i class="fas fa-arrow-left mr-2"></i>
-                Go to Dashboard
+                <span class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/70 to-transparent"></span>
+                <span class="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-blue-900/15 to-transparent"></span>
+                <i class="fas fa-arrow-left mr-2 relative"></i>
+                <span class="relative">Go to Dashboard</span>
               </router-link>
               <button
                 @click="$emit('retry')"
-                class="inline-flex items-center justify-center px-6 py-3 rounded-xl border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-gray-50 dark:hover:bg-white/[0.06] text-gray-700 dark:text-white/70 hover:text-gray-900 dark:hover:text-white shadow-sm hover:shadow-md transition-all duration-300 font-medium"
+                class="inline-flex items-center justify-center px-6 py-3 rounded-full border border-blue-200/70 dark:border-white/[0.12] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-blue-950/80 dark:text-white/70 hover:text-blue-950 dark:hover:text-white shadow-sm hover:shadow-md transition-all duration-300 font-medium"
               >
                 <i class="fas fa-sync-alt mr-2"></i>
                 Retry
@@ -42,3 +44,51 @@
 <script setup lang="ts">
 const props = defineProps<{ error: string | null | undefined }>()
 </script>
+
+<style scoped>
+/* Crisp, sharply-defined card matching Home/About/Projects */
+.crisp-card {
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.03),
+    0 1px 2px rgba(15, 23, 42, 0.06),
+    0 4px 10px -2px rgba(15, 23, 42, 0.07),
+    0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
+
+.dark .crisp-card {
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 12px 28px -10px rgba(0, 0, 0, 0.55);
+}
+
+/* Soft 3D button matching the site's primary "Start Building" button */
+.btn-3d {
+  transform: translateY(0) translateZ(0);
+  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+  box-shadow:
+    0 1px 2px rgba(30, 58, 138, 0.14),
+    0 4px 10px -2px rgba(30, 58, 138, 0.16),
+    0 10px 20px -6px rgba(30, 58, 138, 0.18),
+    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
+    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.12);
+}
+
+.btn-3d:active {
+  transition-duration: 0.1s;
+}
+
+.btn-accent {
+  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
+}
+
+.dark .btn-3d {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 10px 20px -6px rgba(0, 0, 0, 0.5),
+    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
+    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.18);
+}
+</style>

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspacePreview.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspacePreview.vue
@@ -3,7 +3,7 @@
     <!-- Loading state -->
     <div
       v-if="isLoading"
-      class="flex-1 flex flex-col items-center justify-center gap-3 text-gray-600 dark:text-white/60"
+      class="flex-1 flex flex-col items-center justify-center gap-3 text-blue-950/60 dark:text-white/60"
     >
       <i class="fas fa-spinner fa-spin text-2xl"></i>
       <span class="text-sm font-medium">Starting preview server…</span>
@@ -17,10 +17,10 @@
       <div class="w-12 h-12 bg-red-50 dark:bg-red-900/10 border border-red-200 dark:border-red-800/30 rounded-xl flex items-center justify-center">
         <i class="fas fa-exclamation-triangle text-red-600 dark:text-red-400"></i>
       </div>
-      <p class="text-sm text-gray-700 dark:text-white/70 max-w-md">{{ error }}</p>
+      <p class="text-sm text-blue-950/70 dark:text-white/70 max-w-md">{{ error }}</p>
       <button
         @click="loadPreview"
-        class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-gray-50 dark:hover:bg-white/[0.06] text-sm font-medium text-gray-700 dark:text-white/70 transition-colors"
+        class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-sm font-medium text-blue-950/70 dark:text-white/70 transition-colors"
       >
         <i class="fas fa-sync-alt text-xs"></i>
         Retry
@@ -29,13 +29,13 @@
 
     <!-- Ready state: app + page selectors + iframe -->
     <template v-else-if="previewUrl">
-      <div class="flex flex-col gap-2 px-3 py-2 border-b border-gray-200 dark:border-white/[0.08] bg-gray-50 dark:bg-white/[0.02]">
+      <div class="flex flex-col gap-2 px-3 py-2 border-b border-blue-200/60 dark:border-white/[0.08] bg-blue-50/50 dark:bg-white/[0.02]">
         <div class="flex items-center gap-2 flex-wrap">
           <button
             type="button"
             @click="reload"
             title="Refresh page"
-            class="inline-flex items-center justify-center w-9 h-9 shrink-0 rounded-lg border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-gray-100 dark:hover:bg-white/[0.06] text-gray-700 dark:text-white/70 transition-colors"
+            class="inline-flex items-center justify-center w-9 h-9 shrink-0 rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-blue-950/70 dark:text-white/70 transition-colors"
           >
             <i class="fas fa-sync-alt text-sm"></i>
           </button>
@@ -44,7 +44,7 @@
             type="button"
             @click="goHome"
             title="Go to home page"
-            class="inline-flex items-center justify-center w-9 h-9 shrink-0 rounded-lg border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-gray-100 dark:hover:bg-white/[0.06] text-gray-700 dark:text-white/70 transition-colors"
+            class="inline-flex items-center justify-center w-9 h-9 shrink-0 rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-blue-950/70 dark:text-white/70 transition-colors"
           >
             <i class="fas fa-home text-sm"></i>
           </button>
@@ -55,16 +55,16 @@
               type="button"
               @click="menuOpen = !menuOpen"
               :disabled="apps.length === 0"
-              class="w-full flex items-center gap-2 rounded-lg border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-gray-50 dark:hover:bg-white/[0.06] focus:border-gray-400 dark:focus:border-white/20 outline-none py-2 pl-3 pr-9 text-sm font-medium text-gray-900 dark:text-white/90 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+              class="w-full flex items-center gap-2 rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] focus:border-blue-400 dark:focus:border-blue-300/40 outline-none py-2 pl-3 pr-9 text-sm font-medium text-blue-950 dark:text-white/90 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              <i class="fas fa-cube text-xs text-gray-500 dark:text-white/50 shrink-0"></i>
+              <i class="fas fa-cube text-xs text-blue-950/50 dark:text-white/50 shrink-0"></i>
               <span class="truncate flex-1 text-left">{{ triggerLabel }}</span>
-              <i class="fas fa-chevron-down absolute right-3 top-1/2 -translate-y-1/2 text-xs text-gray-500 dark:text-white/40 pointer-events-none"></i>
+              <i class="fas fa-chevron-down absolute right-3 top-1/2 -translate-y-1/2 text-xs text-blue-950/50 dark:text-white/40 pointer-events-none"></i>
             </button>
 
             <div
               v-if="menuOpen && apps.length > 0"
-              class="absolute z-20 mt-1 left-0 min-w-[14rem] rounded-lg border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-[#0f0f0f] shadow-lg py-1"
+              class="absolute z-20 mt-1 left-0 min-w-[14rem] rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-[#0f0f0f] shadow-lg py-1"
             >
               <div
                 v-for="app in apps"
@@ -76,18 +76,18 @@
                 <button
                   type="button"
                   @click="hoveredApp = hoveredApp === app.name ? '' : app.name"
-                  class="w-full flex items-center justify-between gap-2 px-3 py-2 text-sm text-gray-900 dark:text-white/90 hover:bg-gray-50 dark:hover:bg-white/[0.05]"
+                  class="w-full flex items-center justify-between gap-2 px-3 py-2 text-sm text-blue-950 dark:text-white/90 hover:bg-blue-50 dark:hover:bg-white/[0.05]"
                 >
                   <span class="flex items-center gap-2 truncate">
-                    <i class="fas fa-cube text-xs text-gray-500 dark:text-white/50"></i>
+                    <i class="fas fa-cube text-xs text-blue-950/50 dark:text-white/50"></i>
                     {{ app.title }}
                   </span>
-                  <i class="fas fa-chevron-right text-[10px] text-gray-400 dark:text-white/40"></i>
+                  <i class="fas fa-chevron-right text-[10px] text-blue-950/40 dark:text-white/40"></i>
                 </button>
 
                 <div
                   v-if="hoveredApp === app.name && app.pages.length"
-                  class="absolute top-0 left-full ml-1 min-w-[14rem] rounded-lg border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-[#0f0f0f] shadow-lg py-1"
+                  class="absolute top-0 left-full ml-1 min-w-[14rem] rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-[#0f0f0f] shadow-lg py-1"
                   @mouseenter="onAppEnter(app.name)"
                   @mouseleave="onAppLeave(app.name)"
                 >
@@ -98,10 +98,10 @@
                     @click="onSelectPage(page.path)"
                     :class="['w-full flex items-center gap-2 px-3 py-2 text-sm text-left',
                              page.path === currentPath
-                               ? 'bg-gray-100 dark:bg-white/[0.08] text-gray-900 dark:text-white'
-                               : 'text-gray-700 dark:text-white/80 hover:bg-gray-50 dark:hover:bg-white/[0.05]']"
+                               ? 'bg-blue-50 dark:bg-white/[0.08] text-blue-950 dark:text-white'
+                               : 'text-blue-950/70 dark:text-white/80 hover:bg-blue-50 dark:hover:bg-white/[0.05]']"
                   >
-                    <i class="fas fa-file-alt text-xs text-gray-500 dark:text-white/50"></i>
+                    <i class="fas fa-file-alt text-xs text-blue-950/50 dark:text-white/50"></i>
                     <span class="truncate">{{ page.title }}</span>
                   </button>
                 </div>


### PR DESCRIPTION
Restyle the Imagi build workspace so its components and color scheme match
the rest of the site. Structure is unchanged; only presentation is updated.

- Replace the workspace's gray + indigo palette with the site's blue-950 /
  blue / orange palette across the chat sidebar, agent manager, instance
  cards, preview toolbar, error state, balance display, and confirm modal.
- Swap the dark-gradient send and primary buttons for the site's baby-blue
  "btn-accent" treatment (rounded-full, blue-950 text, layered 3D shadow).
- Adopt the shared crisp-card shadow and blue/orange-tinted borders on
  workspace cards and inputs.
- Tint chat message labels, prose, inline code (orange accent), and typing
  indicators to the brand palette; update focus rings to blue.
- Update the (unused) workspace background and search input to the blue/
  orange scheme for module-wide consistency.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YXdchhyZ9kM8isbYV4HWdH