### PR TITLE
Stream the workspace agent's run as it happens

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -12,7 +12,7 @@
     {
       "name": "backend-django",
       "runtimeExecutable": "bash",
-      "runtimeArgs": ["-c", "bash ../../.claude/hooks/dev-setup.sh backend; pipenv run python manage.py runserver"],
+      "runtimeArgs": ["-c", "bash ../../.claude/hooks/dev-setup.sh backend; pipenv run uvicorn imagi.asgi:application --reload --port 8000"],
       "cwd": "backend/django",
       "port": 8000
     }

--- a/backend/django/Dockerfile
+++ b/backend/django/Dockerfile
@@ -10,16 +10,23 @@ RUN pip install --no-cache-dir pipenv
 COPY backend/django/Pipfile backend/django/Pipfile.lock ./
 RUN pipenv install --system --deploy
 
-# Install production server and PostgreSQL adapter
-RUN pip install --no-cache-dir gunicorn psycopg2-binary
+# Install servers and PostgreSQL adapter. Kept out of the Pipfile (as gunicorn
+# and psycopg2 already are) so adding them cannot re-lock the whole dependency
+# graph. Local dev needs uvicorn too, for streaming to behave as it does here:
+#   pipenv run pip install "uvicorn[standard]"
+RUN pip install --no-cache-dir gunicorn "uvicorn[standard]" psycopg2-binary
 
 COPY backend/django/ .
 
 EXPOSE 8000
 
 # Shell form so $PORT expands at runtime (Railway assigns it dynamically).
+# ASGI via uvicorn workers: agent runs stream over SSE for minutes, which sync
+# workers cannot hold open (one run would occupy a whole worker, and gunicorn
+# would kill it at --timeout since sync workers do not heartbeat mid-request).
 CMD python manage.py migrate --noinput && \
-    gunicorn imagi.wsgi:application \
+    gunicorn imagi.asgi:application \
+        --worker-class uvicorn.workers.UvicornWorker \
         --bind "[::]:${PORT:-8000}" \
         --workers 3 \
         --timeout 120

--- a/backend/django/apps/Imagi/Build/api/urls.py
+++ b/backend/django/apps/Imagi/Build/api/urls.py
@@ -23,6 +23,7 @@ from .views import (
     DeleteDirectoryView,
     # Agent views
     agent,
+    agent_stream,
     conversations_list_create,
     conversation_detail,
     conversation_messages,
@@ -56,6 +57,7 @@ builder_patterns = [
 
 agents_patterns = [
     path('agent/', agent, name='agent'),
+    path('agent/stream/', agent_stream, name='agent_stream'),
     path('conversations/', conversations_list_create, name='conversations_list_create'),
     path('conversations/<int:conversation_id>/', conversation_detail, name='conversation_detail'),
     path('conversations/<int:conversation_id>/messages/', conversation_messages, name='conversation_messages'),

--- a/backend/django/apps/Imagi/Build/api/views.py
+++ b/backend/django/apps/Imagi/Build/api/views.py
@@ -15,7 +15,9 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from asgiref.sync import sync_to_async
 from django.conf import settings
+from django.http import JsonResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.views.decorators.cache import never_cache
@@ -1043,6 +1045,106 @@ def agent(request):
         logger.error(f"Error in agent API: {str(e)}")
         logger.error(traceback.format_exc())
         return create_error_response(str(e), status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+def _sse(event: dict) -> str:
+    """Frame one event as an SSE message."""
+    return f"data: {json.dumps(event)}\n\n"
+
+
+async def _authenticate_stream_request(request):
+    """Resolve the user for a streaming request from its auth token, or None.
+
+    DRF's decorators are sync-only, so this endpoint authenticates by hand.
+    Token only, deliberately: this view is csrf_exempt (DRF's CSRF handling
+    comes with SessionAuthentication, which it cannot use), and honouring the
+    session cookie without a CSRF check would let any origin drive an agent run
+    against the victim's project. An Authorization header is not sent
+    cross-origin by default, so requiring one closes that off. The frontend
+    always authenticates by token.
+    """
+    from rest_framework.authentication import TokenAuthentication
+    from rest_framework.exceptions import AuthenticationFailed
+
+    if not request.META.get('HTTP_AUTHORIZATION'):
+        return None
+    try:
+        result = await sync_to_async(TokenAuthentication().authenticate)(request)
+    except AuthenticationFailed:
+        return None
+    return result[0] if result else None
+
+
+@csrf_exempt
+async def agent_stream(request):
+    """Stream an agent run as Server-Sent Events.
+
+    Same work as the blocking `agent` endpoint, but the client sees text and
+    tool activity as they happen instead of waiting for the whole run. The
+    terminal "done" event carries the payload `agent` would have returned.
+    """
+    if request.method != 'POST':
+        return JsonResponse({'error': 'Method not allowed'}, status=405)
+
+    user = await _authenticate_stream_request(request)
+    if user is None:
+        return JsonResponse({'error': 'Authentication required'}, status=401)
+
+    try:
+        payload = json.loads(request.body or '{}')
+    except json.JSONDecodeError:
+        return JsonResponse({'error': 'Invalid JSON body'}, status=400)
+
+    message = payload.get('message')
+    project_id = payload.get('project_id')
+
+    if not message:
+        return JsonResponse({'error': 'Message is required'}, status=400)
+    if not project_id:
+        return JsonResponse({'error': 'Project ID is required'}, status=400)
+    try:
+        project_id = int(project_id)
+    except (ValueError, TypeError):
+        return JsonResponse({'error': 'Invalid project ID'}, status=400)
+
+    conversation_id = payload.get('conversation_id')
+    if conversation_id:
+        try:
+            conversation_id = int(conversation_id)
+        except (ValueError, TypeError):
+            conversation_id = None
+
+    model = resolve_model(payload.get('model', DEFAULT_MODEL))
+    reasoning_effort = payload.get('reasoning_effort')
+
+    agent_service = ImagiAgentService(model=model, reasoning_effort=reasoning_effort)
+
+    async def event_stream():
+        try:
+            async for event in agent_service.process_stream(
+                user_input=message,
+                user=user,
+                model=model,
+                project_id=project_id,
+                current_file=payload.get('current_file'),
+                conversation_id=conversation_id,
+                reasoning_effort=reasoning_effort,
+            ):
+                yield _sse(event)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.error(f"Error in agent stream: {e}")
+            logger.error(traceback.format_exc())
+            yield _sse({"type": "error", "error": str(e)})
+
+    response = StreamingHttpResponse(
+        event_stream(),
+        content_type='text/event-stream',
+    )
+    response['Cache-Control'] = 'no-cache'
+    # Tell nginx not to buffer this response; without it the whole stream is
+    # held back and delivered at once, which defeats the point.
+    response['X-Accel-Buffering'] = 'no'
+    return response
 
 
 # ---------------------------------------------------------------------------

--- a/backend/django/apps/Imagi/Build/services/base_agent.py
+++ b/backend/django/apps/Imagi/Build/services/base_agent.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from dotenv import load_dotenv
 
 from agents import Agent, Runner, RunConfig
+from asgiref.sync import sync_to_async
 
 try:  # ModelSettings location can vary across SDK versions
     from agents import ModelSettings
@@ -325,6 +326,179 @@ class ImagiAgentService:
     # Main Processing
     # -------------------------------------------------------------------------
 
+    def _run_config(self, user) -> RunConfig:
+        return RunConfig(
+            workflow_name="imagi_agent",
+            trace_metadata={"user_id": str(user.id)},
+        )
+
+    def _prepare_run(
+        self,
+        user_input: str,
+        user,
+        model: Optional[str] = None,
+        project_id: Optional[int] = None,
+        current_file: Optional[Dict[str, Any]] = None,
+        conversation_id: Optional[int] = None,
+        reasoning_effort: Optional[str] = None,
+    ):
+        """Resolve the conversation, context and input messages for a run.
+
+        Shared by the blocking and streaming paths. Every database access for a
+        run happens here, so the streaming path can perform it in one hop off
+        the event loop.
+        """
+        model = model or self.model
+        self._apply_reasoning_effort(reasoning_effort)
+
+        # Get or create conversation
+        conversation = None
+        if conversation_id:
+            conversation = self.get_conversation(conversation_id, user)
+        if conversation is None:
+            conversation = self.create_conversation(user, model, project_id=project_id)
+
+        # Add user message to conversation
+        self.add_user_message(conversation, user_input)
+
+        # Get project info
+        project_info = self.get_project_info(project_id, user)
+
+        context = AgentContext(
+            user_id=user.id,
+            project_id=project_id,
+            project_name=project_info["project_name"],
+            project_description=project_info["project_description"],
+            project_path=project_info["project_path"],
+            conversation_id=conversation.id,
+            current_file=current_file,
+        )
+
+        # Build (compacted) conversation history, excluding the message we
+        # just persisted — it is appended as the current input below.
+        conversation_history = self.build_conversation_history(conversation)
+        if conversation_history and conversation_history[-1]["role"] == "user" \
+                and conversation_history[-1]["content"] == user_input:
+            conversation_history = conversation_history[:-1]
+
+        input_messages = list(conversation_history)
+        input_messages.append({"role": "user", "content": user_input})
+
+        return conversation, context, input_messages
+
+    async def process_stream(
+        self,
+        user_input: str,
+        user,
+        model: Optional[str] = None,
+        project_id: Optional[int] = None,
+        current_file: Optional[Dict[str, Any]] = None,
+        conversation_id: Optional[int] = None,
+        reasoning_effort: Optional[str] = None,
+    ):
+        """Run the agent, yielding events as they happen.
+
+        Same work as process(), but surfaced incrementally so the workspace can
+        show text and tool activity while the run is still going. Yields dicts
+        shaped {"type": ..., ...}; the terminal "done" event carries the same
+        payload process() returns, so both paths agree on the contract.
+
+        The assistant's reply is persisted even if the client disconnects
+        mid-run: the agent has already edited files by then, so dropping the
+        message would leave the conversation out of step with the project.
+        """
+        conversation = None
+        text_parts: List[str] = []
+        persisted = False
+
+        try:
+            if not project_id:
+                yield {"type": "error", "error": "Project ID is required"}
+                return
+            if not user_input:
+                yield {"type": "error", "error": "Message is required"}
+                return
+
+            conversation, context, input_messages = await sync_to_async(self._prepare_run)(
+                user_input=user_input,
+                user=user,
+                model=model,
+                project_id=project_id,
+                current_file=current_file,
+                conversation_id=conversation_id,
+                reasoning_effort=reasoning_effort,
+            )
+
+            yield {"type": "start", "conversation_id": conversation.id}
+
+            # run_streamed returns immediately; the run advances as events are
+            # consumed. Sync function tools are dispatched to worker threads by
+            # the SDK, so their ORM writes stay off this event loop.
+            result = Runner.run_streamed(
+                self.agent,
+                input=input_messages,
+                context=context,
+                max_turns=MAX_AGENT_TURNS,
+                run_config=self._run_config(user),
+            )
+
+            async for event in result.stream_events():
+                if event.type == "raw_response_event":
+                    data = getattr(event, 'data', None)
+                    if getattr(data, 'type', '') == 'response.output_text.delta':
+                        delta = getattr(data, 'delta', '')
+                        if delta:
+                            text_parts.append(delta)
+                            yield {"type": "delta", "text": delta}
+
+                elif event.type == "run_item_stream_event":
+                    item = getattr(event, 'item', None)
+                    if getattr(item, 'type', '') == 'tool_call_item':
+                        name = getattr(getattr(item, 'raw_item', None), 'name', None)
+                        if name:
+                            yield {"type": "tool_call", "name": name}
+                            # The plan lives on the context and is rewritten in
+                            # place, so re-send it whenever it may have changed.
+                            if name == 'update_plan':
+                                yield {"type": "plan", "plan": list(context.plan)}
+
+            response_content = result.final_output or "".join(text_parts)
+            metadata = extract_run_metadata(result)
+
+            await sync_to_async(self.add_assistant_message)(conversation, response_content)
+            persisted = True
+
+            yield {
+                "type": "done",
+                "success": True,
+                "response": response_content,
+                "conversation_id": conversation.id,
+                "files_changed": metadata["files_changed"],
+                "tool_calls": metadata["tool_calls"],
+                "plan": list(context.plan),
+                "single_message": True,
+            }
+
+        except Exception as e:
+            logger.error(f"Error in imagi_agent stream: {str(e)}")
+            import traceback
+            logger.error(traceback.format_exc())
+            yield {
+                "type": "error",
+                "error": str(e),
+                "conversation_id": conversation.id if conversation else None,
+            }
+        finally:
+            # Covers client disconnect (GeneratorExit) and mid-run failure:
+            # keep whatever the agent already said rather than losing it.
+            if conversation is not None and not persisted:
+                partial = "".join(text_parts).strip()
+                if partial:
+                    try:
+                        await sync_to_async(self.add_assistant_message)(conversation, partial)
+                    except Exception as e:  # pragma: no cover - best effort
+                        logger.warning(f"Could not persist partial agent reply: {e}")
+
     def process(
         self,
         user_input: str,
@@ -351,53 +525,22 @@ class ImagiAgentService:
             if not user_input:
                 return {"success": False, "error": "Message is required"}
 
-            model = model or self.model
-            self._apply_reasoning_effort(reasoning_effort)
-
-            # Get or create conversation
-            if conversation_id:
-                conversation = self.get_conversation(conversation_id, user)
-            if conversation is None:
-                conversation = self.create_conversation(
-                    user, model, project_id=project_id
-                )
-
-            # Add user message to conversation
-            self.add_user_message(conversation, user_input)
-
-            # Get project info
-            project_info = self.get_project_info(project_id, user)
-
-            # Build context for the agent
-            context = AgentContext(
-                user_id=user.id,
+            conversation, context, input_messages = self._prepare_run(
+                user_input=user_input,
+                user=user,
+                model=model,
                 project_id=project_id,
-                project_name=project_info["project_name"],
-                project_description=project_info["project_description"],
-                project_path=project_info["project_path"],
-                conversation_id=conversation.id,
                 current_file=current_file,
+                conversation_id=conversation_id,
+                reasoning_effort=reasoning_effort,
             )
-
-            # Build (compacted) conversation history, excluding the message we
-            # just persisted — it is appended as the current input below.
-            conversation_history = self.build_conversation_history(conversation)
-            if conversation_history and conversation_history[-1]["role"] == "user" \
-                    and conversation_history[-1]["content"] == user_input:
-                conversation_history = conversation_history[:-1]
-
-            input_messages = list(conversation_history)
-            input_messages.append({"role": "user", "content": user_input})
 
             result = Runner.run_sync(
                 self.agent,
                 input=input_messages,
                 context=context,
                 max_turns=MAX_AGENT_TURNS,
-                run_config=RunConfig(
-                    workflow_name="imagi_agent",
-                    trace_metadata={"user_id": str(user.id)}
-                )
+                run_config=self._run_config(user),
             )
 
             response_content = result.final_output or ""

--- a/backend/django/apps/Imagi/Build/tests/test_agents.py
+++ b/backend/django/apps/Imagi/Build/tests/test_agents.py
@@ -11,12 +11,17 @@ import os
 import shutil
 import tempfile
 from types import SimpleNamespace
+from unittest.mock import PropertyMock, patch
 
+from asgiref.sync import async_to_sync
 from django.contrib.auth.models import User
 from django.test import SimpleTestCase, TestCase
+from django.urls import reverse
+from rest_framework.authtoken.models import Token
 
 from apps.Imagi.Build.services.base_agent import (
     AgentContext,
+    ImagiAgentService,
     compact_history,
     extract_run_metadata,
 )
@@ -301,6 +306,162 @@ class ExtractRunMetadataTests(SimpleTestCase):
     def test_handles_empty_result(self):
         metadata = extract_run_metadata(SimpleNamespace(new_items=[]))
         self.assertEqual(metadata, {'tool_calls': [], 'files_changed': []})
+
+
+class _FakeStreamedRun:
+    """Stands in for the SDK's RunResultStreaming."""
+
+    def __init__(self, events, final_output='All done.', new_items=None):
+        self._events = events
+        self.final_output = final_output
+        self.new_items = new_items or []
+
+    async def stream_events(self):
+        for event in self._events:
+            yield event
+
+
+def _delta_event(text):
+    return SimpleNamespace(
+        type='raw_response_event',
+        data=SimpleNamespace(type='response.output_text.delta', delta=text),
+    )
+
+
+def _tool_call_event(name):
+    return SimpleNamespace(
+        type='run_item_stream_event',
+        item=SimpleNamespace(type='tool_call_item', raw_item=SimpleNamespace(name=name)),
+    )
+
+
+class ProcessStreamTests(TestCase):
+    """The streaming run: event order, persistence, and failure handling."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username='streamer', password='pw123456')
+        self.service = ImagiAgentService()
+
+        conversation = SimpleNamespace(id=7)
+        self.context = AgentContext(user_id=self.user.id, project_id=1)
+        self.persisted = []
+
+        self.service._prepare_run = lambda **kwargs: (
+            conversation, self.context, [{'role': 'user', 'content': kwargs['user_input']}]
+        )
+        self.service.add_assistant_message = lambda conv, content: self.persisted.append(content)
+
+    async def _collect(self, **overrides):
+        kwargs = {'user_input': 'build me a page', 'user': self.user, 'project_id': 1}
+        kwargs.update(overrides)
+        return [event async for event in self.service.process_stream(**kwargs)]
+
+    def _run(self, fake_run, **overrides):
+        with patch.object(type(self.service), 'agent', new_callable=PropertyMock) as mock_agent, \
+                patch('apps.Imagi.Build.services.base_agent.Runner') as mock_runner:
+            mock_agent.return_value = SimpleNamespace()
+            mock_runner.run_streamed.return_value = fake_run
+            return async_to_sync(self._collect)(**overrides)
+
+    def test_streams_deltas_then_done(self):
+        events = self._run(_FakeStreamedRun([_delta_event('Hel'), _delta_event('lo')]))
+
+        self.assertEqual(events[0], {'type': 'start', 'conversation_id': 7})
+        self.assertEqual(
+            [e['text'] for e in events if e['type'] == 'delta'], ['Hel', 'lo']
+        )
+        done = events[-1]
+        self.assertEqual(done['type'], 'done')
+        self.assertTrue(done['success'])
+        self.assertEqual(done['response'], 'All done.')
+        self.assertEqual(done['conversation_id'], 7)
+        # The reply is persisted exactly once, from the run's final output.
+        self.assertEqual(self.persisted, ['All done.'])
+
+    def test_reports_tool_calls_and_plan(self):
+        self.context.plan = [{'step': 'write the page', 'status': 'done'}]
+        events = self._run(_FakeStreamedRun([
+            _tool_call_event('read_file'), _tool_call_event('update_plan'),
+        ]))
+
+        self.assertEqual(
+            [e['name'] for e in events if e['type'] == 'tool_call'],
+            ['read_file', 'update_plan'],
+        )
+        # A plan event follows update_plan so the UI can redraw it mid-run.
+        plans = [e for e in events if e['type'] == 'plan']
+        self.assertEqual(len(plans), 1)
+        self.assertEqual(plans[0]['plan'], [{'step': 'write the page', 'status': 'done'}])
+
+    def test_falls_back_to_streamed_text_when_final_output_missing(self):
+        events = self._run(
+            _FakeStreamedRun([_delta_event('partial ')], final_output=None)
+        )
+        self.assertEqual(events[-1]['response'], 'partial ')
+        self.assertEqual(self.persisted, ['partial '])
+
+    def test_requires_message_and_project(self):
+        self.assertEqual(
+            self._run(_FakeStreamedRun([]), user_input='')[0],
+            {'type': 'error', 'error': 'Message is required'},
+        )
+        self.assertEqual(
+            self._run(_FakeStreamedRun([]), project_id=None)[0],
+            {'type': 'error', 'error': 'Project ID is required'},
+        )
+
+    def test_mid_run_failure_persists_partial_reply(self):
+        # The agent may already have edited files before blowing up, so the
+        # text it produced must not be silently dropped.
+        class Exploding(_FakeStreamedRun):
+            async def stream_events(self):
+                yield _delta_event('I started ')
+                raise RuntimeError('model exploded')
+
+        events = self._run(Exploding([]))
+
+        self.assertEqual(events[-1]['type'], 'error')
+        self.assertIn('model exploded', events[-1]['error'])
+        self.assertEqual(self.persisted, ['I started'])
+
+
+class AgentStreamEndpointTests(TestCase):
+    """Auth on the SSE endpoint, which cannot use DRF's sync-only decorators."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(username='api', password='pw123456')
+        self.url = reverse('agent_stream')
+
+    def test_rejects_unauthenticated_request(self):
+        resp = self.client.post(
+            self.url, data='{"message": "hi", "project_id": 1}',
+            content_type='application/json',
+        )
+        self.assertEqual(resp.status_code, 401)
+
+    def test_rejects_session_auth_without_token(self):
+        # csrf_exempt + cookie auth would let any origin drive an agent run,
+        # so a session alone must not authenticate this endpoint.
+        self.client.force_login(self.user)
+        resp = self.client.post(
+            self.url, data='{"message": "hi", "project_id": 1}',
+            content_type='application/json',
+        )
+        self.assertEqual(resp.status_code, 401)
+
+    def test_rejects_get(self):
+        token = Token.objects.create(user=self.user)
+        resp = self.client.get(self.url, HTTP_AUTHORIZATION=f'Token {token.key}')
+        self.assertEqual(resp.status_code, 405)
+
+    def test_validates_body(self):
+        token = Token.objects.create(user=self.user)
+        resp = self.client.post(
+            self.url, data='{"project_id": 1}', content_type='application/json',
+            HTTP_AUTHORIZATION=f'Token {token.key}',
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn('Message is required', resp.json()['error'])
 
 
 class ProjectMemoryTests(SimpleTestCase):

--- a/backend/django/imagi/settings.py
+++ b/backend/django/imagi/settings.py
@@ -112,6 +112,9 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = 'imagi.wsgi.application'
+# Served over ASGI in production: the agent streams its run over SSE, which
+# needs async request handling to avoid tying up a worker per run.
+ASGI_APPLICATION = 'imagi.asgi.application'
 
 
 # Database

--- a/frontend/vuejs/nginx.conf
+++ b/frontend/vuejs/nginx.conf
@@ -16,6 +16,18 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+
+        # The agent streams its run over SSE. Buffering would hold the whole
+        # response back and release it at once, and HTTP/1.0 with keep-alive
+        # off would close the connection early.
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        # An agent run can think for minutes between tokens.
+        proxy_read_timeout 600s;
+        # gzip buffers to fill a compression window, which stalls the stream.
+        gzip off;
     }
 
     # Support Vue Router history mode

--- a/frontend/vuejs/src/apps/imagi/build/services/__tests__/agentService.spec.ts
+++ b/frontend/vuejs/src/apps/imagi/build/services/__tests__/agentService.spec.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { AgentService } from '../agentService'
+
+// The service checks rate limits and prompt length before opening the stream.
+vi.mock('../modelsService', () => ({
+  ModelsService: {
+    checkRateLimit: vi.fn().mockResolvedValue(undefined),
+    getConfig: () => ({ maxTokens: 128000 }),
+    estimateTokens: () => 10,
+  },
+}))
+
+vi.mock('@/shared/services/api', () => ({
+  default: {},
+  getAuthToken: () => 'test-token',
+}))
+
+vi.mock('@/apps/payments/stores/payments', () => ({
+  usePaymentStore: () => ({ fetchBalance: vi.fn() }),
+}))
+
+/** A fetch Response whose body streams the given chunks verbatim. */
+function streamingResponse(chunks: string[]) {
+  const encoder = new TextEncoder()
+  let i = 0
+  return {
+    ok: true,
+    body: {
+      getReader: () => ({
+        read: async () =>
+          i < chunks.length
+            ? { value: encoder.encode(chunks[i++]), done: false }
+            : { value: undefined, done: true },
+      }),
+    },
+  }
+}
+
+const sse = (event: object) => `data: ${JSON.stringify(event)}\n\n`
+
+describe('AgentService.streamAgent', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  const call = (handlers = {}) =>
+    AgentService.streamAgent('13', { prompt: 'hi', model: 'gpt-5.6-sol' }, handlers)
+
+  it('reports deltas as they arrive and resolves with the done payload', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      streamingResponse([
+        sse({ type: 'start', conversation_id: 4 }),
+        sse({ type: 'delta', text: 'Hel' }),
+        sse({ type: 'delta', text: 'lo' }),
+        sse({ type: 'tool_call', name: 'read_file' }),
+        sse({
+          type: 'done',
+          response: 'Hello',
+          conversation_id: 4,
+          files_changed: ['a.vue'],
+          tool_calls: ['read_file'],
+          plan: [],
+          single_message: true,
+        }),
+      ]) as any,
+    )
+
+    const deltas: string[] = []
+    const tools: string[] = []
+    let started: number | undefined
+
+    const result = await call({
+      onStart: (id: number) => { started = id },
+      onDelta: (t: string) => deltas.push(t),
+      onToolCall: (n: string) => tools.push(n),
+    })
+
+    expect(started).toBe(4)
+    expect(deltas).toEqual(['Hel', 'lo'])
+    expect(tools).toEqual(['read_file'])
+    expect(result.response).toBe('Hello')
+    expect(result.files_changed).toEqual(['a.vue'])
+  })
+
+  it('reassembles frames split across chunk boundaries', async () => {
+    // TCP does not respect message boundaries: a frame can arrive in pieces.
+    vi.mocked(fetch).mockResolvedValue(
+      streamingResponse([
+        'data: {"type": "delta", "te',
+        'xt": "split"}\n\ndata: {"type": "do',
+        'ne", "response": "split", "conversation_id": 1}\n\n',
+      ]) as any,
+    )
+
+    const deltas: string[] = []
+    const result = await call({ onDelta: (t: string) => deltas.push(t) })
+
+    expect(deltas).toEqual(['split'])
+    expect(result.response).toBe('split')
+  })
+
+  it('throws when the run reports an error', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      streamingResponse([sse({ type: 'error', error: 'model exploded' })]) as any,
+    )
+    await expect(call()).rejects.toThrow('model exploded')
+  })
+
+  it('keeps partial text when the stream ends without a done event', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      streamingResponse([sse({ type: 'delta', text: 'partial' })]) as any,
+    )
+    const result = await call()
+    expect(result.response).toBe('partial')
+  })
+
+  it('surfaces a pre-stream error body', async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: 'Authentication required' }),
+    } as any)
+    await expect(call()).rejects.toThrow('Authentication required')
+  })
+})

--- a/frontend/vuejs/src/apps/imagi/build/services/agentService.ts
+++ b/frontend/vuejs/src/apps/imagi/build/services/agentService.ts
@@ -1,7 +1,8 @@
-import api from '@/shared/services/api'
+import api, { getAuthToken } from '@/shared/services/api'
 import type {
   AIModel,
   AgentResponse,
+  AgentPlanStep,
   VersionControlResponse,
   ConversationDto
 } from '../types/services'
@@ -23,7 +24,164 @@ function getPaymentsStore() {
  * processAgent; the rest of the service covers conversation CRUD and
  * version control.
  */
+/** Events the agent stream emits, in the order a run produces them. */
+export interface AgentStreamHandlers {
+  onStart?: (conversationId: number) => void
+  /** A chunk of the agent's reply. Chunks concatenate into the final text. */
+  onDelta?: (text: string) => void
+  onToolCall?: (name: string) => void
+  onPlan?: (plan: AgentPlanStep[]) => void
+}
+
 export const AgentService = {
+  /**
+   * Run the agent, surfacing output as it arrives.
+   *
+   * Uses fetch rather than the shared axios client because axios is built on
+   * XHR, which cannot expose a response body before it completes. Resolves
+   * with the same shape as processAgent once the run finishes.
+   */
+  async streamAgent(
+    projectId: string,
+    data: {
+      prompt: string;
+      model: string;
+      reasoningEffort?: string;
+      file?: any;
+      conversationId?: number | string | null;
+    },
+    handlers: AgentStreamHandlers = {},
+    signal?: AbortSignal,
+  ): Promise<AgentResponse> {
+    if (!data.prompt || !data.model) {
+      throw new Error('Prompt and model are required')
+    }
+    if (!projectId) {
+      throw new Error('Project ID is required')
+    }
+
+    await ModelsService.checkRateLimit(data.model)
+
+    const config = ModelsService.getConfig({ id: data.model } as AIModel)
+    if (ModelsService.estimateTokens(data.prompt) > config.maxTokens) {
+      throw new Error(`Prompt is too long for selected model. Please reduce length or choose a different model.`)
+    }
+
+    let currentFile = null
+    if (data.file) {
+      currentFile = {
+        path: data.file.path,
+        type: data.file.type || this.getFileType(data.file.path),
+        content: data.file.content || ''
+      }
+    }
+
+    const token = getAuthToken()
+    const response = await fetch('/api/v1/agents/agent/stream/', {
+      method: 'POST',
+      signal,
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'text/event-stream',
+        ...(token ? { Authorization: `Token ${token}` } : {}),
+      },
+      body: JSON.stringify({
+        message: data.prompt,
+        model: data.model,
+        reasoning_effort: data.reasoningEffort,
+        project_id: String(projectId),
+        conversation_id: data.conversationId ?? undefined,
+        current_file: currentFile,
+      }),
+    })
+
+    if (!response.ok || !response.body) {
+      // Errors before the stream opens are plain JSON, not SSE.
+      let detail = ''
+      try {
+        detail = (await response.json())?.error || ''
+      } catch { /* non-JSON body */ }
+      throw new Error(detail || `Agent request failed (${response.status})`)
+    }
+
+    const reader = response.body.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ''
+    let done: AgentResponse | null = null
+    let streamError = ''
+    const text: string[] = []
+    const toolCalls: string[] = []
+    let plan: AgentPlanStep[] = []
+    let conversationId: number | undefined
+
+    const handleEvent = (event: any) => {
+      switch (event.type) {
+        case 'start':
+          conversationId = event.conversation_id
+          handlers.onStart?.(event.conversation_id)
+          break
+        case 'delta':
+          text.push(event.text)
+          handlers.onDelta?.(event.text)
+          break
+        case 'tool_call':
+          toolCalls.push(event.name)
+          handlers.onToolCall?.(event.name)
+          break
+        case 'plan':
+          plan = event.plan || []
+          handlers.onPlan?.(plan)
+          break
+        case 'done':
+          done = {
+            response: event.response ?? text.join(''),
+            conversation_id: event.conversation_id,
+            files_changed: event.files_changed || [],
+            tool_calls: event.tool_calls || toolCalls,
+            plan: event.plan || plan,
+            single_message: event.single_message ?? true,
+          }
+          break
+        case 'error':
+          streamError = event.error || 'Agent run failed'
+          break
+      }
+    }
+
+    while (true) {
+      const { value, done: finished } = await reader.read()
+      if (finished) break
+      buffer += decoder.decode(value, { stream: true })
+
+      // SSE frames are separated by a blank line; the last chunk may be partial.
+      const frames = buffer.split('\n\n')
+      buffer = frames.pop() ?? ''
+      for (const frame of frames) {
+        const line = frame.split('\n').find(l => l.startsWith('data: '))
+        if (!line) continue
+        try {
+          handleEvent(JSON.parse(line.slice(6)))
+        } catch {
+          console.warn('Skipping malformed agent stream frame')
+        }
+      }
+    }
+
+    if (streamError) throw new Error(streamError)
+    if (done) return done
+
+    // Stream ended without a terminal event (server died, connection dropped).
+    // Keep whatever text arrived rather than discarding a partial reply.
+    return {
+      response: text.join(''),
+      conversation_id: conversationId as any,
+      files_changed: [],
+      tool_calls: toolCalls,
+      plan,
+      single_message: true,
+    }
+  },
+
   async processAgent(projectId: string, data: {
     prompt: string;
     model: string;

--- a/frontend/vuejs/src/apps/imagi/build/stores/agentStore.ts
+++ b/frontend/vuejs/src/apps/imagi/build/stores/agentStore.ts
@@ -284,6 +284,23 @@ export const useAgentStore = defineStore('agent', {
       instance.lastMessagePreview = (validMessage.content || '').split('\n')[0]?.slice(0, 140) || ''
     },
 
+    /**
+     * Replace the content of a message already in the conversation.
+     *
+     * Used while streaming: the assistant's message is added empty and then
+     * rewritten as each chunk arrives, so the reply appears to type itself
+     * rather than landing all at once when the run ends.
+     */
+    setMessageContent(instanceId: string, messageId: string, content: string) {
+      const instance = this._findInstance(instanceId)
+      if (!instance) return
+      const message = instance.conversation.find(m => m.id === messageId)
+      if (!message) return
+      message.content = content
+      instance.updatedAt = new Date().toISOString()
+      instance.lastMessagePreview = content.split('\n')[0]?.slice(0, 140) || ''
+    },
+
     updateInstanceConversationId(instanceId: string, conversationId: number) {
       const instance = this._findInstance(instanceId)
       if (!instance) return

--- a/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
+++ b/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
@@ -276,26 +276,62 @@ async function handlePrompt(promptText: string) {
     const isUserAuthenticated = await useAuthStore().validateAuth()
     if (!isUserAuthenticated) return
 
+    // The assistant message is created empty and filled in as chunks arrive.
+    const streamingMessageId = `assistant-response-${Date.now()}`
+    let streamedText = ''
+    let messageStarted = false
+
     try {
-      const response = await AgentService.processAgent(projectId.value, {
-        prompt: promptText,
-        model: instance.selectedModelId,
-        reasoningEffort: instance.selectedEffort,
-        file: instance.selectedFile,
-        conversationId: conversationIdBefore ?? undefined
-      })
+      const response = await AgentService.streamAgent(
+        projectId.value,
+        {
+          prompt: promptText,
+          model: instance.selectedModelId,
+          reasoningEffort: instance.selectedEffort,
+          file: instance.selectedFile,
+          conversationId: conversationIdBefore ?? undefined
+        },
+        {
+          onStart: (conversationId) => {
+            if (conversationId && !instance.conversationId) {
+              store.updateInstanceConversationId(instanceId, conversationId)
+            }
+          },
+          onDelta: (text) => {
+            // Defer creating the message until there is something to show, so
+            // a tools-only turn does not leave an empty bubble behind.
+            if (!messageStarted) {
+              messageStarted = true
+              store.addMessageToInstance(instanceId, {
+                role: 'assistant',
+                content: '',
+                timestamp: new Date().toISOString(),
+                id: streamingMessageId
+              })
+            }
+            streamedText += text
+            store.setMessageContent(instanceId, streamingMessageId, streamedText)
+          },
+        }
+      )
 
       if ((response as any).conversation_id && !instance.conversationId) {
         store.updateInstanceConversationId(instanceId, (response as any).conversation_id)
       }
 
-      if (response.response) {
-        store.addMessageToInstance(instanceId, {
-          role: 'assistant',
-          content: response.response,
-          timestamp: new Date().toISOString(),
-          id: `assistant-response-${Date.now()}`
-        })
+      // Reconcile with the run's authoritative final text: deltas can miss
+      // content the model emitted without streaming it.
+      if (response.response && response.response !== streamedText) {
+        if (messageStarted) {
+          store.setMessageContent(instanceId, streamingMessageId, response.response)
+        } else {
+          store.addMessageToInstance(instanceId, {
+            role: 'assistant',
+            content: response.response,
+            timestamp: new Date().toISOString(),
+            id: streamingMessageId
+          })
+        }
       }
 
       if (response.files_changed && response.files_changed.length > 0) {

--- a/frontend/vuejs/src/shared/services/api.ts
+++ b/frontend/vuejs/src/shared/services/api.ts
@@ -33,28 +33,39 @@ const api: AxiosInstance = axios.create({
 })
 
 
+/**
+ * Read the stored auth token, honouring its expiry.
+ *
+ * Exported because requests that stream bypass axios (and so the interceptor
+ * below) and have to build the same Authorization header themselves.
+ */
+export function getAuthToken(): string | null {
+  try {
+    const raw = typeof window !== 'undefined' ? localStorage.getItem('token') : null
+    if (!raw) return null
+    try {
+      const parsed = JSON.parse(raw)
+      const token = typeof parsed === 'string' ? parsed : parsed?.value
+      const expires = parsed?.expires
+      if (expires && Date.now() > Number(expires)) return null
+      return token || null
+    } catch {
+      return raw
+    }
+  } catch (_) {
+    return null
+  }
+}
+
 // Request interceptor
 api.interceptors.request.use(
   async (config: InternalAxiosRequestConfig) => {
     // Attach Authorization header from localStorage
     try {
       if (!config.headers['Authorization']) {
-        const raw = typeof window !== 'undefined' ? localStorage.getItem('token') : null
-        if (raw) {
-          let token: string | null = null
-          try {
-            const parsed = JSON.parse(raw)
-            token = typeof parsed === 'string' ? parsed : parsed?.value
-            const expires = parsed?.expires
-            if (expires && Date.now() > Number(expires)) {
-              token = null
-            }
-          } catch {
-            token = raw
-          }
-          if (token) {
-            config.headers['Authorization'] = `Token ${token}`
-          }
+        const token = getAuthToken()
+        if (token) {
+          config.headers['Authorization'] = `Token ${token}`
         }
       }
     } catch (_) {}


### PR DESCRIPTION
## What

The agent ran behind a single blocking POST, so the user watched a spinner for the whole run and saw nothing until it ended. This adds `POST /api/v1/agents/agent/stream/`, an SSE endpoint that emits the run live: reply text arrives token by token, and tool calls and plan updates surface as they happen.

Verified against the live API — the timestamps are from a real run:

```
[+    29ms] {"type": "start", "conversation_id": 14}
[+  1491ms] {"type": "delta", "text": "One"}
```

That 1.5s gap is the point: the connection stayed open and flushed incrementally rather than buffering.

## Why, beyond the UX

This removes the root cause of a confusing bug. The frontend gave up after 90s (and gunicorn killed the worker at 120s), but the backend kept going and **still persisted the assistant reply** — so files changed and the DB held the answer while the UI showed an error, and the message reappeared on reload. The connection now lives for the whole run, and a reply cut short is persisted rather than dropped: the agent has usually edited files by then, so losing the message would leave the conversation out of step with the project.

`process_stream()` and `process()` share `_prepare_run()`, and the terminal `done` event carries exactly the payload `process()` returns, so the two paths can't drift.

## Three deployment landmines this had to clear

Each of these would have made streaming silently fail:

1. **Sync gunicorn workers can't hold a streaming response open.** They don't heartbeat mid-request, so gunicorn kills them at `--timeout` (the *real* ceiling was 120s, not the 90s the frontend thought), and one run would occupy a whole worker. Now serves `imagi.asgi` via uvicorn workers.
2. **nginx buffered `/api/`.** It would have collected the whole SSE response and released it at once — working locally and doing nothing in production. Added `proxy_buffering off`, `gzip off`, and a 600s read timeout.
3. **`runserver` is WSGI-only**, so streaming wouldn't work in local dev at all — the inverse trap. `launch.json` now points at uvicorn to match prod.

## Reviewer notes

**The stream endpoint is token-auth only, deliberately.** It must be `csrf_exempt` (DRF's CSRF handling comes with `SessionAuthentication`, which an async view can't use), and honouring the session cookie without a CSRF check would let any origin drive an agent run against a logged-in victim's project. Requiring an `Authorization` header closes that off, since browsers don't send it cross-origin. The frontend always uses tokens, so nothing changes in practice. There's a test pinning this.

**No dependency churn — on purpose.** Adding uvicorn to the Pipfile re-resolves the whole graph and silently upgraded 26 packages, including `openai-agents` 0.13.6 → 0.18.2. That's a major agent-SDK jump that shouldn't ride along inside a streaming change, so the lock is reverted and uvicorn is installed in the Dockerfile's pip line, matching how gunicorn and psycopg2 are already handled. Everything here is verified on the pinned 0.13.6 that actually ships. **Local dev needs `pipenv run pip install "uvicorn[standard]"`** for streaming to behave as it does in prod (noted in the Dockerfile).

**`processAgent` and the blocking `agent` endpoint are now unused by the frontend.** I left them — the sync `process()` is still what initial builds use — but the frontend method is dead code worth removing in a follow-up.

**`AgentService.streamAgent` uses `fetch`, not the shared axios client**, because axios is XHR-based and can't expose a response body before it completes. The shared token-reading logic was extracted to `getAuthToken()` rather than duplicated.

## Testing

- 265 backend tests, 51 frontend tests, typecheck clean.
- New coverage: the streaming generator (event order, tool/plan events, partial-reply persistence on mid-run failure), endpoint auth (including the session-without-token rejection), and the client's SSE parsing.
- The client tests include a frame **split across a chunk boundary** — a TCP-level failure that's invisible to happy-path tests and the most likely thing to break in production.
- Live end-to-end run against the real OpenAI API on the pinned SDK, confirming incremental delivery.

**Gap:** I did not verify the workspace UI in a browser — injecting an auth token into `localStorage` was correctly blocked as credential materialization and I didn't route around it. The backend is proven live and the client parsing is unit-tested against mocked streams, but the actual rendering is untested. Worth a manual look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)