### PR TITLE
Clean up preview server files when a project is deleted

### DIFF
--- a/backend/django/apps/Imagi/Build/services/preview_service.py
+++ b/backend/django/apps/Imagi/Build/services/preview_service.py
@@ -17,6 +17,13 @@ logger = logging.getLogger(__name__)
 # npm install for a freshly scaffolded frontend can legitimately take minutes
 NPM_INSTALL_TIMEOUT = 600
 
+# The per-project files this service keeps beside the project directory, by
+# filename suffix. They are named after project.name, not the timestamped
+# directory, so deleting the directory does not remove them.
+PID_SUFFIXES = ('_frontend.pid', '_backend.pid', '_server.pid')  # _server.pid predates dual-stack
+LOG_SUFFIXES = ('_frontend.log', '_backend.log')
+PORTS_SUFFIX = '_preview_ports.json'
+
 
 class PreviewService:
     """Service for project preview operations with dual-stack support."""
@@ -27,18 +34,18 @@ class PreviewService:
         self.backend_port = 8080   # Django dev server - use 8080 to avoid conflict with main project on 8000
 
         # Ensure the PID file directory exists
-        pid_dir = os.path.join(settings.PROJECTS_ROOT, str(project.user.id))
-        os.makedirs(pid_dir, exist_ok=True)
+        self.pid_dir = os.path.join(settings.PROJECTS_ROOT, str(project.user.id))
+        os.makedirs(self.pid_dir, exist_ok=True)
 
-        self.frontend_pid_file = os.path.join(pid_dir, f"{project.name}_frontend.pid")
-        self.backend_pid_file = os.path.join(pid_dir, f"{project.name}_backend.pid")
+        self.frontend_pid_file = os.path.join(self.pid_dir, f"{project.name}_frontend.pid")
+        self.backend_pid_file = os.path.join(self.pid_dir, f"{project.name}_backend.pid")
         # Records the ports the servers were actually started on, so stopping
         # only ever touches those ports (never someone else's dev server).
-        self.ports_file = os.path.join(pid_dir, f"{project.name}_preview_ports.json")
+        self.ports_file = os.path.join(self.pid_dir, f"{project.name}{PORTS_SUFFIX}")
         # Dev server output goes to log files: piping to subprocess.PIPE without
         # draining would freeze the servers once the pipe buffer fills.
-        self.frontend_log_file = os.path.join(pid_dir, f"{project.name}_frontend.log")
-        self.backend_log_file = os.path.join(pid_dir, f"{project.name}_backend.log")
+        self.frontend_log_file = os.path.join(self.pid_dir, f"{project.name}_frontend.log")
+        self.backend_log_file = os.path.join(self.pid_dir, f"{project.name}_backend.log")
 
     def start_preview(self):
         """Start both frontend and backend development servers."""
@@ -327,12 +334,17 @@ class PreviewService:
             logger.warning(f"Could not save preview port state: {e}")
 
     def _load_port_state(self):
-        """Return the recorded ports of a running preview, or None."""
+        """Return the recorded ports of a running preview, or None.
+
+        The file can be stale or truncated from an earlier crash, so anything
+        that is not a well-formed mapping is treated as absent.
+        """
         try:
             with open(self.ports_file, 'r') as f:
-                return json.load(f)
+                state = json.load(f)
         except (OSError, ValueError):
             return None
+        return state if isinstance(state, dict) else None
 
     def _start_legacy_preview(self):
         """Start preview for legacy single Django projects."""
@@ -471,6 +483,41 @@ class PreviewService:
             logger.error(f"Error stopping preview servers: {str(e)}")
             raise
 
+    def cleanup_project_files(self, name_variants=None):
+        """Stop the servers and remove every file this service wrote for the project.
+
+        For deleting a project, where stop_preview() is not enough: it leaves the
+        logs behind (deliberately, so a stopped server's output stays readable)
+        and only knows the project's current name. Older releases wrote these
+        files under sanitized spellings of the name, so callers can pass
+        name_variants to sweep those too.
+        """
+        try:
+            self.stop_preview()
+        except Exception as e:
+            # Best effort: a project must still be deletable when its dev
+            # servers are already gone or unkillable.
+            logger.warning(f"Error stopping preview while cleaning up {self.project.name}: {e}")
+
+        for name in name_variants or [self.project.name]:
+            for suffix in PID_SUFFIXES:
+                # stop_preview already cleared the current-name PID files; this
+                # catches legacy and renamed leftovers, killing what they name.
+                try:
+                    self._kill_from_pid_file(os.path.join(self.pid_dir, f"{name}{suffix}"))
+                except Exception as e:
+                    logger.warning(f"Error stopping process from {name}{suffix}: {e}")
+
+            for suffix in LOG_SUFFIXES + (PORTS_SUFFIX,):
+                path = os.path.join(self.pid_dir, f"{name}{suffix}")
+                if not os.path.exists(path):
+                    continue
+                try:
+                    os.remove(path)
+                    logger.info(f"Deleted project file: {path}")
+                except OSError as e:
+                    logger.warning(f"Failed to delete project file {path}: {e}")
+
     def _stop_vuejs_frontend(self, port=None):
         """Stop VueJS frontend server."""
         try:
@@ -494,7 +541,7 @@ class PreviewService:
             return False
 
     def _kill_from_pid_file(self, pid_file):
-        """Kill the recorded process (and its children), removing the PID file."""
+        """Stop the recorded process (and its children), removing the PID file."""
         if not os.path.exists(pid_file):
             return False
 
@@ -508,17 +555,34 @@ class PreviewService:
         if pid:
             try:
                 process = psutil.Process(pid)
-                # Kill all child processes first
-                children = process.children(recursive=True)
-                for child in children:
-                    child.kill()
-                process.kill()
+                # Children first, so a dying parent cannot orphan them.
+                for proc in process.children(recursive=True) + [process]:
+                    self._stop_process(proc)
                 stopped = True
             except (psutil.NoSuchProcess, psutil.AccessDenied):
                 pass
 
-        os.remove(pid_file)
+        try:
+            os.remove(pid_file)
+        except OSError as e:
+            logger.warning(f"Failed to delete PID file {pid_file}: {e}")
         return stopped
+
+    @staticmethod
+    def _stop_process(proc):
+        """Ask a process to exit, escalating to SIGKILL if it ignores that."""
+        try:
+            proc.terminate()
+            proc.wait(timeout=3)
+        except psutil.TimeoutExpired:
+            try:
+                proc.kill()
+            except psutil.NoSuchProcess:
+                pass
+        except psutil.NoSuchProcess:
+            pass
+        except psutil.AccessDenied:
+            logger.warning(f"Access denied stopping process {proc.pid}")
 
     def _kill_by_port(self, port):
         """Kill any process still listening on the given port."""

--- a/backend/django/apps/Imagi/ProjectManager/services/project_management_service.py
+++ b/backend/django/apps/Imagi/ProjectManager/services/project_management_service.py
@@ -7,6 +7,7 @@ from ..models import Project
 
 logger = logging.getLogger(__name__)
 
+
 class ProjectManagementService:
     def __init__(self, user):
         self.user = user
@@ -38,8 +39,9 @@ class ProjectManagementService:
             project_path = project.project_path
             project_id = project.id
             
-            # Stop any running preview server and delete PID file
-            self._stop_project_server_and_cleanup_pid(project_name)
+            # Stop any running preview servers and delete the PID, log and
+            # preview-port files that live outside the project directory
+            self._stop_project_server_and_cleanup_files(project)
             
             # Delete project files using path (preferred) or name as fallback
             if project_path and os.path.exists(project_path):
@@ -182,97 +184,47 @@ class ProjectManagementService:
                     # Use the robust deletion method
                     self._delete_project_directory(project_path)
 
-    def _stop_project_server_and_cleanup_pid(self, project_name):
-        """Stop any running dev servers and delete PID files for the project.
-        
-        Handles both dual-stack PreviewService naming and legacy naming:
-        - Dual-stack: {project.name}_frontend.pid, {project.name}_backend.pid
-        - Legacy:     {project.name}_server.pid (plus sanitized fallbacks)
+    def _project_name_variants(self, project_name):
+        """Every name a project's sidecar files may have been written under.
+
+        PreviewService uses project.name verbatim, but older code sanitized it
+        first, so both spellings can exist on disk.
+        """
+        variants = [
+            project_name,
+            project_name.lower().replace(' ', '_'),
+            project_name.replace(' ', '-'),
+        ]
+        try:
+            from .project_creation_service import ProjectCreationService
+            creation_service = ProjectCreationService(self.user)
+            variants.append(creation_service._sanitize_project_name(project_name))
+        except Exception:
+            # If sanitization fails, continue with available names
+            pass
+
+        # Deduplicate while preserving order
+        seen = set()
+        return [v for v in variants if v and not (v in seen or seen.add(v))]
+
+    def _stop_project_server_and_cleanup_files(self, project):
+        """Stop the project's dev servers and delete the files they left behind.
+
+        PreviewService owns those processes and files, so it does the work; this
+        only supplies the older spellings of the project name to sweep. A stale
+        ports file is worse than clutter: a later project reusing this name would
+        read it and kill whatever now holds those ports.
         """
         try:
-            pid_files_to_check = []
-            # Primary dual-stack PID files used by PreviewService
-            pid_files_to_check.append(os.path.join(self.base_directory, f"{project_name}_frontend.pid"))
-            pid_files_to_check.append(os.path.join(self.base_directory, f"{project_name}_backend.pid"))
-            # Legacy single PID file
-            pid_files_to_check.append(os.path.join(self.base_directory, f"{project_name}_server.pid"))
+            # Imported here because PreviewService imports this package back.
+            from apps.Imagi.Build.services.preview_service import PreviewService
 
-            # Add sanitized fallback names
-            try:
-                from .project_creation_service import ProjectCreationService
-                creation_service = ProjectCreationService(self.user)
-                sanitized_name = creation_service._sanitize_project_name(project_name)
-                pid_files_to_check.extend([
-                    os.path.join(self.base_directory, f"{sanitized_name}_frontend.pid"),
-                    os.path.join(self.base_directory, f"{sanitized_name}_backend.pid"),
-                    os.path.join(self.base_directory, f"{sanitized_name}_server.pid"),
-                    os.path.join(self.base_directory, f"{project_name.lower().replace(' ', '_')}_server.pid"),
-                    os.path.join(self.base_directory, f"{project_name.replace(' ', '-')}_server.pid"),
-                ])
-            except Exception:
-                # If sanitization fails, continue with available names
-                pass
-
-            # Deduplicate while preserving order
-            seen = set()
-            pid_files_to_check = [p for p in pid_files_to_check if not (p in seen or seen.add(p))]
-
-            # Iterate through all candidate PID files
-            for pid_path in pid_files_to_check:
-                if not os.path.exists(pid_path):
-                    continue
-                try:
-                    pid = None
-                    try:
-                        with open(pid_path, 'r') as f:
-                            pid = int(f.read().strip())
-                    except Exception as e:
-                        logger.debug(f"Could not read PID from {pid_path}: {e}")
-
-                    if pid is not None:
-                        try:
-                            import psutil
-                            process = psutil.Process(pid)
-                            # Terminate children first
-                            for child in process.children(recursive=True):
-                                try:
-                                    child.terminate()
-                                    child.wait(timeout=3)
-                                except (psutil.TimeoutExpired, psutil.NoSuchProcess):
-                                    try:
-                                        child.kill()
-                                    except psutil.NoSuchProcess:
-                                        pass
-                            # Terminate main process
-                            try:
-                                process.terminate()
-                                process.wait(timeout=3)
-                            except (psutil.TimeoutExpired, psutil.NoSuchProcess):
-                                try:
-                                    process.kill()
-                                except psutil.NoSuchProcess:
-                                    pass
-                            logger.info(f"Stopped process {pid} from PID file {pid_path}")
-                        except ImportError:
-                            logger.warning("psutil not available; cannot gracefully stop process. Removing PID file only.")
-                        except psutil.AccessDenied:
-                            logger.warning(f"Access denied stopping process {pid} from {pid_path}")
-                        except psutil.NoSuchProcess:
-                            logger.debug(f"Process {pid} from {pid_path} was already stopped")
-                    # Remove PID file regardless
-                    try:
-                        os.remove(pid_path)
-                        logger.info(f"Deleted PID file: {pid_path}")
-                    except Exception as e:
-                        logger.warning(f"Failed to delete PID file {pid_path}: {e}")
-                except Exception as e:
-                    logger.warning(f"Error handling PID file {pid_path}: {e}")
-
-            # If we reach here, we've attempted all candidates
-            return
+            PreviewService(project).cleanup_project_files(
+                name_variants=self._project_name_variants(project.name)
+            )
         except Exception as e:
-            logger.warning(f"Error during server stop and PID cleanup for project '{project_name}': {str(e)}")
-            # Don't raise the exception as PID file cleanup is not critical for project deletion
+            logger.warning(f"Error during server stop and file cleanup for project '{project.name}': {str(e)}")
+            # Don't raise: this cleanup is not critical for project deletion
 
     
     

--- a/backend/django/apps/Imagi/ProjectManager/tests.py
+++ b/backend/django/apps/Imagi/ProjectManager/tests.py
@@ -8,6 +8,7 @@ performed by ProjectCreationService is mocked out so the suite stays fast and
 does not pollute the repository or depend on npm/Django scaffolding.
 """
 
+import os
 import shutil
 import tempfile
 from unittest.mock import patch
@@ -152,7 +153,7 @@ class ProjectManagementServiceTests(TestCase):
         theirs = Project.objects.create(user=self.other, name='Theirs')
         self.assertIsNone(self.service.get_project(theirs.id))
 
-    @patch.object(ProjectManagementService, '_stop_project_server_and_cleanup_pid')
+    @patch.object(ProjectManagementService, '_stop_project_server_and_cleanup_files')
     @patch.object(ProjectManagementService, '_delete_project_directory')
     def test_delete_project_hard_deletes_row(self, mock_dir, mock_pid):
         project = Project.objects.create(user=self.user, name='To Delete')
@@ -160,6 +161,49 @@ class ProjectManagementServiceTests(TestCase):
         result = self.service.delete_project(project)
         self.assertTrue(result['success'])
         self.assertFalse(Project.objects.filter(id=pid).exists())
+
+    @patch.object(ProjectManagementService, '_delete_project_directory')
+    def test_delete_project_removes_preview_sidecar_files(self, mock_dir):
+        # PreviewService writes these next to the project directory, so they
+        # survive the rmtree and have to be removed explicitly.
+        project = Project.objects.create(user=self.user, name='Saturn')
+        # A PID no live process holds: cleanup should skip the kill but still
+        # remove the file.
+        contents = {
+            '_backend.log': 'Starting development server...',
+            '_frontend.log': 'VITE ready in 300 ms',
+            '_preview_ports.json': '{"frontend_port": 5174, "backend_port": 8080}',
+            '_backend.pid': '999999',
+            '_frontend.pid': '999999',
+        }
+        sidecars = []
+        for suffix, body in contents.items():
+            path = os.path.join(self.service.base_directory, f'Saturn{suffix}')
+            with open(path, 'w') as f:
+                f.write(body)
+            sidecars.append(path)
+
+        self.service.delete_project(project)
+
+        for path in sidecars:
+            self.assertFalse(os.path.exists(path), f'{path} was left behind')
+
+    @patch.object(ProjectManagementService, '_delete_project_directory')
+    def test_delete_project_removes_legacy_named_sidecar_files(self, mock_dir):
+        # Older releases wrote these under a sanitized spelling of the name.
+        project = Project.objects.create(user=self.user, name='My App')
+        legacy = [
+            os.path.join(self.service.base_directory, name)
+            for name in ('My_App_server.pid', 'My_App_backend.log')
+        ]
+        for path in legacy:
+            with open(path, 'w') as f:
+                f.write('999999')
+
+        self.service.delete_project(project)
+
+        for path in legacy:
+            self.assertFalse(os.path.exists(path), f'{path} was left behind')
 
 
 @override_settings(PROJECTS_ROOT=_TMP_PROJECTS_ROOT)
@@ -278,7 +322,7 @@ class ProjectManagerAPITests(APITestCase):
         )
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
 
-    @patch.object(ProjectManagementService, '_stop_project_server_and_cleanup_pid')
+    @patch.object(ProjectManagementService, '_stop_project_server_and_cleanup_files')
     @patch.object(ProjectManagementService, '_delete_project_directory')
     def test_delete_project_endpoint(self, mock_dir, mock_pid):
         project = Project.objects.create(user=self.user, name='Delete Me')


### PR DESCRIPTION
## What

Deleting an Imagi project removed its directory and PID files, but left three files behind in the user's projects directory:

- `{name}_frontend.log`
- `{name}_backend.log`
- `{name}_preview_ports.json`

These are written by `PreviewService` *beside* the project directory and named after `project.name`, while the directory itself is named `{Sanitized_Name}_{timestamp}`. Because they share no prefix with the directory, the `rmtree` never matched them and they accumulated indefinitely.

## Why it matters beyond clutter

The orphaned ports file was an actual hazard. Delete a project named `Saturn`, create a new one also named `Saturn`, and the first `stop_preview()` would read the stale file and `_kill_by_port()` whatever now occupies those ports — possibly an unrelated dev server. That is the exact scenario the ports file was introduced to prevent, so leaving it behind inverted its purpose.

## The consolidation

Deletion hand-rolled its own process-killing loop, so there were two independent implementations of stopping preview servers — which is how the log files came to be missed in the first place. This moves the work to `PreviewService`, which owns those processes and files, behind a new `cleanup_project_files()`.

The seam: `PreviewService` owns the filename suffixes (now constants next to the code that writes them); `ProjectManagementService` owns the name variants, since the sanitization logic already lives there. Adding a future sidecar file is now a one-line change in one place.

`stop_preview()` is **deliberately** left alone and still keeps the logs on disk — if you stop a server to find out why it crashed, deleting its log would be hostile. Only deletion removes them.

## Reviewer notes

Two judgment calls worth a look:

1. **The stop endpoint's behavior changes.** The two implementations disagreed: `PreviewService` sent SIGKILL immediately, deletion did `terminate()` with a 3s grace period escalating to SIGKILL. Consolidating forced a choice, and I kept the graceful one — so `/api/build/.../stop` now lets dev servers shut down cleanly rather than hard-killing them. Tradeoff: stopping an unresponsive server can take up to 3s per process. Happy to revert to SIGKILL there if that is preferred.

2. **`_load_port_state()` hardened.** It called `.get()` on whatever `json.load()` returned, so a truncated or corrupt ports file from an earlier crash (e.g. one containing just `999999` — valid JSON, but an int) would raise `AttributeError` and break the stop path. It now treats anything that is not a mapping as absent. This surfaced for real while writing the tests.

## Testing

- Full backend suite green: **256 tests pass**.
- Two new tests cover the current and legacy (sanitized) filename spellings. Both were confirmed to **fail against the pre-fix code** (`Saturn_backend.log was left behind`) and pass now.
- Two existing tests patched the old method name; `patch.object` raises on a missing attribute, so they were updated.
- Since the kill logic was rewritten and the unit tests only ever kill a nonexistent PID, I separately verified against a **real spawned subprocess** that `cleanup_project_files()` stops it via the graceful path and removes every file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)