### PR TITLE
Wire up build workspace agent platform defaults, web search, and dev project copy

### DIFF
--- a/backend/django/apps/Imagi/Build/services/base_agent.py
+++ b/backend/django/apps/Imagi/Build/services/base_agent.py
@@ -40,13 +40,17 @@ logger = logging.getLogger(__name__)
 # Get API key
 OPENAI_API_KEY = os.getenv('OPENAI_KEY') or getattr(settings, 'OPENAI_KEY', None)
 
+# Platform defaults for every user's project (see IMAGI_BUILDER in
+# imagi/settings.py); fallbacks keep tests and scripts working without it.
+_BUILDER_SETTINGS = getattr(settings, 'IMAGI_BUILDER', {})
+
 # Default model for agents
-DEFAULT_MODEL = "gpt-5.6-sol"
+DEFAULT_MODEL = _BUILDER_SETTINGS.get('DEFAULT_MODEL', 'gpt-5.6-sol')
 
 # Upper bound on agent-loop iterations for a single request: room for
 # plan → search → read → edit → verify cycles without letting a confused
 # run spin forever.
-MAX_AGENT_TURNS = 30
+MAX_AGENT_TURNS = _BUILDER_SETTINGS.get('MAX_AGENT_TURNS', 30)
 
 # Character budget for conversation history sent to the model. When exceeded,
 # older messages are compacted into a short summary (auto-compaction, like

--- a/backend/django/apps/Imagi/Build/services/coding_agent.py
+++ b/backend/django/apps/Imagi/Build/services/coding_agent.py
@@ -12,7 +12,14 @@ import logging
 import os
 from typing import Optional
 
+from django.conf import settings
+
 from agents import Agent, RunContextWrapper
+
+try:  # Hosted web-search tool (available on the OpenAI Responses API)
+    from agents import WebSearchTool
+except ImportError:  # pragma: no cover - defensive fallback
+    WebSearchTool = None
 
 from apps.Imagi.Build.services.models_service import (
     get_backend_model_id,
@@ -25,8 +32,11 @@ from .tools import CODING_AGENT_TOOLS
 # Configure logging
 logger = logging.getLogger(__name__)
 
+# Platform defaults (see IMAGI_BUILDER in imagi/settings.py)
+_BUILDER_SETTINGS = getattr(settings, 'IMAGI_BUILDER', {})
+
 # Default model
-DEFAULT_MODEL = "gpt-5.6-sol"
+DEFAULT_MODEL = _BUILDER_SETTINGS.get('DEFAULT_MODEL', 'gpt-5.6-sol')
 
 # Project memory files, in priority order (Codex reads AGENTS.md,
 # Claude Code reads CLAUDE.md). Only the first one found is loaded.
@@ -51,6 +61,10 @@ Project layout (every Imagi project is a dual-stack monorepo):
 
 Technology stack: Django + REST framework, Vue 3 (Composition API + TypeScript), TailwindCSS, Pinia, Vite, Axios.
 """
+
+# Appended to the instructions only when the hosted web-search tool is attached.
+WEB_SEARCH_INSTRUCTIONS = """
+Web search: you can search the web. Use it when a task needs current outside information — real-world facts about the user's business or industry, up-to-date library or API usage — not for things you already know or that live in the project itself."""
 
 
 def load_project_memory(project_path: Optional[str]) -> Optional[str]:
@@ -129,17 +143,28 @@ def create_coding_agent(model: str = DEFAULT_MODEL, reasoning_effort: Optional[s
     effort = resolve_reasoning_effort(model, reasoning_effort)
     identity = get_model_identity_instructions(model)
 
+    tools = list(CODING_AGENT_TOOLS)
+    web_search_enabled = (
+        WebSearchTool is not None
+        and _BUILDER_SETTINGS.get('ENABLE_WEB_SEARCH', True)
+    )
+    if web_search_enabled:
+        tools.append(WebSearchTool())
+
     def instructions_with_identity(context: RunContextWrapper, agent: Agent) -> str:
-        return get_dynamic_coding_instructions(context, agent) + "\n\n" + identity
+        instructions = get_dynamic_coding_instructions(context, agent)
+        if web_search_enabled:
+            instructions += "\n" + WEB_SEARCH_INSTRUCTIONS
+        return instructions + "\n\n" + identity
 
     kwargs = {}
-    settings = build_model_settings(effort)
-    if settings is not None:
-        kwargs['model_settings'] = settings
+    model_settings = build_model_settings(effort)
+    if model_settings is not None:
+        kwargs['model_settings'] = model_settings
     return Agent(
         name="Imagi",
         instructions=instructions_with_identity,
         model=backend_model,
-        tools=list(CODING_AGENT_TOOLS),
+        tools=tools,
         **kwargs
     )

--- a/backend/django/apps/Imagi/Build/services/create_app_service.py
+++ b/backend/django/apps/Imagi/Build/services/create_app_service.py
@@ -7,12 +7,18 @@ for both frontend and backend via codegen templates.
 import logging
 from typing import Dict, List, Any
 import os
+from django.conf import settings
 from rest_framework.exceptions import ValidationError, NotFound
 from apps.Imagi.ProjectManager.models import Project
 from .create_file_service import CreateFileService
 from .codegen.prebuilt_apps import generate_prebuilt_app_files
 
 logger = logging.getLogger(__name__)
+
+# Apps scaffolded into every new project (see IMAGI_BUILDER in imagi/settings.py)
+DEFAULT_APPS = list(
+    getattr(settings, 'IMAGI_BUILDER', {}).get('DEFAULT_APPS', ['home', 'auth', 'payments'])
+)
 
 class CreateAppService:
     def __init__(self, user=None, project=None):
@@ -66,8 +72,7 @@ class CreateAppService:
             app_welcome = app_description.strip() if app_description and app_description.strip() else f'Welcome to the {app_name} app.'
 
             # If this is a default app, use prebuilt codegen (includes backend + frontend)
-            default_apps = {"home", "auth", "payments"}
-            if app_name in default_apps:
+            if app_name in DEFAULT_APPS:
                 files_to_create = generate_prebuilt_app_files(app_name, app_description)
                 # Fallback to generic if codegen returns nothing for some reason
                 if not files_to_create:
@@ -137,7 +142,7 @@ class CreateAppService:
             def has_backend(app: str) -> bool:
                 return os.path.isdir(os.path.join(backend_apps_dir, app))
 
-            required_apps = ['home', 'auth', 'payments']
+            required_apps = DEFAULT_APPS
             # Track existing status
             existing_frontend = [app for app in required_apps if has_frontend(app)]
             existing_backend = [app for app in required_apps if has_backend(app)]

--- a/backend/django/apps/Imagi/Build/services/models_service.py
+++ b/backend/django/apps/Imagi/Build/services/models_service.py
@@ -8,7 +8,12 @@ ensuring that model information (IDs, names, costs, etc.) is maintained in a sin
 import logging
 from typing import List, Tuple, Dict, Any
 
+from django.conf import settings
+
 logger = logging.getLogger(__name__)
+
+# Platform defaults for every user's project (see IMAGI_BUILDER in imagi/settings.py)
+_BUILDER_SETTINGS = getattr(settings, 'IMAGI_BUILDER', {})
 
 # Centralized Model Definitions
 # The GPT 5.6 suite: three tiers users can choose from when building.
@@ -76,7 +81,7 @@ REASONING_EFFORT_CHOICES = [
     ('high', 'High'),
 ]
 REASONING_EFFORT_IDS = [effort_id for effort_id, _ in REASONING_EFFORT_CHOICES]
-DEFAULT_REASONING_EFFORT = 'medium'
+DEFAULT_REASONING_EFFORT = _BUILDER_SETTINGS.get('DEFAULT_REASONING_EFFORT', 'medium')
 
 # Provider Choices
 PROVIDER_CHOICES = [
@@ -178,11 +183,12 @@ def get_available_models() -> list:
 def get_default_model_id() -> str:
     """
     Get the default model ID to use when none is specified.
-    
+
     Returns:
         str: The default model ID
     """
-    return 'gpt-5.6-sol'
+    default = _BUILDER_SETTINGS.get('DEFAULT_MODEL', 'gpt-5.6-sol')
+    return default if default in MODELS else 'gpt-5.6-sol'
 
 def get_model_display_name(model_id: str) -> str:
     """

--- a/backend/django/apps/Imagi/ProjectManager/services/initial_build_service.py
+++ b/backend/django/apps/Imagi/ProjectManager/services/initial_build_service.py
@@ -88,11 +88,10 @@ def _run_initial_build(project_id: int, user_id: int) -> None:
             user,
             service.model,
             project_id=project_id,
-            mode='agent',
             title='Initial build',
         )
 
-        result = service.process_agent(
+        result = service.process(
             user_input=build_initial_prompt(project.name, project.description),
             user=user,
             project_id=project_id,

--- a/backend/django/apps/Imagi/ProjectManager/tests.py
+++ b/backend/django/apps/Imagi/ProjectManager/tests.py
@@ -361,11 +361,14 @@ class InitialBuildServiceTests(TestCase):
     def _run_with_agent_result(self, result):
         from unittest.mock import Mock
         from apps.Imagi.ProjectManager.services import initial_build_service
+        from apps.Imagi.Build.services.base_agent import ImagiAgentService
 
-        fake_service = Mock()
+        # spec= the real class so this test fails if the service API drifts
+        # (a bare Mock once hid a rename that broke every initial build).
+        fake_service = Mock(spec=ImagiAgentService)
         fake_service.model = 'gpt-5.6-sol'
         fake_service.create_conversation.return_value = Mock(id=42)
-        fake_service.process_agent.return_value = result
+        fake_service.process.return_value = result
 
         with patch(
             'apps.Imagi.Build.services.base_agent.ImagiAgentService',
@@ -384,14 +387,13 @@ class InitialBuildServiceTests(TestCase):
         self.assertIsNotNone(self.project.last_generated_at)
 
         # The prompt must carry the business name and description into the agent.
-        prompt = fake_service.process_agent.call_args.kwargs['user_input']
+        prompt = fake_service.process.call_args.kwargs['user_input']
         self.assertIn('Beanline', prompt)
         self.assertIn('coffee roastery', prompt)
         fake_service.create_conversation.assert_called_once_with(
             self.user,
             'gpt-5.6-sol',
             project_id=self.project.pk,
-            mode='agent',
             title='Initial build',
         )
 

--- a/backend/django/imagi/settings.py
+++ b/backend/django/imagi/settings.py
@@ -230,11 +230,42 @@ FRONTEND_URL = os.environ.get('FRONTEND_URL', 'http://localhost:5173')
 
 
 # Products / Imagi builder
-# Root directory where ProjectManager writes generated user projects. Lives
-# outside the repository so git operations (clean, fresh clones, worktrees)
-# can never wipe user projects; the old in-repo default was gitignored and
-# projects silently disappeared with it.
-PROJECTS_ROOT = os.environ.get('PROJECTS_ROOT', os.path.expanduser('~/.imagi/projects'))
+#
+# Hardcoded platform defaults applied to every user's project. Imagi is built
+# for nontechnical users, so none of this is exposed in the product today —
+# every project starts from the same defaults. If we later add a settings
+# surface where users can adjust some of these, it should read/override this
+# block rather than replace it. Code reads the block via
+# getattr(settings, 'IMAGI_BUILDER', {}) with matching fallbacks, so tests
+# and scripts work without it.
+IMAGI_BUILDER = {
+    # Public suite model id the agent runs on (see Build/services/models_service.py
+    # for the mapping to real OpenAI model ids).
+    'DEFAULT_MODEL': 'gpt-5.6-sol',
+    # Reasoning effort used when a request doesn't specify one.
+    'DEFAULT_REASONING_EFFORT': 'medium',
+    # Upper bound on agent-loop iterations for a single request.
+    'MAX_AGENT_TURNS': 30,
+    # Attach OpenAI's hosted web-search tool to the agent.
+    'ENABLE_WEB_SEARCH': True,
+    # Apps scaffolded into every new project.
+    'DEFAULT_APPS': ['home', 'auth', 'payments'],
+}
+
+# Root directory where ProjectManager writes the working copy of generated
+# user projects. The database (Build.ProjectFile rows) is the durable store
+# and the working copy can always be rehydrated from it, so this directory is
+# disposable:
+#  - In development it lives inside the Build module so generated projects are
+#    easy to browse while testing the agent (the path is gitignored).
+#  - In production it lives outside the repository so git operations (clean,
+#    fresh clones, worktrees) never touch it.
+_DEFAULT_PROJECTS_ROOT = (
+    str(BASE_DIR / 'apps' / 'Imagi' / 'Build' / 'imagi_projects')
+    if DEBUG
+    else os.path.expanduser('~/.imagi/projects')
+)
+PROJECTS_ROOT = os.environ.get('PROJECTS_ROOT', _DEFAULT_PROJECTS_ROOT)
 
 
 # Marketing / Twilio


### PR DESCRIPTION
The build workspace agent design: every project is a Vue 3 + Django
dual-stack app scaffolded from platform-wide defaults, first built by the
agent from the project name/description, and stored durably in the
database with a disposable working copy on disk.

- Add IMAGI_BUILDER settings block: hardcoded platform defaults applied to
  every user's project (agent model, reasoning effort, max agent turns,
  web search toggle, default apps). Nontechnical users never see these; a
  future settings surface can override them. base_agent, coding_agent,
  models_service, and create_app_service now read from it.
- Give the agent OpenAI's hosted web-search tool (WebSearchTool), with a
  matching instructions line, gated by the ENABLE_WEB_SEARCH default.
- In development, default PROJECTS_ROOT to
  backend/django/apps/Imagi/Build/imagi_projects (already gitignored) so
  generated projects are browsable while testing the agent. Safe now that
  the database copy is the durable store and the working copy rehydrates.
- Fix the initial AI build: it called service.process_agent() and passed
  mode= to create_conversation(), neither of which exist on the current
  ImagiAgentService API, so every initial build crashed. The tests hid
  this behind a bare Mock; they now spec against the real class.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016xnmAyXHwon3cYg5XSUCQo