### PR TITLE
Show live agent activity in chat and fix streaming-era UI rough edges

### DIFF
--- a/frontend/vuejs/src/apps/imagi/build/components/__tests__/ChatConversation.spec.ts
+++ b/frontend/vuejs/src/apps/imagi/build/components/__tests__/ChatConversation.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ChatConversation from '../organisms/chat/ChatConversation.vue'
+import type { AIMessage } from '@/apps/imagi/build/types/services'
+
+const user = (content: string): AIMessage => ({
+  role: 'user', content, timestamp: '2026-01-01T00:00:00Z', id: 'u1',
+})
+const assistant = (content: string): AIMessage => ({
+  role: 'assistant', content, timestamp: '2026-01-01T00:00:01Z', id: 'a1',
+})
+
+const indicatorText = (wrapper: ReturnType<typeof mount>) => {
+  const indicator = wrapper.find('.typing-indicator')
+  return indicator.exists() ? indicator.element.parentElement?.textContent?.trim() : null
+}
+
+describe('ChatConversation activity indicator', () => {
+  const mountWith = (props: object) =>
+    mount(ChatConversation, { props: { messages: [user('hi')], ...props } })
+
+  it('shows the status while the agent has not started replying', () => {
+    const wrapper = mountWith({ isProcessing: true, statusText: 'Thinking…' })
+    expect(indicatorText(wrapper)).toBe('Thinking…')
+  })
+
+  it('falls back to a generic label without a status', () => {
+    const wrapper = mountWith({ isProcessing: true })
+    expect(indicatorText(wrapper)).toBe('Working…')
+  })
+
+  it('hides while the reply is streaming in', () => {
+    // The growing assistant message already shows progress; a second
+    // indicator under it would just dangle.
+    const wrapper = mountWith({
+      isProcessing: true,
+      statusText: '',
+      messages: [user('hi'), assistant('partial reply')],
+    })
+    expect(indicatorText(wrapper)).toBeNull()
+  })
+
+  it('returns with tool activity after text has streamed', () => {
+    const wrapper = mountWith({
+      isProcessing: true,
+      statusText: 'Editing project files…',
+      messages: [user('hi'), assistant('working on it')],
+    })
+    expect(indicatorText(wrapper)).toBe('Editing project files…')
+  })
+
+  it('hides when the run is over', () => {
+    const wrapper = mountWith({
+      isProcessing: false,
+      messages: [user('hi'), assistant('done')],
+    })
+    expect(indicatorText(wrapper)).toBeNull()
+  })
+})

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/chat/ChatConversation.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/chat/ChatConversation.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="h-full flex flex-col relative z-10 transition-colors duration-300" :class="{'mode-transition': disableAllAnimations}">
     <!-- Messages Container -->
-    <div ref="messagesContainer" class="flex-grow overflow-y-auto px-4 py-6">
+    <div ref="messagesContainer" class="flex-grow overflow-y-auto overflow-x-hidden px-4 py-6">
       <!-- Empty state -->
       <div v-if="!processedMessages.length" class="h-full flex flex-col items-center justify-center px-6 py-4 text-center min-h-0">
         <!-- Empty state with no content -->
@@ -53,8 +53,9 @@
             </div>
           </template>
           
-          <!-- "AI is typing" indicator -->
-          <div v-if="props.isProcessing" class="message-block message-assistant animate-fade-in">
+          <!-- Agent activity indicator. Hidden while the reply itself is
+               streaming in — the growing message already shows progress. -->
+          <div v-if="showActivityIndicator" class="message-block message-assistant animate-fade-in">
             <div class="message-label text-blue-700/70 dark:text-blue-300/70">Imagi</div>
             <div class="message-content">
               <div class="flex items-center gap-3">
@@ -63,7 +64,7 @@
                   <span></span>
                   <span></span>
                 </div>
-                <span class="text-sm text-blue-950/50 dark:text-blue-100/50">Working...</span>
+                <span class="text-sm text-blue-950/50 dark:text-blue-100/50">{{ props.statusText || 'Working…' }}</span>
               </div>
             </div>
           </div>
@@ -88,7 +89,22 @@ interface ProcessedMessage extends AIMessage {
 const props = defineProps<{
   messages: AIMessage[]
   isProcessing?: boolean
+  /** What the agent is doing right now; empty while its reply is streaming. */
+  statusText?: string
 }>()
+
+/**
+ * Show the activity indicator while the agent works, except when the reply is
+ * actively streaming (last message is the assistant's, growing in place) and
+ * nothing else is going on — then the indicator would just dangle beneath it.
+ * A tool call mid-run sets statusText again, which brings the indicator back.
+ */
+const showActivityIndicator = computed(() => {
+  if (!props.isProcessing) return false
+  if (props.statusText) return true
+  const last = props.messages[props.messages.length - 1]
+  return !(last?.role === 'assistant' && (last.content || '').trim().length > 0)
+})
 
 const emit = defineEmits<{
   (e: 'apply-code', code: string): void
@@ -271,6 +287,11 @@ const copyToClipboard = (code: string) => {
 .message-content {
   font-size: 0.875rem;
   line-height: 1.6;
+  /* Long unbroken strings (paths, URLs) wrap instead of widening the chat
+     and dragging in a horizontal scrollbar. Code blocks keep their own
+     overflow-x so they scroll within their box, not the page. */
+  overflow-wrap: anywhere;
+  min-width: 0;
 }
 
 /* Prose styling */
@@ -311,6 +332,14 @@ const copyToClipboard = (code: string) => {
   color: theme('colors.orange.300');
   background: rgba(251, 146, 60, 0.1);
   border: 1px solid rgba(251, 146, 60, 0.2);
+}
+
+/* Wide tables scroll within their own box; the container clips overflow, so
+   without this their far columns would be cut off with no way to reach them. */
+.prose table {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
 }
 
 .prose p {

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
@@ -38,6 +38,7 @@
       <ChatConversation
         :messages="ensureValidMessages(activeInstance?.conversation || [])"
         :is-processing="!!activeInstance?.isProcessing"
+        :status-text="activeInstance?.statusText || ''"
         @use-example="handleExamplePrompt"
         class="flex-1"
       />

--- a/frontend/vuejs/src/apps/imagi/build/stores/agentStore.ts
+++ b/frontend/vuejs/src/apps/imagi/build/stores/agentStore.ts
@@ -22,6 +22,7 @@ function dtoToInstance(dto: ConversationDto, fallbackModelId: string | null): Ag
     selectedFile: null,
     conversation: [],
     isProcessing: false,
+    statusText: '',
     archivedAt: dto.archived_at,
     updatedAt: dto.updated_at,
     lastMessagePreview: dto.last_message_preview || '',
@@ -268,6 +269,18 @@ export const useAgentStore = defineStore('agent', {
       const instance = this._findInstance(instanceId)
       if (!instance) return
       instance.isProcessing = value
+      if (!value) instance.statusText = ''
+    },
+
+    /**
+     * Describe what the running agent is doing ("Thinking…", "Editing project
+     * files…"). Cleared while reply text is streaming, so the status line and
+     * the growing message never show together.
+     */
+    setInstanceStatus(instanceId: string, text: string) {
+      const instance = this._findInstance(instanceId)
+      if (!instance) return
+      instance.statusText = text
     },
 
     addMessageToInstance(instanceId: string, message: AIMessage) {

--- a/frontend/vuejs/src/apps/imagi/build/types/services.ts
+++ b/frontend/vuejs/src/apps/imagi/build/types/services.ts
@@ -187,6 +187,9 @@ export interface AgentInstance {
   selectedFile: any | null;
   conversation: AIMessage[];
   isProcessing: boolean;
+  /** What the running agent is doing right now ("Thinking…", "Editing project
+   *  files…"). Transient — empty while text is streaming or when idle. */
+  statusText: string;
   archivedAt: string | null;
   updatedAt: string;
   lastMessagePreview: string;

--- a/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
+++ b/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
@@ -239,6 +239,19 @@ function createCommitFromPrompt(filePath: string, prompt: string) {
   );
 }
 
+/** Turn an agent tool name into a status line the user can read. */
+function describeAgentTool(name: string): string {
+  if (name === 'update_plan') return 'Planning…'
+  if (name === 'web_search' || name === 'web_search_call') return 'Searching the web…'
+  if (['get_project_tree', 'list_project_files', 'glob_files', 'grep_files', 'read_file'].includes(name)) {
+    return 'Reading project files…'
+  }
+  if (['edit_file', 'update_file', 'create_file', 'delete_file', 'create_directory', 'delete_directory'].includes(name)) {
+    return 'Editing project files…'
+  }
+  return 'Working…'
+}
+
 async function handlePrompt(promptText: string) {
   if (!promptText.trim()) return
 
@@ -282,6 +295,7 @@ async function handlePrompt(promptText: string) {
     let messageStarted = false
 
     try {
+      store.setInstanceStatus(instanceId, 'Thinking…')
       const response = await AgentService.streamAgent(
         projectId.value,
         {
@@ -309,8 +323,13 @@ async function handlePrompt(promptText: string) {
                 id: streamingMessageId
               })
             }
+            // The reply is streaming; the status line would just sit under it.
+            store.setInstanceStatus(instanceId, '')
             streamedText += text
             store.setMessageContent(instanceId, streamingMessageId, streamedText)
+          },
+          onToolCall: (name) => {
+            store.setInstanceStatus(instanceId, describeAgentTool(name))
           },
         }
       )
@@ -365,6 +384,14 @@ async function handlePrompt(promptText: string) {
     }
   } catch (error) {
     console.error('Error processing prompt:', error)
+    // Failures outside the agent call (store errors, setup bugs) must still
+    // surface in the chat — a console-only error reads as "nothing happened".
+    store.addMessageToInstance(instanceId, {
+      role: 'assistant',
+      content: `Error: ${error instanceof Error ? error.message : 'Something went wrong processing your request.'}`,
+      timestamp: new Date().toISOString(),
+      id: `system-error-${Date.now()}`
+    })
   } finally {
     store.setInstanceProcessing(instanceId, false)
   }


### PR DESCRIPTION
Follow-up to #55, from testing streaming in production.

## What

Three fixes to how the chat behaves around a streaming run:

1. **The activity indicator now narrates the run instead of squatting under it.** It used to show a bare "Working..." for the whole run — including beneath the reply while it streamed, which looked broken. It now shows "Thinking…" from the moment of send, then live tool activity ("Reading project files…", "Editing project files…", "Planning…", "Searching the web…") driven by the `tool_call` events the stream already carried but the UI ignored. It hides while reply text is streaming — the growing message is its own progress signal — and returns if the agent goes back to tool work mid-run.

2. **The chat pane can no longer scroll horizontally.** Agent replies are full of long unbroken strings (file paths, URLs); they now wrap via `overflow-wrap: anywhere`, the container clips x-overflow, and markdown tables scroll within their own box so the clipping can't silently cut off their far columns.

3. **`handlePrompt` failures now surface in the conversation, not just the console.** An exception outside the agent call previously died in an outer catch that only logged — the user saw "nothing happened." This shipped for real: after a hot-reload, a stale Pinia store threw on the new action and every prompt failed silently until a page refresh.

## On the latency

The remaining wait before first token was measured at ~30ms of backend work — the rest is model reasoning, already user-tunable via the effort selector. So the available win was making the wait legible, not shorter. If faster first tokens matter more than edit quality, defaulting new instances to `low` effort is a one-line follow-up.

## Testing

- New component tests pin the indicator contract (shows with status, falls back to "Working…", hides during streaming, returns for mid-run tool work, gone when idle). 56 frontend tests pass, typecheck clean.
- Verified live in the dev workspace end-to-end: tool statuses cycled during a real agent run, the indicator yielded to streaming text, and the chat container reported `scrollWidth === clientWidth` with a path-heavy reply on screen.

## Reviewer note

Dev-only gotcha worth knowing: editing Pinia store files under Vite HMR leaves the old store instance live (actions added in the edit don't exist at runtime) until a full page reload. That's what produced the silent failure above; production bundles are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)