### PR TITLE
Center the project workspace layout and refine the module cards

### DIFF
--- a/frontend/vuejs/src/apps/imagi/project-manager/components/organisms/hub/ToolCategoryCard.vue
+++ b/frontend/vuejs/src/apps/imagi/project-manager/components/organisms/hub/ToolCategoryCard.vue
@@ -7,47 +7,47 @@
 <template>
   <router-link
     :to="target"
-    class="crisp-card group relative flex flex-col h-full p-6 rounded-2xl bg-white dark:bg-white/[0.05] border transition-colors duration-300"
+    class="crisp-card group relative flex flex-col items-center text-center h-full px-6 pt-8 pb-6 rounded-2xl bg-white dark:bg-white/[0.05] border transition-all duration-300 hover:-translate-y-1"
     :class="accent.cardBorder"
     :title="tool.name"
   >
     <!-- Soft accent glow on hover -->
     <div
-      class="pointer-events-none absolute -top-px -right-px w-40 h-40 rounded-full blur-3xl opacity-0 group-hover:opacity-100 bg-gradient-to-br to-transparent transition-opacity duration-500"
+      class="pointer-events-none absolute -top-px inset-x-0 mx-auto w-40 h-40 rounded-full blur-3xl opacity-0 group-hover:opacity-100 bg-gradient-to-b to-transparent transition-opacity duration-500"
       :class="accent.glow"
     ></div>
 
-    <!-- Icon + status -->
-    <div class="relative flex items-start justify-between mb-4">
-      <div
-        class="w-12 h-12 rounded-xl flex items-center justify-center border transition-colors duration-300"
-        :class="[accent.iconWrap]"
-      >
-        <i :class="['fas', tool.icon, accent.iconText]" class="text-xl"></i>
-      </div>
-      <span
-        v-if="isBuilding"
-        class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-[11px] font-semibold uppercase tracking-[0.14em] transition-colors duration-300"
-        :class="accent.badge"
-      >
-        <span class="w-3 h-3 rounded-full border-2 border-current border-t-transparent animate-spin"></span>
-        AI building
-      </span>
+    <!-- Status -->
+    <span
+      v-if="isBuilding"
+      class="absolute top-3 right-3 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-[11px] font-semibold uppercase tracking-[0.14em] transition-colors duration-300"
+      :class="accent.badge"
+    >
+      <span class="w-3 h-3 rounded-full border-2 border-current border-t-transparent animate-spin"></span>
+      AI building
+    </span>
+
+    <!-- Icon -->
+    <div
+      class="relative w-14 h-14 rounded-2xl flex items-center justify-center border mb-5 transition-transform duration-300 group-hover:scale-105"
+      :class="[accent.iconWrap]"
+    >
+      <i :class="['fas', tool.icon, accent.iconText]" class="text-xl"></i>
     </div>
 
     <!-- Name + tagline -->
     <div class="relative flex-1">
-      <h3 class="text-lg font-semibold text-blue-950 dark:text-white mb-1 transition-colors duration-300">
+      <h3 class="text-lg font-semibold text-blue-950 dark:text-white mb-1.5 tracking-tight transition-colors duration-300">
         {{ tool.name }}
       </h3>
-      <p class="text-sm text-blue-950/70 dark:text-blue-100/70 leading-snug transition-colors duration-300">
+      <p class="text-sm text-blue-950/70 dark:text-blue-100/70 leading-relaxed transition-colors duration-300">
         {{ isBuilding ? 'Imagi is building the first version of your app from your business description…' : tool.tagline }}
       </p>
     </div>
 
     <!-- CTA -->
     <div
-      class="relative flex items-center gap-1.5 text-sm font-medium mt-5 pt-4 border-t border-blue-200/60 dark:border-white/[0.1] transition-colors duration-300"
+      class="relative flex items-center justify-center gap-1.5 w-full text-sm font-medium mt-6 pt-4 border-t border-blue-200/60 dark:border-white/[0.1] transition-colors duration-300"
       :class="accent.link"
     >
       <span>{{ tool.status === 'available' ? 'Open workspace' : 'Preview' }}</span>
@@ -95,11 +95,27 @@ const target = computed<RouteLocationRaw>(() => {
     0 12px 28px -10px rgba(15, 23, 42, 0.10);
 }
 
+.crisp-card:hover {
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.04),
+    0 2px 4px rgba(15, 23, 42, 0.07),
+    0 8px 18px -4px rgba(15, 23, 42, 0.09),
+    0 20px 40px -12px rgba(15, 23, 42, 0.14);
+}
+
 :global(.dark) .crisp-card {
   box-shadow:
     0 0 0 1px rgba(255, 255, 255, 0.04),
     0 1px 2px rgba(0, 0, 0, 0.5),
     0 4px 10px -2px rgba(0, 0, 0, 0.45),
     0 12px 28px -10px rgba(0, 0, 0, 0.55);
+}
+
+:global(.dark) .crisp-card:hover {
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.07),
+    0 2px 4px rgba(0, 0, 0, 0.55),
+    0 8px 18px -4px rgba(0, 0, 0, 0.5),
+    0 20px 40px -12px rgba(0, 0, 0, 0.6);
 }
 </style>

--- a/frontend/vuejs/src/apps/imagi/project-manager/views/ProjectHub.vue
+++ b/frontend/vuejs/src/apps/imagi/project-manager/views/ProjectHub.vue
@@ -59,19 +59,20 @@
           <!-- Hub -->
           <template v-else>
             <!-- Project header -->
-            <section class="mb-8 md:mb-10">
-              <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-blue-200/70 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 text-xs font-semibold text-blue-700 dark:text-blue-300 uppercase tracking-[0.18em] mb-4 transition-colors duration-300">Project workspace</p>
-              <h1 class="text-3xl sm:text-4xl font-semibold text-blue-950 dark:text-white mb-2 tracking-tight transition-colors duration-300">
+            <section class="flex flex-col items-center text-center mb-10 md:mb-14">
+              <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-blue-200/70 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 text-xs font-semibold text-blue-700 dark:text-blue-300 uppercase tracking-[0.18em] mb-5 transition-colors duration-300">Project workspace</p>
+              <h1 class="text-3xl sm:text-4xl lg:text-5xl font-semibold text-blue-950 dark:text-white mb-3 tracking-tight transition-colors duration-300">
                 {{ project.name }}
               </h1>
-              <p class="text-base text-blue-950/70 dark:text-blue-100/70 max-w-2xl transition-colors duration-300">
+              <p class="text-base sm:text-lg text-blue-950/70 dark:text-blue-100/70 max-w-2xl leading-relaxed transition-colors duration-300">
                 {{ project.description || 'Build your product and run your business — all in one place. Choose a workspace to get started.' }}
               </p>
+              <div class="mt-7 h-px w-16 bg-gradient-to-r from-transparent via-blue-300/60 dark:via-blue-300/25 to-transparent"></div>
             </section>
 
             <!-- Category grid -->
             <section>
-              <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5">
+              <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5 sm:gap-6">
                 <ToolCategoryCard
                   v-for="tool in businessTools"
                   :key="tool.id"


### PR DESCRIPTION
## What

Centers the project workspace hub (`/imagi/project/:projectName`) — the page where a user picks between the Build, Sell, Market, and Operate modules — and refines the module card design.

**Header** ([ProjectHub.vue](../blob/claude/project-workspace-center-layout-8b2e2c/frontend/vuejs/src/apps/imagi/project-manager/views/ProjectHub.vue))
- The "Project workspace" pill, project name, and description are now a centered stacked block.
- The project name scales up to `text-5xl` on large screens; the description goes to `text-lg` with relaxed leading.
- A short fading hairline rule closes the block and separates it from the card grid.
- The "All projects" back link stays left-aligned — it's navigation, not part of the header.

**Cards** ([ToolCategoryCard.vue](../blob/claude/project-workspace-center-layout-8b2e2c/frontend/vuejs/src/apps/imagi/project-manager/components/organisms/hub/ToolCategoryCard.vue))
- Icon tile moved to top center and grew from 48px to 56px with a softer `rounded-2xl`.
- Name, tagline, and the "Open workspace" CTA are centered beneath it.
- The "AI building" badge previously shared a row with the icon; with the icon centered it's now pinned to the card's top-right corner.
- Hover lifts the card 4px, scales the icon tile, and deepens the shadow. The accent glow now fades in from the top center rather than the top-right corner.

## Why

The hub is a chooser — its entire content is a header plus four equal module cards. A left-aligned header sitting over a symmetric 4-up grid gave the eye no single axis to follow. Centering the header and the card content puts the whole page on one vertical line, which reads more deliberate and finished.

## Notes for reviewers

- No behavior or logic changes — this is presentation only. The build-status polling, routing, and the `isBuilding` state all work exactly as before.
- Styling reuses the existing `accentClasses` tokens in `utils/businessTools.ts` and the established `.crisp-card` shadow, so each module keeps its blue/emerald/violet/amber accent and the cards stay consistent with the rest of the site. The hover shadow is a new `:hover` variant layered on the existing `.crisp-card` recipe, in both light and dark.
- **Not visually verified.** The hub sits behind login and I couldn't reach it in the preview, so the layout hasn't been seen rendered — worth a quick look in the browser before merging, particularly the centered card content at the `sm:` 2-up breakpoint and the "AI building" badge in its new corner position (it's only visible while a freshly created project is generating). `npm run type-check` passes and the dev server compiles both files without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)