### PR TITLE
Fix build workspace preview server

### DIFF
--- a/backend/django/apps/Imagi/Build/api/views.py
+++ b/backend/django/apps/Imagi/Build/api/views.py
@@ -272,9 +272,11 @@ class PreviewView(APIView):
             raise
         except Exception as e:
             logger.error(f"Error starting preview server: {str(e)}")
+            # Preview is a DEBUG-only feature, so the real reason is safe to
+            # surface and saves a trip to the server logs.
             return Response({
                 'success': False,
-                'error': 'Preview server failed to start.'
+                'error': f'Preview server failed to start: {str(e)}'
             }, status=status.HTTP_503_SERVICE_UNAVAILABLE)
     
     def delete(self, request, project_id):

--- a/backend/django/apps/Imagi/Build/services/create_app_service.py
+++ b/backend/django/apps/Imagi/Build/services/create_app_service.py
@@ -392,11 +392,23 @@ export const use{cap_name}Store = defineStore('{app_name}', () => {{
         return files
 
     # ... (rest of the code remains the same)
+    # App labels Django's contrib apps already claim. Registering e.g.
+    # 'apps.auth' (default label: 'auth') alongside django.contrib.auth makes
+    # the generated project unbootable with "Application labels aren't unique".
+    RESERVED_APP_LABELS = {'admin', 'auth', 'contenttypes', 'sessions', 'messages', 'staticfiles'}
+
     def _register_backend_app(self, project_path: str, app_name: str) -> None:
         """Ensure the backend Django app is added to INSTALLED_APPS and URLs.
         Skips if a capitalized variant already exists (e.g., 'apps.Home').
         """
         try:
+            if app_name.lower() in self.RESERVED_APP_LABELS:
+                logger.warning(
+                    f"Skipping INSTALLED_APPS registration for 'apps.{app_name}': "
+                    f"its default label conflicts with a Django contrib app"
+                )
+                return
+
             # Discover the actual Django project directory (contains settings.py and urls.py)
             backend_root = os.path.join(project_path, 'backend', 'django')
             project_dir = None

--- a/backend/django/apps/Imagi/Build/services/preview_service.py
+++ b/backend/django/apps/Imagi/Build/services/preview_service.py
@@ -4,6 +4,8 @@ Service for project preview operations in the Builder app.
 
 import subprocess
 import os
+import sys
+import shutil
 import psutil
 import time
 import logging
@@ -12,44 +14,60 @@ from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
+# npm install for a freshly scaffolded frontend can legitimately take minutes
+NPM_INSTALL_TIMEOUT = 600
+
+
 class PreviewService:
     """Service for project preview operations with dual-stack support."""
-    
+
     def __init__(self, project):
         self.project = project
         self.frontend_port = 5174  # Vite dev server - use 5174 to avoid conflict with Imagi itself on 5173
         self.backend_port = 8080   # Django dev server - use 8080 to avoid conflict with main project on 8000
-        
+
         # Ensure the PID file directory exists
         pid_dir = os.path.join(settings.PROJECTS_ROOT, str(project.user.id))
         os.makedirs(pid_dir, exist_ok=True)
-        
+
         self.frontend_pid_file = os.path.join(pid_dir, f"{project.name}_frontend.pid")
         self.backend_pid_file = os.path.join(pid_dir, f"{project.name}_backend.pid")
-    
+        # Records the ports the servers were actually started on, so stopping
+        # only ever touches those ports (never someone else's dev server).
+        self.ports_file = os.path.join(pid_dir, f"{project.name}_preview_ports.json")
+        # Dev server output goes to log files: piping to subprocess.PIPE without
+        # draining would freeze the servers once the pipe buffer fills.
+        self.frontend_log_file = os.path.join(pid_dir, f"{project.name}_frontend.log")
+        self.backend_log_file = os.path.join(pid_dir, f"{project.name}_backend.log")
+
     def start_preview(self):
         """Start both frontend and backend development servers."""
         try:
             logger.info(f"Starting preview for project: {self.project.name} (ID: {self.project.id})")
             logger.info(f"Project path: {self.project.project_path}")
-            
+
             # Validate project path
             if not self.project.project_path:
                 raise ValueError("Project path is not set")
-            
+
             if not os.path.exists(self.project.project_path):
                 raise FileNotFoundError(f"Project path does not exist: {self.project.project_path}")
-            
+
+            # Repair the project skeleton if it went missing (generated projects
+            # aren't tracked by Imagi's git repo, so a clean checkout can lose
+            # everything but the DB record and the per-app files).
+            self._ensure_scaffold()
+
             # Stop any existing servers for this project
             self.stop_preview()
-            
+
             # Check if project has the new dual-stack structure
             frontend_path = os.path.join(self.project.project_path, 'frontend', 'vuejs')
             backend_path = os.path.join(self.project.project_path, 'backend', 'django')
-            
+
             logger.info(f"Frontend path: {frontend_path} (exists: {os.path.exists(frontend_path)})")
             logger.info(f"Backend path: {backend_path} (exists: {os.path.exists(backend_path)})")
-            
+
             if os.path.exists(frontend_path) and os.path.exists(backend_path):
                 # New dual-stack structure
                 logger.info("Detected dual-stack project structure")
@@ -58,40 +76,56 @@ class PreviewService:
                 # Legacy single Django project
                 logger.info("Detected legacy Django project structure")
                 return self._start_legacy_preview()
-                
+
         except Exception as e:
             logger.error(f"Error starting preview server: {str(e)}")
             import traceback
             logger.error(f"Stack trace: {traceback.format_exc()}")
             raise
 
+    def _ensure_scaffold(self):
+        """Recreate any missing scaffold files before trying to boot servers."""
+        from apps.Imagi.ProjectManager.services.project_creation_service import ProjectCreationService
+
+        try:
+            creation_service = ProjectCreationService(self.project.user)
+            repaired = creation_service.ensure_scaffold(self.project)
+            if repaired:
+                logger.info(
+                    f"Repaired missing scaffold for project {self.project.name}: {', '.join(repaired)}"
+                )
+        except Exception as e:
+            raise Exception(f"Project scaffold repair failed: {e}")
+
     def _start_dual_stack_preview(self, frontend_path, backend_path):
         """Start both VueJS frontend and Django backend servers."""
         logger.info("Starting dual-stack preview (VueJS + Django)")
-        
+
         # Start Django backend first
-        backend_success = self._start_django_backend(backend_path)
-        if not backend_success:
-            raise Exception("Failed to start Django backend")
-        
+        backend_error = self._start_django_backend(backend_path)
+        if backend_error:
+            raise Exception(f"Django backend failed to start: {backend_error}")
+
         # Wait a moment for backend to start
         time.sleep(3)
-        
+
         # Start VueJS frontend
-        frontend_success = self._start_vuejs_frontend(frontend_path)
-        if not frontend_success:
+        frontend_error = self._start_vuejs_frontend(frontend_path)
+        if frontend_error:
             # If frontend fails, stop the backend
-            self._stop_django_backend()
-            raise Exception("Failed to start VueJS frontend")
-        
+            self._stop_django_backend(port=self.backend_port)
+            raise Exception(f"VueJS frontend failed to start: {frontend_error}")
+
         # Wait for frontend to start
         time.sleep(5)
-        
+
+        self._save_port_state()
+
         frontend_url = f"http://localhost:{self.frontend_port}"
-        
+
         # Note: Browser opening is handled by the frontend client via window.open()
         # Do not use webbrowser.open() here to avoid opening duplicate tabs
-        
+
         return {
             'success': True,
             'preview_url': frontend_url,
@@ -101,276 +135,334 @@ class PreviewService:
         }
 
     def _start_django_backend(self, backend_path):
-        """Start Django backend server."""
+        """Start Django backend server. Returns None on success, error text on failure."""
         try:
             logger.info(f"Attempting to start Django backend in: {backend_path}")
-            
+
             # Find manage.py
             manage_py = os.path.join(backend_path, 'manage.py')
             if not os.path.exists(manage_py):
                 logger.error(f"manage.py not found in {backend_path}")
-                return False
-            
+                return f"manage.py not found in {backend_path}"
+
             logger.info(f"Found manage.py at: {manage_py}")
-            
+
             # Get project name for Django settings
-            project_dirs = [d for d in os.listdir(backend_path) 
-                          if os.path.isdir(os.path.join(backend_path, d)) 
+            project_dirs = [d for d in os.listdir(backend_path)
+                          if os.path.isdir(os.path.join(backend_path, d))
                           and os.path.exists(os.path.join(backend_path, d, 'settings.py'))]
-            
+
             logger.info(f"Found project directories with settings.py: {project_dirs}")
-            
+
             if not project_dirs:
                 logger.error("No Django project directory found")
-                return False
-            
+                return f"no Django settings module found under {backend_path}"
+
             project_name = project_dirs[0]
             logger.info(f"Using Django project: {project_name}")
-            
+
             # Set up environment
             env = os.environ.copy()
             env['DJANGO_SETTINGS_MODULE'] = f"{project_name}.settings"
-            
+
             # Find available port for backend (avoiding conflict with main project on 8000)
             self.backend_port = self._find_available_port_excluding(8080, 8100, exclude_ports=[8000])
             logger.info(f"Starting Django backend on port {self.backend_port}")
-            
+
             # Ensure PID file directory exists
             os.makedirs(os.path.dirname(self.backend_pid_file), exist_ok=True)
-            
-            # Start Django development server
-            process = subprocess.Popen(
-                ['python', 'manage.py', 'runserver', f'127.0.0.1:{self.backend_port}'],
-                cwd=backend_path,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                universal_newlines=True,
-                env=env
-            )
-            
+
+            # Start Django development server. sys.executable is the
+            # interpreter running Imagi itself, which is guaranteed to exist
+            # and to have Django/DRF installed (a bare 'python' may be neither).
+            with open(self.backend_log_file, 'w') as log_fh:
+                process = subprocess.Popen(
+                    [sys.executable, 'manage.py', 'runserver', f'127.0.0.1:{self.backend_port}'],
+                    cwd=backend_path,
+                    stdout=log_fh,
+                    stderr=subprocess.STDOUT,
+                    env=env
+                )
+
             # Save the PID
             with open(self.backend_pid_file, 'w') as f:
                 f.write(str(process.pid))
-            
+
             logger.info(f"Django backend started with PID {process.pid}")
-            
+
             # Wait a moment and check if process is still running
             time.sleep(1)
             if process.poll() is not None:
-                # Process has terminated
-                stdout, stderr = process.communicate()
+                output = self._read_log_tail(self.backend_log_file)
                 logger.error(f"Django backend process terminated unexpectedly")
                 logger.error(f"Return code: {process.returncode}")
-                logger.error(f"STDOUT: {stdout}")
-                logger.error(f"STDERR: {stderr}")
-                return False
-            
-            return True
-            
+                logger.error(f"Output: {output}")
+                return f"process exited with code {process.returncode}: {output}"
+
+            return None
+
         except Exception as e:
             logger.error(f"Error starting Django backend: {e}")
             import traceback
             logger.error(f"Stack trace: {traceback.format_exc()}")
-            return False
+            return str(e)
 
     def _start_vuejs_frontend(self, frontend_path):
-        """Start VueJS frontend server."""
+        """Start VueJS frontend server. Returns None on success, error text on failure."""
         try:
             logger.info(f"Attempting to start VueJS frontend in: {frontend_path}")
-            
+
             # Check if package.json exists
             package_json = os.path.join(frontend_path, 'package.json')
             if not os.path.exists(package_json):
                 logger.error(f"package.json not found in {frontend_path}")
-                return False
-            
+                return f"package.json not found in {frontend_path}"
+
             logger.info(f"Found package.json at: {package_json}")
-            
-            # Check if node_modules exists
-            node_modules = os.path.join(frontend_path, 'node_modules')
-            if not os.path.exists(node_modules):
-                logger.warning(f"node_modules not found in {frontend_path}, npm dependencies may not be installed")
-            
+
+            npm = shutil.which('npm')
+            if not npm:
+                logger.error("npm command not found on PATH")
+                return "npm is not installed or not on PATH"
+
+            # Install dependencies if they are missing (e.g. after a scaffold
+            # repair, or when the original background install never finished).
+            deps_error = self._ensure_frontend_dependencies(frontend_path, npm)
+            if deps_error:
+                return deps_error
+
             # Find available port for frontend (avoiding conflict with Imagi itself on 5173)
             self.frontend_port = self._find_available_port_excluding(5174, 5200, exclude_ports=[5173])
             logger.info(f"Starting VueJS frontend on port {self.frontend_port}")
-            
-            # Set up environment for Vite
+
+            # Set up environment for Vite. VITE_BACKEND_URL points the generated
+            # app's /api proxy at its own Django backend rather than the default.
             env = os.environ.copy()
             env['PORT'] = str(self.frontend_port)
-            
+            env['VITE_BACKEND_URL'] = f"http://localhost:{self.backend_port}"
+
             # Ensure PID file directory exists
             os.makedirs(os.path.dirname(self.frontend_pid_file), exist_ok=True)
-            
+
             # Start Vite development server
-            process = subprocess.Popen(
-                ['npm', 'run', 'dev', '--', '--port', str(self.frontend_port), '--host'],
-                cwd=frontend_path,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                universal_newlines=True,
-                env=env
-            )
-            
+            with open(self.frontend_log_file, 'w') as log_fh:
+                process = subprocess.Popen(
+                    [npm, 'run', 'dev', '--', '--port', str(self.frontend_port), '--host'],
+                    cwd=frontend_path,
+                    stdout=log_fh,
+                    stderr=subprocess.STDOUT,
+                    env=env
+                )
+
             # Save the PID
             with open(self.frontend_pid_file, 'w') as f:
                 f.write(str(process.pid))
-            
+
             logger.info(f"VueJS frontend started with PID {process.pid}")
-            
+
             # Wait a moment and check if process is still running
             time.sleep(2)
             if process.poll() is not None:
-                # Process has terminated
-                stdout, stderr = process.communicate()
+                output = self._read_log_tail(self.frontend_log_file)
                 logger.error(f"VueJS frontend process terminated unexpectedly")
                 logger.error(f"Return code: {process.returncode}")
-                logger.error(f"STDOUT: {stdout}")
-                logger.error(f"STDERR: {stderr}")
-                return False
-            
-            return True
-            
+                logger.error(f"Output: {output}")
+                return f"process exited with code {process.returncode}: {output}"
+
+            return None
+
         except Exception as e:
             logger.error(f"Error starting VueJS frontend: {e}")
             import traceback
             logger.error(f"Stack trace: {traceback.format_exc()}")
-            return False
+            return str(e)
+
+    def _ensure_frontend_dependencies(self, frontend_path, npm):
+        """Run npm install when node_modules is missing.
+
+        Returns None on success, error text on failure. Blocking on purpose:
+        the preview cannot start without dependencies, and the caller reports
+        progress/failure to the user.
+        """
+        if os.path.isdir(os.path.join(frontend_path, 'node_modules')):
+            return None
+
+        logger.info(f"node_modules missing - running npm install in {frontend_path}")
+        try:
+            result = subprocess.run(
+                [npm, 'install'],
+                cwd=frontend_path,
+                capture_output=True,
+                text=True,
+                timeout=NPM_INSTALL_TIMEOUT,
+            )
+        except subprocess.TimeoutExpired:
+            return f"npm install timed out after {NPM_INSTALL_TIMEOUT} seconds"
+
+        if result.returncode != 0:
+            tail = (result.stderr or result.stdout or '').strip()[-2000:]
+            logger.error(f"npm install failed in {frontend_path}: {tail}")
+            return f"npm install failed: {tail}"
+
+        logger.info(f"npm install completed in {frontend_path}")
+        return None
+
+    def _read_log_tail(self, log_path, max_chars=2000):
+        """Return the tail of a server log file for error reporting."""
+        try:
+            with open(log_path, 'r') as f:
+                return f.read()[-max_chars:].strip()
+        except OSError:
+            return ''
+
+    def _save_port_state(self):
+        """Persist the ports the servers were started on for a targeted stop."""
+        try:
+            with open(self.ports_file, 'w') as f:
+                json.dump({
+                    'frontend_port': self.frontend_port,
+                    'backend_port': self.backend_port,
+                }, f)
+        except OSError as e:
+            logger.warning(f"Could not save preview port state: {e}")
+
+    def _load_port_state(self):
+        """Return the recorded ports of a running preview, or None."""
+        try:
+            with open(self.ports_file, 'r') as f:
+                return json.load(f)
+        except (OSError, ValueError):
+            return None
 
     def _start_legacy_preview(self):
         """Start preview for legacy single Django projects."""
         logger.info("Starting legacy Django preview")
-        
+
         # Get the project's manage.py path
         manage_py = os.path.join(self.project.project_path, 'manage.py')
-        
+
         if not os.path.exists(manage_py):
             raise FileNotFoundError(f"manage.py not found in {self.project.project_path}")
-        
+
         # Get an available port
         port = self._find_available_port(8080, 8100)
-        
+
         # Get the project name from the path
         project_name = os.path.basename(self.project.project_path)
-        
+
         # Set up environment
         env = os.environ.copy()
         env['PYTHONPATH'] = self.project.project_path
         env['DJANGO_SETTINGS_MODULE'] = f"{project_name}.settings"
-        
+
         # Start the development server
-        process = subprocess.Popen(
-            ['python', 'manage.py', 'runserver', f'127.0.0.1:{port}'],
-            cwd=self.project.project_path,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            universal_newlines=True,
-            env=env
-        )
-        
+        with open(self.backend_log_file, 'w') as log_fh:
+            process = subprocess.Popen(
+                [sys.executable, 'manage.py', 'runserver', f'127.0.0.1:{port}'],
+                cwd=self.project.project_path,
+                stdout=log_fh,
+                stderr=subprocess.STDOUT,
+                env=env
+            )
+
         # Save the PID (use backend_pid_file for legacy projects)
         with open(self.backend_pid_file, 'w') as f:
             f.write(str(process.pid))
-        
+
         # Wait for server to start
         time.sleep(2)
-        
+
         # Check if the server started successfully
         if process.poll() is not None:
-            error_output = process.stderr.read()
+            error_output = self._read_log_tail(self.backend_log_file)
             raise Exception(f"Server failed to start: {error_output}")
-        
+
+        self.backend_port = port
+        self._save_port_state()
+
         server_url = f"http://localhost:{port}"
-        
+
         # Note: Browser opening is handled by the frontend client via window.open()
         # Do not use webbrowser.open() here to avoid opening duplicate tabs
-        
+
         return {
             'success': True,
             'preview_url': server_url,
             'message': 'Development server started successfully'
         }
-    
+
     def _find_available_port(self, start_port, max_port):
         """Find an available port starting from the start_port."""
-        port = start_port
-        
-        while port <= max_port:
-            try:
-                # Check if port is in use
-                in_use = False
-                for proc in psutil.process_iter(['pid', 'name']):
-                    try:
-                        for conn in proc.connections():
-                            if hasattr(conn, 'laddr') and conn.laddr.port == port:
-                                in_use = True
-                                break
-                    except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.Error):
-                        continue
-                
-                if not in_use:
-                    return port
-            except:
-                pass
-                
-            port += 1
-            
-        # If we reach here, return start_port and hope for the best
-        return start_port
-    
+        return self._find_available_port_excluding(start_port, max_port)
+
     def _find_available_port_excluding(self, start_port, max_port, exclude_ports=None):
         """Find an available port starting from the start_port, excluding specified ports."""
         if exclude_ports is None:
             exclude_ports = []
-            
+
         port = start_port
-        
+
         while port <= max_port:
             # Skip excluded ports
             if port in exclude_ports:
                 port += 1
                 continue
-                
-            try:
-                # Check if port is in use
-                in_use = False
-                for proc in psutil.process_iter(['pid', 'name']):
-                    try:
-                        for conn in proc.connections():
-                            if hasattr(conn, 'laddr') and conn.laddr.port == port:
-                                in_use = True
-                                break
-                    except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.Error):
-                        continue
-                
-                if not in_use:
-                    return port
-            except:
-                pass
-                
+
+            if not self._port_in_use(port):
+                return port
+
             port += 1
-            
+
         # If we reach here, return start_port and hope for the best (excluding excluded ports)
         if start_port not in exclude_ports:
             return start_port
         else:
             return start_port + 1
-    
+
+    @staticmethod
+    def _process_connections(proc):
+        """Process connections across psutil versions (connections() was
+        renamed to net_connections() in psutil 6)."""
+        if hasattr(proc, 'net_connections'):
+            return proc.net_connections()
+        return proc.connections()
+
+    def _port_in_use(self, port):
+        """Check whether any process is listening on the given port."""
+        try:
+            for proc in psutil.process_iter(['pid', 'name']):
+                try:
+                    for conn in self._process_connections(proc):
+                        if hasattr(conn, 'laddr') and conn.laddr and conn.laddr.port == port:
+                            return True
+                except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.Error):
+                    continue
+        except Exception:
+            pass
+        return False
+
     def stop_preview(self):
         """Stop both frontend and backend development servers."""
         try:
             success_messages = []
-            
+
+            # Only sweep the ports this preview actually recorded; killing by
+            # default port numbers could take down unrelated dev servers.
+            port_state = self._load_port_state() or {}
+
             # Stop frontend server
-            if self._stop_vuejs_frontend():
+            if self._stop_vuejs_frontend(port=port_state.get('frontend_port')):
                 success_messages.append("Frontend server stopped")
-            
+
             # Stop backend server
-            if self._stop_django_backend():
+            if self._stop_django_backend(port=port_state.get('backend_port')):
                 success_messages.append("Backend server stopped")
-            
+
+            if os.path.exists(self.ports_file):
+                os.remove(self.ports_file)
+
             message = ', '.join(success_messages) if success_messages else 'No servers were running'
-            
+
             return {
                 'success': True,
                 'message': f'Development servers stopped successfully: {message}'
@@ -379,76 +471,65 @@ class PreviewService:
             logger.error(f"Error stopping preview servers: {str(e)}")
             raise
 
-    def _stop_vuejs_frontend(self):
+    def _stop_vuejs_frontend(self, port=None):
         """Stop VueJS frontend server."""
         try:
-            stopped = False
-            
-            # Stop using PID file
-            if os.path.exists(self.frontend_pid_file):
-                with open(self.frontend_pid_file, 'r') as f:
-                    pid = int(f.read().strip())
-                try:
-                    process = psutil.Process(pid)
-                    # Kill all child processes first
-                    children = process.children(recursive=True)
-                    for child in children:
-                        child.kill()
-                    process.kill()
-                    stopped = True
-                except (psutil.NoSuchProcess, psutil.AccessDenied):
-                    pass
-                os.remove(self.frontend_pid_file)
-            
-            # Also check for processes on frontend port
-            for proc in psutil.process_iter(['pid', 'name']):
-                try:
-                    for conn in proc.connections():
-                        if hasattr(conn, 'laddr') and conn.laddr.port == self.frontend_port:
-                            proc.kill()
-                            stopped = True
-                            break
-                except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.Error):
-                    continue
-            
+            stopped = self._kill_from_pid_file(self.frontend_pid_file)
+            if port:
+                stopped = self._kill_by_port(port) or stopped
             return stopped
         except Exception as e:
             logger.error(f"Error stopping frontend server: {e}")
             return False
 
-    def _stop_django_backend(self):
+    def _stop_django_backend(self, port=None):
         """Stop Django backend server."""
         try:
-            stopped = False
-            
-            # Stop using PID file
-            if os.path.exists(self.backend_pid_file):
-                with open(self.backend_pid_file, 'r') as f:
-                    pid = int(f.read().strip())
-                try:
-                    process = psutil.Process(pid)
-                    # Kill all child processes first
-                    children = process.children(recursive=True)
-                    for child in children:
-                        child.kill()
-                    process.kill()
-                    stopped = True
-                except (psutil.NoSuchProcess, psutil.AccessDenied):
-                    pass
-                os.remove(self.backend_pid_file)
-            
-            # Also check for processes on backend port
-            for proc in psutil.process_iter(['pid', 'name']):
-                try:
-                    for conn in proc.connections():
-                        if hasattr(conn, 'laddr') and conn.laddr.port == self.backend_port:
-                            proc.kill()
-                            stopped = True
-                            break
-                except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.Error):
-                    continue
-            
+            stopped = self._kill_from_pid_file(self.backend_pid_file)
+            if port:
+                stopped = self._kill_by_port(port) or stopped
             return stopped
         except Exception as e:
             logger.error(f"Error stopping backend server: {e}")
-            return False 
+            return False
+
+    def _kill_from_pid_file(self, pid_file):
+        """Kill the recorded process (and its children), removing the PID file."""
+        if not os.path.exists(pid_file):
+            return False
+
+        stopped = False
+        try:
+            with open(pid_file, 'r') as f:
+                pid = int(f.read().strip())
+        except (OSError, ValueError):
+            pid = None
+
+        if pid:
+            try:
+                process = psutil.Process(pid)
+                # Kill all child processes first
+                children = process.children(recursive=True)
+                for child in children:
+                    child.kill()
+                process.kill()
+                stopped = True
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                pass
+
+        os.remove(pid_file)
+        return stopped
+
+    def _kill_by_port(self, port):
+        """Kill any process still listening on the given port."""
+        stopped = False
+        for proc in psutil.process_iter(['pid', 'name']):
+            try:
+                for conn in self._process_connections(proc):
+                    if hasattr(conn, 'laddr') and conn.laddr and conn.laddr.port == port:
+                        proc.kill()
+                        stopped = True
+                        break
+            except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.Error):
+                continue
+        return stopped

--- a/backend/django/apps/Imagi/ProjectManager/services/codegen/templates.py
+++ b/backend/django/apps/Imagi/ProjectManager/services/codegen/templates.py
@@ -76,20 +76,24 @@ def vite_config() -> str:
         "  ],\n"
         "  server: {\n"
         "    // No need to set base here; handled globally above\n"
-        "    port: 5173,\n"
-        "    strictPort: true, // This will fail if port 5173 is not available\n"
+        "    // 5174 keeps generated apps clear of the main Imagi dev server on 5173;\n"
+        "    // the Imagi preview runner overrides this with an explicit --port flag.\n"
+        "    port: 5174,\n"
+        "    strictPort: false, // Fall through to the next free port instead of failing\n"
         "    hmr: {\n"
         "      overlay: false, // Disable the HMR error overlay to prevent URI errors from breaking the UI\n"
         "    },\n"
         "    proxy: {\n"
-        "      // Proxy all API requests to the Django backend\n"
-        "      // This allows consistent API calls using relative URLs in both development and production\n"
+        "      // Proxy all API requests to this app's own Django backend.\n"
+        "      // The Imagi preview runner sets VITE_BACKEND_URL to the port it started\n"
+        "      // the backend on; the fallback matches start-dev.sh (8080, not the main\n"
+        "      // Imagi backend on 8000).\n"
         "      '/api': {\n"
-        "        target: process.env.VITE_BACKEND_URL || 'http://localhost:8000',\n"
+        "        target: process.env.VITE_BACKEND_URL || 'http://localhost:8080',\n"
         "        changeOrigin: true,\n"
         "        secure: false,\n"
         "        configure: (proxy, _options) => {\n"
-        "          const backendUrl = process.env.VITE_BACKEND_URL || 'http://localhost:8000';\n\n"
+        "          const backendUrl = process.env.VITE_BACKEND_URL || 'http://localhost:8080';\n\n"
         "          proxy.on('proxyReq', (proxyReq, req, _res) => {\n"
         "            // Log request info when debugging\n"
         "            if (process.env.NODE_ENV !== 'production') {\n"
@@ -174,12 +178,16 @@ def tailwind_config() -> str:
 def django_additional_settings() -> str:
     """Django CORS and DRF settings snippet to append to settings.py."""
     return (
-        """
+        r"""
 # CORS settings
 CORS_ALLOW_ALL_ORIGINS = True
 CORS_ALLOWED_ORIGINS = [
-    "http://localhost:5173",
-    "http://127.0.0.1:5173",
+    "http://localhost:5174",
+    "http://127.0.0.1:5174",
+]
+# The dev server port is assigned dynamically (5174+), so accept any localhost port
+CORS_ALLOWED_ORIGIN_REGEXES = [
+    r"^http://(localhost|127\.0\.0\.1):\d+$",
 ]
 
 # REST Framework settings
@@ -1139,20 +1147,23 @@ def start_dev_sh() -> str:
         "    echo \"📦 Installing frontend dependencies...\"\n"
         "    cd frontend/vuejs && npm install && cd ../..\n"
         "fi\n\n"
+        "# Ports 8080/5174 keep this app clear of the main Imagi dev servers (8000/5173)\n"
+        "BACKEND_PORT=\"${BACKEND_PORT:-8080}\"\n"
+        "FRONTEND_PORT=\"${FRONTEND_PORT:-5174}\"\n\n"
         "# Start Django backend\n"
-        "echo \"🐍 Starting Django backend on port 8000...\"\n"
-        "cd backend/django && python manage.py runserver &\n"
+        "echo \"🐍 Starting Django backend on port $BACKEND_PORT...\"\n"
+        "cd backend/django && python manage.py runserver \"127.0.0.1:$BACKEND_PORT\" &\n"
         "DJANGO_PID=$!\n\n"
         "# Wait a moment for Django to start\n"
         "sleep 3\n\n"
         "# Start Vue frontend  \n"
-        "echo \"⚡ Starting Vue frontend on port 5173...\"\n"
-        "cd frontend/vuejs && npm run dev &\n"
+        "echo \"⚡ Starting Vue frontend on port $FRONTEND_PORT...\"\n"
+        "cd frontend/vuejs && VITE_BACKEND_URL=\"http://localhost:$BACKEND_PORT\" npm run dev -- --port \"$FRONTEND_PORT\" &\n"
         "VUE_PID=$!\n\n"
         "echo \"\"\n"
         "echo \"✅ Development servers started!\"\n"
-        "echo \"🌐 Frontend: http://localhost:5173\"\n"
-        "echo \"🔧 Backend API: http://localhost:8000\"\n"
+        "echo \"🌐 Frontend: http://localhost:$FRONTEND_PORT\"\n"
+        "echo \"🔧 Backend API: http://localhost:$BACKEND_PORT\"\n"
         "echo \"📱 Press Ctrl+C to stop both servers\"\n\n"
         "# Wait for background processes\n"
         "wait\n"
@@ -1198,6 +1209,7 @@ def django_project_views() -> str:
 
 def django_base_template(project_name: str) -> str:
     return (
+        f"{{% load static %}}\n"
         f"<!DOCTYPE html>\n"
         f"<html lang=\"en\">\n"
         f"<head>\n"
@@ -1233,7 +1245,7 @@ def django_index_template(project_name: str, project_description: str | None) ->
         + safe_project_name
         + "</h1>\n"
         + description_content
-        + "\n    <p>This is your Django backend API. The frontend is served separately on port 5173.</p>\n"
+        + "\n    <p>This is your Django backend API. The frontend dev server runs separately (port 5174 by default).</p>\n"
         "    <div class=\"cta-button\">\n"
         "        <a href=\"/admin/\">Go to Admin</a>\n"
         "        <a href=\"/api/\">Browse API</a>\n"

--- a/backend/django/apps/Imagi/ProjectManager/services/project_creation_service.py
+++ b/backend/django/apps/Imagi/ProjectManager/services/project_creation_service.py
@@ -125,6 +125,62 @@ class ProjectCreationService:
 
     # Legacy methods removed - now using _create_django_backend for proper dual-stack structure
 
+    def ensure_scaffold(self, project):
+        """Recreate missing scaffold files for an existing dual-stack project.
+
+        Generated projects are not tracked by Imagi's own git repository, so a
+        project directory can lose its runnable skeleton (package.json, vite
+        config, manage.py, settings, ...) while the database record and the
+        per-app files survive. This repairs the skeleton in place without
+        touching app code under src/apps or backend/django/apps.
+
+        Returns a list of the parts that were repaired (empty if nothing was
+        missing).
+        """
+        project_path = project.project_path
+        if not project_path or not os.path.exists(project_path):
+            raise ValueError(f"Project path does not exist: {project_path}")
+
+        frontend_path = os.path.join(project_path, 'frontend', 'vuejs')
+        backend_path = os.path.join(project_path, 'backend', 'django')
+        repaired = []
+
+        # Frontend: package.json is the marker for the whole Vite scaffold.
+        if not os.path.exists(os.path.join(frontend_path, 'package.json')):
+            logger.info(f"Repairing missing frontend scaffold at: {frontend_path}")
+            os.makedirs(frontend_path, exist_ok=True)
+            tpl.create_vuejs_frontend_files(frontend_path, project.name, project.description)
+            repaired.append('frontend scaffold')
+
+        # Backend: manage.py is the marker for the Django scaffold.
+        if not os.path.exists(os.path.join(backend_path, 'manage.py')):
+            logger.info(f"Repairing missing backend scaffold at: {backend_path}")
+            os.makedirs(os.path.join(backend_path, 'apps'), exist_ok=True)
+            unique_name = self._sanitize_project_name(
+                os.path.basename(os.path.normpath(project_path))
+            )
+            self._create_django_backend(backend_path, unique_name, project.name, project.description)
+            self._cleanup_root_django_dirs(project_path)
+            self._register_existing_backend_apps(project)
+            repaired.append('backend scaffold')
+
+        if repaired and not os.path.exists(os.path.join(project_path, 'README.md')):
+            self._create_root_project_files(project_path, project.name, project.description)
+
+        return repaired
+
+    def _register_existing_backend_apps(self, project):
+        """Re-register surviving backend apps in a freshly recreated settings.py."""
+        apps_dir = os.path.join(project.project_path, 'backend', 'django', 'apps')
+        if not os.path.isdir(apps_dir):
+            return
+
+        app_service = CreateAppService(user=self.user, project=project)
+        for entry in sorted(os.listdir(apps_dir)):
+            if entry.startswith(('.', '__')) or not os.path.isdir(os.path.join(apps_dir, entry)):
+                continue
+            app_service._register_backend_app(project.project_path, entry)
+
     def _create_vuejs_frontend(self, frontend_path, project_name, project_description):
         """Create VueJS frontend by delegating to templates module and install deps."""
         logger.info(f"Creating VueJS frontend at: {frontend_path}")
@@ -384,13 +440,18 @@ class ProjectCreationService:
         static_replacement = "STATIC_URL = 'static/'\nSTATICFILES_DIRS = [\n    BASE_DIR / 'static',\n]"
         settings_content = re.sub(static_url_pattern, static_replacement, settings_content)
         
-        # Add CORS and REST Framework settings
-        if "# Default primary key field type" in settings_content:
+        # Add CORS and REST Framework settings. Django's default settings.py
+        # layout changes between versions (the anchor comment below is gone in
+        # Django 6), so fall back to appending at the end of the file.
+        if 'CORS_ALLOW' not in settings_content:
             additional_settings = tpl.django_additional_settings()
-            settings_content = settings_content.replace(
-                "# Default primary key field type",
-                additional_settings + "\n# Default primary key field type"
-            )
+            if "# Default primary key field type" in settings_content:
+                settings_content = settings_content.replace(
+                    "# Default primary key field type",
+                    additional_settings + "\n# Default primary key field type"
+                )
+            else:
+                settings_content = settings_content.rstrip() + "\n" + additional_settings
         
         with open(settings_path, 'w') as f:
             f.write(settings_content)
@@ -402,21 +463,32 @@ class ProjectCreationService:
         with open(urls_path, 'r') as f:
             urls_content = f.read()
         
-        # Add include import and TemplateView
-        if 'include' not in urls_content:
+        # Extend the django.urls import line. Check the import statement
+        # itself, not the whole file: the default docstring already mentions
+        # include(), which used to defeat a whole-file check and leave the
+        # generated urls.py crashing with NameError on boot.
+        def _extend_urls_import(match):
+            imported = match.group(1)
+            if 'include' in [name.strip() for name in imported.split(',')]:
+                return match.group(0)
+            return f"from django.urls import {imported}, include"
+
+        urls_content = re.sub(
+            r"^from django\.urls import (.+)$",
+            _extend_urls_import,
+            urls_content,
+            count=1,
+            flags=re.MULTILINE,
+        )
+
+        if 'from django.views.generic import TemplateView' not in urls_content:
             urls_content = urls_content.replace(
-                'from django.urls import path',
-                'from django.urls import path, include'
+                'from django.contrib import admin',
+                'from django.contrib import admin\nfrom django.views.generic import TemplateView'
             )
-        
-        if 'TemplateView' not in urls_content:
-            urls_content = urls_content.replace(
-                'from django.urls import path, include',
-                'from django.urls import path, include\nfrom django.views.generic import TemplateView'
-            )
-        
+
         # Add home page and API URLs
-        if 'api/' not in urls_content:
+        if "path('api/'" not in urls_content:
             urls_content = urls_content.replace(
                 'urlpatterns = [',
                 'urlpatterns = [\n    path(\'\', TemplateView.as_view(template_name=\'index.html\'), name=\'home\'),\n    path(\'api/\', include(\'api.urls\')),'

--- a/backend/django/imagi/settings.py
+++ b/backend/django/imagi/settings.py
@@ -230,8 +230,11 @@ FRONTEND_URL = os.environ.get('FRONTEND_URL', 'http://localhost:5173')
 
 
 # Products / Imagi builder
-# Root directory where ProjectManager writes generated user projects.
-PROJECTS_ROOT = os.environ.get('PROJECTS_ROOT', str(BASE_DIR / 'apps' / 'Imagi' / 'Build' / 'imagi_projects'))
+# Root directory where ProjectManager writes generated user projects. Lives
+# outside the repository so git operations (clean, fresh clones, worktrees)
+# can never wipe user projects; the old in-repo default was gitignored and
+# projects silently disappeared with it.
+PROJECTS_ROOT = os.environ.get('PROJECTS_ROOT', os.path.expanduser('~/.imagi/projects'))
 
 
 # Marketing / Twilio

--- a/frontend/vuejs/src/apps/imagi/build/services/previewService.ts
+++ b/frontend/vuejs/src/apps/imagi/build/services/previewService.ts
@@ -18,7 +18,8 @@ export const PreviewService = {
       };
     } catch (error: any) {
       if (error?.response?.status === 503) {
-        throw new Error('Preview server failed to start.');
+        // The backend includes the actual failure reason in dev
+        throw new Error(error.response?.data?.error || 'Preview server failed to start.');
       }
       throw new Error(`Failed to generate preview: ${this.formatError(error)}`);
     }


### PR DESCRIPTION
## What changed

The build workspace preview (dev servers for a generated user app) failed with a generic "Preview server failed to start." This fixes the whole path so the preview boots reliably and reports real errors.

### Scaffold self-repair
Generated projects aren't tracked by Imagi's git repo, so a project directory could lose its runnable skeleton (`package.json`, `vite.config.ts`, `manage.py`, settings, `node_modules`) while the DB record and per-app files survived — which is exactly the state the existing Mars project was in. `PreviewService.start_preview()` now calls a new `ProjectCreationService.ensure_scaffold()` that regenerates missing frontend/backend skeletons in place (never touching app code under `src/apps` or `backend/django/apps`), re-registers surviving backend apps, and runs a blocking `npm install` when `node_modules` is missing.

### Generator bugs that broke every generated backend at boot
- The `urls.py` import injection checked for the word `include` anywhere in the file; Django's default docstring contains it, so imports were never added and the generated backend died with `NameError: name 'TemplateView' is not defined`. The check now targets the import statement itself.
- The CORS/DRF settings block was anchored on a comment Django 6's `startproject` no longer emits, so it was silently dropped; it now falls back to appending at the end of the file.
- Registering `apps.auth` in `INSTALLED_APPS` duplicated Django's reserved `auth` label ("Application labels aren't unique"); reserved labels are now skipped.
- Generated `base.html` used `{% static %}` without `{% load static %}`, 500ing the backend's index page.

### Ports and backend wiring
- The preview runner now passes `VITE_BACKEND_URL` pointing at the Django port it actually started, so the generated app's `/api` proxy hits **its own** backend instead of the main Imagi backend on 8000.
- Generated `vite.config.ts` defaults to port 5174 with `strictPort: false`; `start-dev.sh` uses 8080/5174. Both keep generated apps clear of the main Imagi dev servers (5173/8000). Dynamic port selection (5174–5200, 8080–8100) is unchanged.

### Reliability and visibility
- Dev server output goes to per-project log files instead of unread `subprocess.PIPE`s, which froze the preview backend once the 64KB pipe buffer filled with request logs.
- `sys.executable` replaces bare `python` (may not exist on PATH); npm is resolved via `shutil.which`.
- Stopping a preview only kills recorded PIDs and the ports saved at start, instead of sweeping default port numbers that could belong to unrelated dev servers.
- The real failure reason (including a log tail) flows through the 503 response into the workspace error panel. Preview is DEBUG-only, so surfacing it is safe.
- `PROJECTS_ROOT` now defaults to `~/.imagi/projects` (still env-overridable) so git operations on the Imagi repo can never wipe generated user projects again — the old in-repo default was gitignored via the `build/` pattern, which is how the scaffold disappeared. Existing projects keep working via their stored absolute paths.

## How it was verified

Ran the fixed service end-to-end against the real Mars project while the main Imagi dev servers were running: scaffold repaired → `npm install` → Django on 8080 + Vite on 5174, homepage 200, `/api/v1/health/` returns healthy JSON through the Vite proxy, and `stop_preview` freed both ports without touching the main servers on 5173/8000. All 80 ProjectManager/Build tests pass; `vue-tsc` type-check is clean.

## Notes for reviewers

- `preview_service.py` is substantially rewritten; the start/stop flow and port scanning logic are the areas to read closely.
- The psutil `connections()`/`net_connections()` rename is handled with a version-compatible helper.
- Existing projects created with the broken generator will be repaired lazily the first time a preview is requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)