### PR TITLE
Make generated projects' prebuilt auth work and treat disk as source of truth

### DIFF
--- a/backend/django/apps/Imagi/Build/models.py
+++ b/backend/django/apps/Imagi/Build/models.py
@@ -117,12 +117,13 @@ class ProjectLayout(models.Model):
 class ProjectFile(models.Model):
     """Database copy of a single file in a user's project.
 
-    The database is the durable store for project files: production serves
-    and edits files from these rows, while development additionally keeps a
-    local working copy on disk (under PROJECTS_ROOT) that mirrors them.
-    Every file mutation — agent tools, builder API endpoints, app
-    scaffolding — writes through to both places via
-    services.project_files_service.
+    The working copy on disk (under PROJECTS_ROOT) is the source of truth —
+    dev and production both run projects from disk. These rows are a mirror
+    of the disk copy, kept so project files are browsable from the Build
+    module for debugging, and usable as a backup to rehydrate a working
+    copy that has gone missing. Every file mutation — agent tools, builder
+    API endpoints, app scaffolding — touches disk first and then writes
+    through to this mirror via services.project_files_service.
     """
     project = models.ForeignKey(
         'ProjectManager.Project',

--- a/backend/django/apps/Imagi/Build/services/codegen/prebuilt_apps/auth.py
+++ b/backend/django/apps/Imagi/Build/services/codegen/prebuilt_apps/auth.py
@@ -1033,6 +1033,7 @@ export { default as PasswordRequirements } from './messages/PasswordRequirements
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+import type { PropType } from 'vue'
 
 const isVisible = ref(false)
 const togglePassword = () => { isVisible.value = !isVisible.value }
@@ -1047,8 +1048,8 @@ defineProps({
   id: { type: String, default: () => `password-${Math.random().toString(36).substr(2, 9)}` },
   hasError: { type: Boolean, default: false },
   name: { type: String, default: 'password' },
-  onBlur: { type: Function, default: () => {} },
-  onChange: { type: Function, default: () => {} }
+  onBlur: { type: Function as PropType<(e: FocusEvent) => void>, default: () => {} },
+  onChange: { type: Function as PropType<(e: Event) => void>, default: () => {} }
 })
 
 defineEmits(['update:modelValue'])
@@ -1089,8 +1090,10 @@ input, input:focus { outline: none !important; box-shadow: none !important; }
 </template>
 
 <script setup lang="ts">
+import type { PropType } from 'vue'
+
 defineProps({
-  type: { type: String, default: 'button' },
+  type: { type: String as PropType<'button' | 'submit' | 'reset'>, default: 'button' },
   disabled: { type: Boolean, default: false },
   loading: { type: Boolean, default: false },
   loadingText: { type: String, default: 'Loading...' }
@@ -1173,6 +1176,8 @@ defineProps({
 </template>
 
 <script setup lang="ts">
+import type { PropType } from 'vue'
+
 defineProps({
   modelValue: { type: String, default: '' },
   name: { type: String, required: true },
@@ -1182,8 +1187,8 @@ defineProps({
   disabled: { type: Boolean, default: false },
   placeholder: { type: String, default: '' },
   hasError: { type: Boolean, default: false },
-  onBlur: { type: Function, default: () => {} },
-  onChange: { type: Function, default: () => {} }
+  onBlur: { type: Function as PropType<(e: FocusEvent) => void>, default: () => {} },
+  onChange: { type: Function as PropType<(e: Event) => void>, default: () => {} }
 })
 
 defineEmits(['update:modelValue'])
@@ -1299,6 +1304,43 @@ defineExpose({ isValid })
 class AuthConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'apps.auth'
+    # Explicit label: the default ('auth') collides with django.contrib.auth
+    label = 'user_auth'
+'''
+    })
+
+    files.append({
+        'name': 'backend/django/apps/auth/migrations/__init__.py',
+        'type': 'python',
+        'content': ''
+    })
+
+    files.append({
+        'name': 'backend/django/apps/auth/migrations/0001_initial.py',
+        'type': 'python',
+        'content': '''import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Profile',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('balance', models.DecimalField(decimal_places=2, default=0.0, max_digits=10)),
+                ('user', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]
 '''
     })
     
@@ -1411,7 +1453,7 @@ class LoginSerializer(serializers.Serializer):
 from rest_framework.response import Response
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.views import APIView
-from rest_framework.authentication import TokenAuthentication
+from rest_framework.authentication import SessionAuthentication, TokenAuthentication
 from rest_framework.authtoken.models import Token
 from django.contrib.auth import get_user_model, login, logout
 from django.middleware.csrf import get_token
@@ -1477,6 +1519,20 @@ class UserView(generics.RetrieveUpdateAPIView):
     def get_object(self):
         return self.request.user
 
+class InitView(APIView):
+    """Session/token bootstrap for the SPA: reports whether the caller is
+    signed in, mirroring Imagi's own auth init endpoint."""
+    authentication_classes = [TokenAuthentication, SessionAuthentication]
+    permission_classes = [AllowAny]
+
+    def get(self, request):
+        if request.user and request.user.is_authenticated:
+            return Response({
+                'isAuthenticated': True,
+                'user': UserSerializer(request.user).data,
+            })
+        return Response({'isAuthenticated': False, 'user': None})
+
 class HealthCheckView(APIView):
     permission_classes = [AllowAny]
     authentication_classes = []
@@ -1500,6 +1556,7 @@ urlpatterns = [
     path('signin/', views.LoginView.as_view(), name='signin'),
     path('logout/', views.LogoutView.as_view(), name='logout'),
     path('register/', views.RegisterView.as_view(), name='register'),
+    path('init/', views.InitView.as_view(), name='init'),
     path('user/', views.UserView.as_view(), name='user'),
 ]
 '''

--- a/backend/django/apps/Imagi/Build/services/codegen/prebuilt_apps/home.py
+++ b/backend/django/apps/Imagi/Build/services/codegen/prebuilt_apps/home.py
@@ -9,6 +9,71 @@ from typing import Dict, List
 from .shared import _frontend_scaffold, _backend_scaffold
 
 
+HOME_VIEW_VUE = """<template>
+  <div class="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 flex flex-col">
+    <!-- Header with auth links -->
+    <header class="w-full">
+      <nav class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-5 flex items-center justify-between">
+        <router-link to="/" class="text-xl font-bold text-gray-900">Home</router-link>
+        <div class="flex items-center gap-4">
+          <template v-if="authStore.isAuthenticated">
+            <span class="text-sm text-gray-600">{{ authStore.user?.username }}</span>
+            <button
+              class="text-sm font-medium text-gray-700 hover:text-gray-900"
+              @click="authStore.logout($router)"
+            >
+              Sign out
+            </button>
+          </template>
+          <template v-else>
+            <router-link to="/auth/signin" class="text-sm font-medium text-gray-700 hover:text-gray-900">
+              Sign in
+            </router-link>
+            <router-link
+              to="/auth/register"
+              class="text-sm font-medium px-4 py-2 rounded-lg bg-gray-900 text-white hover:bg-gray-700 transition-colors"
+            >
+              Create account
+            </router-link>
+          </template>
+        </div>
+      </nav>
+    </header>
+
+    <!-- Hero -->
+    <main class="flex-grow flex items-center">
+      <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16 text-center">
+        <h1 class="text-5xl font-bold text-gray-900 mb-6">Welcome</h1>
+        <p class="text-xl text-gray-600 max-w-3xl mx-auto mb-10">
+          Welcome to your new project. Sign in or create an account to get started.
+        </p>
+        <div class="flex items-center justify-center gap-4">
+          <router-link
+            to="/auth/register"
+            class="px-8 py-4 rounded-xl bg-gray-900 text-white font-medium hover:bg-gray-700 transition-colors"
+          >
+            Get started
+          </router-link>
+          <router-link
+            to="/auth/signin"
+            class="px-8 py-4 rounded-xl border border-gray-300 text-gray-900 font-medium hover:bg-gray-100 transition-colors"
+          >
+            Sign in
+          </router-link>
+        </div>
+      </div>
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useAuthStore } from '../../auth/stores/auth'
+
+const authStore = useAuthStore()
+</script>
+"""
+
+
 def home_app_files() -> List[Dict[str, str]]:
     app_name = 'home'
     cap = 'Home'
@@ -16,9 +81,12 @@ def home_app_files() -> List[Dict[str, str]]:
     files: List[Dict[str, str]] = []
     files += _frontend_scaffold(app_name, cap, welcome)
     files += _backend_scaffold(app_name, cap)
-    # Override the home app router to serve '/' instead of '/home'
     for f in files:
+        # Override the home app router to serve '/' instead of '/home'
         if f['name'] == f'frontend/vuejs/src/apps/{app_name}/router/index.ts':
             f['content'] = f['content'].replace("path: '/home'", "path: '/'")
-            break
+        # Override the generic view with a landing page that links to the
+        # prebuilt auth app's sign-in and register pages
+        elif f['name'] == f'frontend/vuejs/src/apps/{app_name}/views/{cap}View.vue':
+            f['content'] = HOME_VIEW_VUE
     return files

--- a/backend/django/apps/Imagi/Build/services/codegen/prebuilt_apps/shared.py
+++ b/backend/django/apps/Imagi/Build/services/codegen/prebuilt_apps/shared.py
@@ -63,17 +63,17 @@ export const use{cap_name}Store = defineStore('{app_name}', () => {{
         {
             'name': f'frontend/vuejs/src/apps/{app_name}/components/atoms/index.ts',
             'type': 'typescript',
-            'content': '// atoms\n',
+            'content': '// atoms\nexport {}\n',
         },
         {
             'name': f'frontend/vuejs/src/apps/{app_name}/components/molecules/index.ts',
             'type': 'typescript',
-            'content': '// molecules\n',
+            'content': '// molecules\nexport {}\n',
         },
         {
             'name': f'frontend/vuejs/src/apps/{app_name}/components/organisms/index.ts',
             'type': 'typescript',
-            'content': '// organisms\n',
+            'content': '// organisms\nexport {}\n',
         },
         {
             'name': f'frontend/vuejs/src/apps/{app_name}/views/{cap_name}View.vue',

--- a/backend/django/apps/Imagi/Build/services/create_app_service.py
+++ b/backend/django/apps/Imagi/Build/services/create_app_service.py
@@ -7,6 +7,7 @@ Stripe-hosted checkout pages.
 """
 
 import logging
+import re
 from typing import Dict, List, Any
 import os
 from django.conf import settings
@@ -291,17 +292,17 @@ export const use{cap_name}Store = defineStore('{app_name}', () => {{
             {
                 'name': f'frontend/vuejs/src/apps/{app_name}/components/atoms/index.ts',
                 'type': 'typescript',
-                'content': '// atoms\n'
+                'content': '// atoms\nexport {}\n'
             },
             {
                 'name': f'frontend/vuejs/src/apps/{app_name}/components/molecules/index.ts',
                 'type': 'typescript',
-                'content': '// molecules\n'
+                'content': '// molecules\nexport {}\n'
             },
             {
                 'name': f'frontend/vuejs/src/apps/{app_name}/components/organisms/index.ts',
                 'type': 'typescript',
-                'content': '// organisms\n'
+                'content': '// organisms\nexport {}\n'
             },
             {
                 'name': f'frontend/vuejs/src/apps/{app_name}/views/{cap_name}View.vue',
@@ -398,18 +399,31 @@ export const use{cap_name}Store = defineStore('{app_name}', () => {{
 
         return files
 
-    # ... (rest of the code remains the same)
     # App labels Django's contrib apps already claim. Registering e.g.
     # 'apps.auth' (default label: 'auth') alongside django.contrib.auth makes
-    # the generated project unbootable with "Application labels aren't unique".
+    # the generated project unbootable with "Application labels aren't unique"
+    # — unless the app's AppConfig declares an explicit non-conflicting label
+    # (the prebuilt auth app sets label = 'user_auth').
     RESERVED_APP_LABELS = {'admin', 'auth', 'contenttypes', 'sessions', 'messages', 'staticfiles'}
+
+    def _app_declares_custom_label(self, project_path: str, app_name: str) -> bool:
+        """Whether the generated app's apps.py sets an explicit AppConfig label."""
+        apps_py = os.path.join(project_path, 'backend', 'django', 'apps', app_name, 'apps.py')
+        try:
+            with open(apps_py, 'r', encoding='utf-8') as f:
+                return bool(re.search(r'^\s*label\s*=', f.read(), re.MULTILINE))
+        except OSError:
+            return False
 
     def _register_backend_app(self, project_path: str, app_name: str) -> None:
         """Ensure the backend Django app is added to INSTALLED_APPS and URLs.
         Skips if a capitalized variant already exists (e.g., 'apps.Home').
         """
         try:
-            if app_name.lower() in self.RESERVED_APP_LABELS:
+            if (
+                app_name.lower() in self.RESERVED_APP_LABELS
+                and not self._app_declares_custom_label(project_path, app_name)
+            ):
                 logger.warning(
                     f"Skipping INSTALLED_APPS registration for 'apps.{app_name}': "
                     f"its default label conflicts with a Django contrib app"
@@ -445,23 +459,65 @@ export const use{cap_name}Store = defineStore('{app_name}', () => {{
             cap_module = f"apps.{app_name.capitalize()}"
 
             # Only add if neither lower nor capitalized variant is present
-            if (lower_module not in settings_src) and (cap_module not in settings_src):
+            if (f"'{lower_module}'" not in settings_src) and (f"'{cap_module}'" not in settings_src):
                 settings_src = self._inject_into_installed_apps(settings_src, lower_module)
                 with open(settings_path, 'w', encoding='utf-8') as f:
                     f.write(settings_src)
 
-            # Update urls.py
-            with open(urls_path, 'r', encoding='utf-8') as f:
-                urls_src = f.read()
+            app_dir = os.path.join(backend_root, 'apps', app_name)
 
-            include_line = f"        path('{app_name}/', include('apps.{app_name}.urls')),"
-            if include_line not in urls_src:
-                urls_src = self._inject_into_urls(urls_src, app_name)
-                with open(urls_path, 'w', encoding='utf-8') as f:
-                    f.write(urls_src)
+            # Apps with root-level urls.py mount at '/<app>/' in the project urls.py
+            if os.path.exists(os.path.join(app_dir, 'urls.py')):
+                with open(urls_path, 'r', encoding='utf-8') as f:
+                    urls_src = f.read()
+
+                include_line = f"path('{app_name}/', include('apps.{app_name}.urls')),"
+                if include_line not in urls_src:
+                    urls_src = self._inject_into_urls(urls_src, app_name)
+                    with open(urls_path, 'w', encoding='utf-8') as f:
+                        f.write(urls_src)
+
+            # Apps with an api/urls.py (like the prebuilt auth app) mount under
+            # '/api/v1/<app>/', mirroring how the main Imagi backend mounts its
+            # per-app API urls.
+            if os.path.exists(os.path.join(app_dir, 'api', 'urls.py')):
+                self._register_api_urls(backend_root, app_name)
         except Exception as e:
             # Don't raise - app creation succeeded; registration can be manual if needed
             logger.warning(f"Failed to register backend app '{app_name}': {str(e)}")
+
+    def _register_api_urls(self, backend_root: str, app_name: str) -> None:
+        """Mount apps.<app>.api.urls at '/api/v1/<app>/' in api/v1/url.py."""
+        api_v1_path = os.path.join(backend_root, 'api', 'v1', 'url.py')
+        if not os.path.exists(api_v1_path):
+            logger.warning(f"api/v1/url.py not found; cannot mount apps.{app_name}.api.urls")
+            return
+
+        with open(api_v1_path, 'r', encoding='utf-8') as f:
+            src = f.read()
+
+        include_line = f"path('{app_name}/', include('apps.{app_name}.api.urls')),"
+        if include_line in src:
+            return
+
+        if 'include' not in src.split('urlpatterns')[0]:
+            src = src.replace(
+                'from django.urls import path',
+                'from django.urls import path, include',
+                1,
+            )
+
+        lines = src.splitlines()
+        for idx in range(len(lines) - 1, -1, -1):
+            if lines[idx].strip().startswith(']'):
+                lines.insert(idx, f"    {include_line}")
+                break
+        else:
+            logger.warning(f"Could not find urlpatterns in api/v1/url.py to mount apps.{app_name}.api.urls")
+            return
+
+        with open(api_v1_path, 'w', encoding='utf-8') as f:
+            f.write("\n".join(lines) + "\n")
 
     def _inject_into_installed_apps(self, settings_src: str, module_name: str) -> str:
         """Insert the module into INSTALLED_APPS list in settings.py.

--- a/backend/django/apps/Imagi/Build/services/project_files_service.py
+++ b/backend/django/apps/Imagi/Build/services/project_files_service.py
@@ -1,22 +1,26 @@
 """
 Project file repository: keeps the database copy of a user's project files
-in sync with the local working copy on disk.
+in sync with the working copy on disk.
 
 Design
 ------
-- The database (ProjectFile rows) is the durable store. In production the
-  platform pulls project files from the database.
-- The local directory at ``project.project_path`` (under PROJECTS_ROOT) is
-  the working copy: the agent's tools, the preview server, and git version
-  control all operate on it. In development it doubles as a browsable copy
-  of the user's project.
-- Every mutation writes through to both: the file services and agent tools
-  call ``record_file`` / ``remove_file`` / ``remove_directory`` after
-  touching disk.
-- ``hydrate_project`` materializes the working copy from the database
-  (production cold starts, fresh dev checkouts); ``import_project_from_disk``
-  does the reverse (backfilling existing projects, or re-syncing after a
-  git reset rewrites the working copy).
+- The directory at ``project.project_path`` (under PROJECTS_ROOT) is the
+  SOURCE OF TRUTH. Everything runs from disk in both development and
+  production: the agent's tools, the preview server, and git version
+  control all operate on these files directly.
+- The database (ProjectFile rows) is a mirror of the disk copy, kept for
+  development/debugging — it makes a user's project files browsable from
+  the Build module — and as a backup for rehydrating a working copy that
+  has gone missing (e.g. a redeployed production host with an empty
+  PROJECTS_ROOT). When disk and database disagree, disk wins.
+- Every mutation touches disk first, then writes through to the mirror:
+  the file services and agent tools call ``record_file`` / ``remove_file``
+  / ``remove_directory`` after touching disk.
+- ``import_project_from_disk`` refreshes the mirror from disk (backfills,
+  or re-syncs after a git reset rewrites the working copy);
+  ``hydrate_project`` goes the other way, and is only used to restore a
+  missing working copy — it never overwrites files already on disk unless
+  explicitly asked.
 """
 
 import logging

--- a/backend/django/apps/Imagi/Build/services/tools.py
+++ b/backend/django/apps/Imagi/Build/services/tools.py
@@ -144,24 +144,28 @@ def _error_result(message: str) -> str:
     })
 
 
-def _db_copy_error(project, file_path: str, should_exist: bool):
-    """Verify the database copy of a file matches expectations.
+def _sync_db_mirror(project, file_path: str, should_exist: bool) -> None:
+    """Keep the database copy of a file in step with the disk operation
+    that just ran.
 
-    Returns an error message when the DB copy is out of step with the disk
-    operation that just ran, or None when everything is consistent. Paths
-    that are never synced to the database (binaries etc.) always pass.
+    Disk is the source of truth — the database rows are a browsable mirror
+    kept for debugging (and for rehydrating a lost working copy) — so a
+    mirror inconsistency must never fail a tool call that already succeeded
+    on disk. This repairs the mirror in place and logs when it cannot.
     """
     from apps.Imagi.Build.services import project_files_service
 
     if not project_files_service.is_syncable_path(file_path):
-        return None
+        return
 
-    exists = project_files_service.get_db_content(project, file_path) is not None
-    if should_exist and not exists:
-        return f"File was written to disk but its database copy is missing: {file_path}"
-    if not should_exist and exists:
-        return f"File was deleted from disk but its database copy still exists: {file_path}"
-    return None
+    try:
+        exists = project_files_service.get_db_content(project, file_path) is not None
+        if should_exist and not exists:
+            project_files_service.record_file(project, file_path)
+        elif not should_exist and exists:
+            project_files_service.remove_file(project, file_path)
+    except Exception as e:
+        logger.warning(f"Could not sync database mirror for {file_path}: {e}")
 
 
 def _get_project(ctx):
@@ -513,11 +517,7 @@ def edit_file(
     try:
         project = _get_project(ctx.context)
         result = edit_file_impl(project, file_path, old_string, new_string, replace_all)
-
-        db_error = _db_copy_error(project, result["path"], should_exist=True)
-        if db_error:
-            return _error_result(db_error)
-
+        _sync_db_mirror(project, result["path"], should_exist=True)
         return json.dumps(result)
     except Exception as e:
         logger.error(f"Error editing file {file_path}: {e}")
@@ -542,10 +542,7 @@ def update_file(ctx: RunContextWrapper, file_path: str, content: str) -> str:
         if not os.path.isfile(full_path):
             return _error_result(f"update_file appeared to succeed but file not found at {file_path}")
 
-        db_error = _db_copy_error(project, file_path, should_exist=True)
-        if db_error:
-            return _error_result(db_error)
-
+        _sync_db_mirror(project, file_path, should_exist=True)
         return json.dumps({"success": True, "path": file_path, "message": result.get("message", "File updated successfully")})
     except Exception as e:
         logger.error(f"Error updating file {file_path}: {e}")
@@ -573,10 +570,7 @@ def create_file(ctx: RunContextWrapper, file_path: str, content: str) -> str:
             return _error_result(f"create_file appeared to succeed but file not found at {file_path}")
 
         actual_path = result.get("path", file_path)
-        db_error = _db_copy_error(project, actual_path, should_exist=True)
-        if db_error:
-            return _error_result(db_error)
-
+        _sync_db_mirror(project, actual_path, should_exist=True)
         return json.dumps({"success": True, "path": actual_path, "message": f"File created at {actual_path}"})
     except Exception as e:
         logger.error(f"Error creating file {file_path}: {e}")
@@ -600,10 +594,7 @@ def delete_file(ctx: RunContextWrapper, file_path: str) -> str:
         if os.path.isfile(full_path):
             return _error_result(f"delete_file appeared to succeed but file still exists at {file_path}")
 
-        db_error = _db_copy_error(project, file_path, should_exist=False)
-        if db_error:
-            return _error_result(db_error)
-
+        _sync_db_mirror(project, file_path, should_exist=False)
         return json.dumps({"success": True, "path": file_path, "message": "File deleted successfully"})
     except Exception as e:
         logger.error(f"Error deleting file {file_path}: {e}")

--- a/backend/django/apps/Imagi/Build/tests/test_builder.py
+++ b/backend/django/apps/Imagi/Build/tests/test_builder.py
@@ -38,6 +38,45 @@ class DefaultAppsTests(TestCase):
         self.assertNotIn('payments', PREBUILT_MAP)
         self.assertEqual(set(PREBUILT_MAP), {'home', 'auth'})
 
+    def test_prebuilt_auth_backend_is_registrable_and_migratable(self):
+        """The auth app must declare a non-conflicting label (its default,
+        'auth', collides with django.contrib.auth) and ship migrations so
+        `manage.py migrate` creates the Profile table in generated projects."""
+        from apps.Imagi.Build.services.codegen.prebuilt_apps import (
+            generate_prebuilt_app_files,
+        )
+
+        files = {f['name']: f['content'] for f in generate_prebuilt_app_files('auth')}
+
+        self.assertIn("label = 'user_auth'", files['backend/django/apps/auth/apps.py'])
+        self.assertIn('backend/django/apps/auth/migrations/__init__.py', files)
+        self.assertIn("name='Profile'", files['backend/django/apps/auth/migrations/0001_initial.py'])
+
+    def test_prebuilt_auth_api_covers_the_frontend_contract(self):
+        """Every endpoint the generated frontend calls must exist: the auth
+        app's own service hits csrf/signin/register/logout/health, and the
+        scaffold's shared auth store bootstraps via init/."""
+        from apps.Imagi.Build.services.codegen.prebuilt_apps import (
+            generate_prebuilt_app_files,
+        )
+
+        files = {f['name']: f['content'] for f in generate_prebuilt_app_files('auth')}
+        urls = files['backend/django/apps/auth/api/urls.py']
+
+        for route in ('csrf/', 'signin/', 'register/', 'logout/', 'init/', 'user/', 'health/'):
+            self.assertIn(f"path('{route}'", urls)
+
+    def test_prebuilt_home_page_links_to_sign_in(self):
+        from apps.Imagi.Build.services.codegen.prebuilt_apps import (
+            generate_prebuilt_app_files,
+        )
+
+        files = {f['name']: f['content'] for f in generate_prebuilt_app_files('home')}
+        home_view = files['frontend/vuejs/src/apps/home/views/HomeView.vue']
+
+        self.assertIn('/auth/signin', home_view)
+        self.assertIn('/auth/register', home_view)
+
     def test_ensure_default_apps_skips_payments(self):
         user = User.objects.create_user(username='founder', password='testpass123')
         project_root = tempfile.mkdtemp(prefix='builder_default_apps_')

--- a/backend/django/apps/Imagi/Build/tests/test_project_files.py
+++ b/backend/django/apps/Imagi/Build/tests/test_project_files.py
@@ -24,7 +24,7 @@ from apps.Imagi.Build.services.create_file_service import CreateFileService
 from apps.Imagi.Build.services.delete_file_service import DeleteFileService
 from apps.Imagi.Build.services.directory_service import DirectoryService
 from apps.Imagi.Build.services.view_file_service import ViewFileService
-from apps.Imagi.Build.services.tools import edit_file_impl
+from apps.Imagi.Build.services.tools import _sync_db_mirror, edit_file_impl
 
 
 class ProjectFilesTestCase(TestCase):
@@ -111,6 +111,40 @@ class WriteThroughTests(ProjectFilesTestCase):
         )
         self.assertIsNone(row)
         self.assertEqual(self.project.files.count(), 0)
+
+
+class SyncDbMirrorTests(ProjectFilesTestCase):
+    """Disk is the source of truth: a mirror inconsistency after a successful
+    disk operation is repaired in place, never surfaced as a tool failure."""
+
+    def test_repairs_missing_row_after_disk_write(self):
+        self._write_disk_file('frontend/vuejs/src/New.vue', '<template/>')
+
+        _sync_db_mirror(self.project, 'frontend/vuejs/src/New.vue', should_exist=True)
+
+        self.assertEqual(self._db_content('frontend/vuejs/src/New.vue'), '<template/>')
+
+    def test_removes_stale_row_after_disk_delete(self):
+        ProjectFile.objects.create(
+            project=self.project, path='frontend/vuejs/src/Old.vue', content='stale'
+        )
+
+        _sync_db_mirror(self.project, 'frontend/vuejs/src/Old.vue', should_exist=False)
+
+        self.assertIsNone(self._db_content('frontend/vuejs/src/Old.vue'))
+
+    def test_ignores_non_syncable_paths(self):
+        _sync_db_mirror(self.project, 'frontend/vuejs/src/logo.png', should_exist=True)
+        self.assertEqual(self.project.files.count(), 0)
+
+    def test_oversized_file_never_errors(self):
+        # Files past the DB size cap stay disk-only; the sync must not raise.
+        big = 'x' * (project_files_service.MAX_SYNCED_FILE_BYTES + 1)
+        self._write_disk_file('frontend/vuejs/src/big.txt', big)
+
+        _sync_db_mirror(self.project, 'frontend/vuejs/src/big.txt', should_exist=True)
+
+        self.assertIsNone(self._db_content('frontend/vuejs/src/big.txt'))
 
 
 class BulkSyncTests(ProjectFilesTestCase):

--- a/backend/django/apps/Imagi/ProjectManager/services/codegen/templates.py
+++ b/backend/django/apps/Imagi/ProjectManager/services/codegen/templates.py
@@ -193,8 +193,8 @@ CORS_ALLOWED_ORIGIN_REGEXES = [
 # REST Framework settings
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.TokenAuthentication',
         'rest_framework.authentication.SessionAuthentication',
-        'rest_framework.authentication.BasicAuthentication',
     ],
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.AllowAny',  # Allow all for development
@@ -288,7 +288,7 @@ axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest'
 const app = createApp(App)
 
 // Type augmentation (available at runtime even without .d.ts)
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $axios: AxiosInstance;
   }
@@ -947,13 +947,13 @@ def create_vuejs_frontend_files(frontend_path: str, project_name: str, project_d
             "isomorphic-dompurify": "^2.22.0",
             "lodash-es": "^4.17.21",
             "marked": "^15.0.7",
-            "pinia": "^2.1.7",
+            "pinia": "^3.0.4",
             "tailwindcss": "^3.4.1",
             "uuid": "^11.1.0",
             "vee-validate": "^4.15.0",
-            "vue": "^3.4.15",
+            "vue": "^3.5.29",
             "vue-chartjs": "^5.3.0",
-            "vue-router": "^4.2.5"
+            "vue-router": "^5.0.3"
         },
         "devDependencies": {
             "@eslint/config-array": "^0.19.2",
@@ -962,11 +962,11 @@ def create_vuejs_frontend_files(frontend_path: str, project_name: str, project_d
             "@types/dompurify": "^3.0.5",
             "@types/lodash-es": "^4.17.12",
             "@types/marked": "^5.0.2",
-            "@types/node": "^20.11.0",
+            "@types/node": "^24.10.13",
             "@types/uuid": "^10.0.0",
             "@typescript-eslint/eslint-plugin": "^6.21.0",
             "@typescript-eslint/parser": "^6.21.0",
-            "@vitejs/plugin-vue": "^5.0.4",
+            "@vitejs/plugin-vue": "^6.0.4",
             "@vue/eslint-config-prettier": "^9.0.0",
             "@vue/eslint-config-typescript": "^12.0.0",
             "@vue/tsconfig": "^0.5.1",
@@ -983,9 +983,9 @@ def create_vuejs_frontend_files(frontend_path: str, project_name: str, project_d
             "postcss": "^8.4.33",
             "prettier": "^3.2.4",
             "rimraf": "^5.0.5",
-            "typescript": "~5.3.3",
-            "vite": "^6.2.1",
-            "vue-tsc": "^2.2.0"
+            "typescript": "~5.9.3",
+            "vite": "^7.3.1",
+            "vue-tsc": "^3.2.5"
         },
         "overrides": {
             "inflight": "^2.0.0",
@@ -1069,6 +1069,10 @@ def create_vuejs_src_files(frontend_path: str, project_name: str, project_descri
 
     for directory in directories:
         os.makedirs(os.path.join(src_path, directory), exist_ok=True)
+
+    # env.d.ts — Vite client types so import.meta.env type-checks
+    with open(os.path.join(src_path, 'env.d.ts'), 'w') as f:
+        f.write('/// <reference types="vite/client" />\n')
 
     # main.ts
     with open(os.path.join(src_path, 'main.ts'), 'w') as f:
@@ -1181,12 +1185,12 @@ def django_pipfile() -> str:
         "verify_ssl = true\n"
         "name = \"pypi\"\n\n"
         "[packages]\n"
-        "django = \"~=4.2.3\"\n"
-        "djangorestframework = \"~=3.14.0\"\n"
-        "django-cors-headers = \"~=4.1.0\"\n\n"
+        "django = \"*\"\n"
+        "djangorestframework = \"*\"\n"
+        "django-cors-headers = \"*\"\n\n"
         "[dev-packages]\n\n"
         "[requires]\n"
-        "python_version = \"3.10\"\n"
+        "python_version = \"3.13\"\n"
     )
 
 
@@ -1772,8 +1776,8 @@ CORS_ALLOW_ALL_ORIGINS = True
 # REST Framework settings
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.TokenAuthentication',
         'rest_framework.authentication.SessionAuthentication',
-        'rest_framework.authentication.BasicAuthentication',
     ],
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.IsAuthenticated',

--- a/backend/django/apps/Imagi/ProjectManager/services/initial_build_service.py
+++ b/backend/django/apps/Imagi/ProjectManager/services/initial_build_service.py
@@ -32,7 +32,7 @@ Business description (written by the founder):
 
 Using this description, build the first version of the business's web application so the founder sees a tailored starting point — not a generic scaffold — when they open the workspace:
 
-1. Rework the home app's landing page around this business: a clear hero (business name and what it does), sections covering its offering and intended customers, and a call to action that matches the sales approach in the description.
+1. Rework the home app's landing page around this business: a clear hero (business name and what it does), sections covering its offering and intended customers, and a call to action that matches the sales approach in the description. Keep the header's sign-in and create-account links to the prebuilt auth pages ('/auth/signin', '/auth/register') present and working.
 2. Update titles, headings, and placeholder copy that still reference the scaffold so they reflect the business.
 3. If the description clearly calls for one or two more simple pages (for example an About or Pricing page), create them and wire up their routes.
 

--- a/backend/django/apps/Imagi/ProjectManager/services/project_creation_service.py
+++ b/backend/django/apps/Imagi/ProjectManager/services/project_creation_service.py
@@ -424,7 +424,7 @@ class ProjectCreationService:
         installed_apps_match = re.search(installed_apps_pattern, settings_content, re.DOTALL)
         if installed_apps_match:
             current_apps = installed_apps_match.group(1)
-            updated_apps = current_apps + "    'rest_framework',\n    'corsheaders',\n"
+            updated_apps = current_apps + "    'rest_framework',\n    'rest_framework.authtoken',\n    'corsheaders',\n"
             settings_content = settings_content.replace(current_apps, updated_apps)
         
         # Add CORS middleware

--- a/backend/django/apps/Imagi/ProjectManager/tests.py
+++ b/backend/django/apps/Imagi/ProjectManager/tests.py
@@ -445,3 +445,83 @@ class InitialBuildServiceTests(TestCase):
         self._run_with_agent_result({'success': False, 'error': 'model error'})
         self.project.refresh_from_db()
         self.assertEqual(self.project.generation_status, 'failed')
+
+
+@override_settings(PROJECTS_ROOT=_TMP_PROJECTS_ROOT)
+class ScaffoldWiringTests(TestCase):
+    """Full-scaffold integration test: run the real ProjectCreationService
+    (npm install mocked out) and verify the generated project is wired so the
+    prebuilt home and auth apps actually work.
+
+    This is the regression net for the initial-build starting point: the
+    frontend's auth pages call /api/v1/auth/..., which requires the auth app
+    to be registered (with its non-conflicting 'user_auth' label), authtoken
+    to be installed, and the API urls to be mounted.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        from apps.Imagi.ProjectManager.services.project_creation_service import (
+            ProjectCreationService,
+        )
+
+        cls.user = User.objects.create_user(username='scaffolder', password='pw123456')
+        cls.project = Project.objects.create(
+            user=cls.user, name='Wiring Check', description=VALID_DESCRIPTION
+        )
+        with patch.object(ProjectCreationService, '_install_vuejs_dependencies'):
+            cls.project = ProjectCreationService(cls.user).create_project(cls.project)
+        cls.backend_root = os.path.join(cls.project.project_path, 'backend', 'django')
+
+    @classmethod
+    def _read(cls, *parts):
+        with open(os.path.join(*parts), 'r', encoding='utf-8') as f:
+            return f.read()
+
+    def _settings_src(self):
+        for entry in os.listdir(self.backend_root):
+            candidate = os.path.join(self.backend_root, entry, 'settings.py')
+            if os.path.isfile(candidate):
+                return self._read(candidate), os.path.join(self.backend_root, entry)
+        self.fail('No Django settings.py found in scaffolded backend')
+
+    def test_auth_app_is_installed_with_authtoken(self):
+        settings_src, _ = self._settings_src()
+        self.assertIn("'apps.auth'", settings_src)
+        self.assertIn("'apps.home'", settings_src)
+        self.assertIn("'rest_framework.authtoken'", settings_src)
+
+    def test_auth_api_is_mounted_under_api_v1(self):
+        api_v1 = self._read(self.backend_root, 'api', 'v1', 'url.py')
+        self.assertIn("path('auth/', include('apps.auth.api.urls'))", api_v1)
+
+    def test_home_urls_are_mounted_exactly_once(self):
+        _, project_dir = self._settings_src()
+        urls_src = self._read(project_dir, 'urls.py')
+        self.assertEqual(
+            urls_src.count("include('apps.home.urls')"), 1,
+            'home urls must be registered exactly once (idempotent registration)',
+        )
+
+    def test_auth_app_ships_label_and_migrations(self):
+        apps_py = self._read(self.backend_root, 'apps', 'auth', 'apps.py')
+        self.assertIn("label = 'user_auth'", apps_py)
+        self.assertTrue(os.path.isfile(
+            os.path.join(self.backend_root, 'apps', 'auth', 'migrations', '0001_initial.py')
+        ))
+
+    def test_home_page_links_to_auth(self):
+        home_view = self._read(
+            self.project.project_path,
+            'frontend', 'vuejs', 'src', 'apps', 'home', 'views', 'HomeView.vue',
+        )
+        self.assertIn('/auth/signin', home_view)
+        self.assertIn('/auth/register', home_view)
+
+    def test_scaffolded_files_are_mirrored_to_database(self):
+        # Disk is the source of truth; the DB mirror should hold the same
+        # files for debugging and rehydration.
+        paths = set(self.project.files.values_list('path', flat=True))
+        self.assertIn('backend/django/apps/auth/api/urls.py', paths)
+        self.assertIn('frontend/vuejs/src/apps/home/views/HomeView.vue', paths)

--- a/backend/django/imagi/settings.py
+++ b/backend/django/imagi/settings.py
@@ -257,10 +257,11 @@ IMAGI_BUILDER = {
     'DEFAULT_APPS': ['home', 'auth'],
 }
 
-# Root directory where ProjectManager writes the working copy of generated
-# user projects. The database (Build.ProjectFile rows) is the durable store
-# and the working copy can always be rehydrated from it, so this directory is
-# disposable:
+# Root directory where ProjectManager writes generated user projects. This
+# working copy on disk is the source of truth — projects run from it in both
+# development and production. The database (Build.ProjectFile rows) keeps a
+# mirror of these files for debugging (browsable from the Build module) and
+# as a backup from which a missing working copy can be rehydrated.
 #  - In development it lives inside the Build module so generated projects are
 #    easy to browse while testing the agent (the path is gitignored).
 #  - In production it lives outside the repository so git operations (clean,


### PR DESCRIPTION
Review of the build-module agent against its specifications found the
prebuilt auth backend in generated projects was dead code: every
/api/v1/auth/* endpoint 404'd because the app was never registered, and
the docs described the ProjectFile mirror as the durable store.

Disk is the source of truth (spec 1):
- Rewrite the project_files_service / ProjectFile / PROJECTS_ROOT docs:
  projects run from disk in dev and prod; the DB rows are a debugging
  mirror and rehydration backup.
- Replace the tools' _db_copy_error check with _sync_db_mirror: a mirror
  inconsistency after a successful disk operation is repaired in place
  instead of failing the tool call (oversized files previously produced
  false failures).

Working initial build (spec 2):
- Give the prebuilt auth app an explicit 'user_auth' AppConfig label so
  it can be registered alongside django.contrib.auth, ship its Profile
  migration, and add the init/ endpoint the scaffold's shared auth store
  bootstraps from (mirroring Imagi's own Auth API).
- Register reserved-label apps when they declare a custom label, mount
  apps.<app>.api.urls under /api/v1/<app>/ (matching the main backend's
  layout), and make URL registration idempotent (home was mounted twice).
- Add rest_framework.authtoken and TokenAuthentication to generated
  settings so the token flow works.
- Give the prebuilt home page a real landing layout with sign-in /
  create-account links to the auth pages, and tell the initial build to
  keep them.

Buildable full-stack scaffold (spec 3):
- Align the generated frontend toolchain with the main Imagi frontend
  (TS 5.9, vue-tsc 3, Vite 7, Vue 3.5, Pinia 3, vue-router 5) and fix
  the template type errors that made `npm run build` fail: missing
  env.d.ts for import.meta.env, '@vue/runtime-core' augmentation,
  non-module component barrels, and untyped component props.
- Align the generated Pipfile with the platform (Django 6 era, py3.13).

Verified end to end: scaffolded a project, booted its backend
(check/migrate clean), exercised register -> signin -> init -> user ->
logout against /api/v1/auth/, and built the generated frontend
(vue-tsc + vite build pass). Backend suite: 278 tests green, including
13 new regression tests for this wiring.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B3yevcrdKzJfsSyKrVpZ2y