### PR TITLE
Replace localhost preview with a server-side headless browser

### DIFF
--- a/backend/django/Dockerfile
+++ b/backend/django/Dockerfile
@@ -5,6 +5,18 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
+# Node.js and Chromium power the Build workspace preview: generated user
+# projects run their Vite + Django dev servers inside this container, and a
+# headless Chromium renders them for the workspace UI — the same setup used
+# in local development, which is what makes preview work on Railway.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl gnupg ca-certificates \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs chromium \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV BROWSER_PREVIEW_EXECUTABLE=/usr/bin/chromium
+
 RUN pip install --no-cache-dir pipenv
 
 COPY backend/django/Pipfile backend/django/Pipfile.lock ./

--- a/backend/django/Pipfile
+++ b/backend/django/Pipfile
@@ -13,6 +13,7 @@ python-dotenv = "*"
 psutil = "*"
 requests = "*"
 cryptography = "*"
+websocket-client = "*"
 
 [dev-packages]
 

--- a/backend/django/Pipfile.lock
+++ b/backend/django/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4b1e2627de076cfadd8c9fa7042da4f04c0fca6176d4a4964cd528d683970fc0"
+            "sha256": "f288d79ff7d087af3113d16ca9c395ad7f6b00ec0dcf849e71137e9b119bbeb7"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -976,14 +976,6 @@
             "markers": "python_version >= '3.7'",
             "version": "==4.67.3"
         },
-        "types-requests": {
-            "hashes": [
-                "sha256:81f31d5ea4acb39f03be7bc8bed569ba6d5a9c5d97e89f45ac43d819b68ca50f",
-                "sha256:95b9a86376807a216b2fb412b47617b202091c3ea7c078f47cc358d5528ccb7b"
-            ],
-            "markers": "python_version >= '3.10'",
-            "version": "==2.33.0.20260408"
-        },
         "typing-extensions": {
             "hashes": [
                 "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466",
@@ -1015,6 +1007,15 @@
             ],
             "markers": "python_version >= '3.10'",
             "version": "==0.44.0"
+        },
+        "websocket-client": {
+            "hashes": [
+                "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98",
+                "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==1.9.0"
         }
     },
     "develop": {}

--- a/backend/django/apps/Imagi/Build/api/urls.py
+++ b/backend/django/apps/Imagi/Build/api/urls.py
@@ -15,6 +15,7 @@ from .views import (
     AIModelsView, CreateFileView, DeleteFileView,
     FileContentView,
     PreviewSessionView,
+    ProjectPagesView,
     PreviewFrameView,
     PreviewInputView,
     PreviewNavigateView,
@@ -41,6 +42,7 @@ builder_patterns = [
     # Browser preview: a headless Chromium on the backend renders the
     # project's dev servers; the client streams frames and sends input.
     path('<int:project_id>/preview/', PreviewSessionView.as_view(), name='api-preview'),
+    path('<int:project_id>/pages/', ProjectPagesView.as_view(), name='api-project-pages'),
     path('<int:project_id>/preview/frame/', PreviewFrameView.as_view(), name='api-preview-frame'),
     path('<int:project_id>/preview/input/', PreviewInputView.as_view(), name='api-preview-input'),
     path('<int:project_id>/preview/navigate/', PreviewNavigateView.as_view(), name='api-preview-navigate'),

--- a/backend/django/apps/Imagi/Build/api/urls.py
+++ b/backend/django/apps/Imagi/Build/api/urls.py
@@ -14,7 +14,11 @@ from .views import (
     # Builder workspace views
     AIModelsView, CreateFileView, DeleteFileView,
     FileContentView,
-    PreviewView,
+    PreviewSessionView,
+    PreviewFrameView,
+    PreviewInputView,
+    PreviewNavigateView,
+    PreviewResizeView,
     VersionControlHistoryView, VersionControlResetView,
     CreateAppView,
     ProjectDirectoriesView,
@@ -34,7 +38,13 @@ builder_patterns = [
     path('<int:project_id>/directories/', ProjectDirectoriesView.as_view(), name='api-project-directories'),
     path('<int:project_id>/directories/create/', CreateDirectoryView.as_view(), name='api-create-directory'),
     path('<int:project_id>/directories/<path:dir_path>/delete/', DeleteDirectoryView.as_view(), name='api-delete-directory'),
-    path('<int:project_id>/preview/', PreviewView.as_view(), name='api-preview'),
+    # Browser preview: a headless Chromium on the backend renders the
+    # project's dev servers; the client streams frames and sends input.
+    path('<int:project_id>/preview/', PreviewSessionView.as_view(), name='api-preview'),
+    path('<int:project_id>/preview/frame/', PreviewFrameView.as_view(), name='api-preview-frame'),
+    path('<int:project_id>/preview/input/', PreviewInputView.as_view(), name='api-preview-input'),
+    path('<int:project_id>/preview/navigate/', PreviewNavigateView.as_view(), name='api-preview-navigate'),
+    path('<int:project_id>/preview/resize/', PreviewResizeView.as_view(), name='api-preview-resize'),
 
     # File management endpoints
     path('<int:project_id>/files/create/', CreateFileView.as_view(), name='api-create-file'),

--- a/backend/django/apps/Imagi/Build/api/views.py
+++ b/backend/django/apps/Imagi/Build/api/views.py
@@ -332,6 +332,25 @@ class PreviewSessionView(BrowserPreviewBaseView):
             raise
 
 
+class ProjectPagesView(BrowserPreviewBaseView):
+    """List the project's navigable pages, read from its actual Vue routers.
+
+    Powers the preview's app/page menu; parsing the generated router files
+    keeps the menu truthful even when routes don't follow the default
+    view-filename conventions.
+    """
+
+    def get(self, request, project_id):
+        project = self.get_project(project_id)
+        try:
+            from ..services.project_files_service import ensure_working_copy
+            ensure_working_copy(project)
+        except Exception as hydrate_err:
+            logger.warning(f"Could not ensure working copy before listing pages: {hydrate_err}")
+        from ..services.pages_service import list_app_pages
+        return Response({'apps': list_app_pages(project)})
+
+
 class PreviewFrameView(BrowserPreviewBaseView):
     """Poll the latest screenshot; `etag` elides an unchanged frame."""
 

--- a/backend/django/apps/Imagi/Build/api/views.py
+++ b/backend/django/apps/Imagi/Build/api/views.py
@@ -16,7 +16,6 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from asgiref.sync import sync_to_async
-from django.conf import settings
 from django.http import JsonResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
@@ -33,7 +32,11 @@ from ..services.create_file_service import CreateFileService
 from ..services.view_file_service import ViewFileService
 from ..services.delete_file_service import DeleteFileService
 from ..services.models_service import ModelsService, get_default_model_id, get_model_by_id
-from ..services.preview_service import PreviewService
+from ..services.browser_preview_service import (
+    BrowserNotRunning,
+    BrowserPreviewError,
+    BrowserPreviewService,
+)
 from apps.Imagi.ProjectManager.models import Project as PMProject
 from apps.Imagi.ProjectManager.services.project_management_service import ProjectManagementService
 from apps.Imagi.ProjectManager.services.project_creation_service import ProjectCreationService
@@ -247,8 +250,13 @@ class FileContentView(APIView):
 # Removed old process_input view - use Agents API instead
 
 @method_decorator(never_cache, name='dispatch')
-class PreviewView(APIView):
-    """Preview a project by starting a development server."""
+class BrowserPreviewBaseView(APIView):
+    """Shared plumbing for the browser-preview endpoints.
+
+    The preview runs a real headless Chromium next to the project's dev
+    servers on the backend host and tunnels frames/input through this API,
+    so it behaves identically in development and production.
+    """
     permission_classes = [IsAuthenticated]
 
     def get_project(self, project_id):
@@ -258,59 +266,112 @@ class PreviewView(APIView):
         except PMProject.DoesNotExist:
             raise NotFound('Project not found')
 
+    def get_service(self, project_id):
+        return BrowserPreviewService(self.get_project(project_id))
+
+    def handle_exception(self, exc):
+        # Session died (browser killed, container restarted): 409 tells the
+        # client to offer a restart rather than showing a hard failure.
+        if isinstance(exc, BrowserNotRunning):
+            return Response({'running': False, 'error': str(exc)},
+                            status=status.HTTP_409_CONFLICT)
+        if isinstance(exc, BrowserPreviewError):
+            return Response({'error': str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        return super().handle_exception(exc)
+
+
+class PreviewSessionView(BrowserPreviewBaseView):
+    """Start / query / stop a project's browser preview session."""
+
     def get(self, request, project_id):
-        # Preview spawns local Django + Vite dev servers; only viable when DEBUG is on.
-        if not settings.DEBUG:
-            return Response({
-                'success': False,
-                'error': 'Preview server is not available in production.'
-            }, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+        service = self.get_service(project_id)
+        if not service.is_running():
+            return Response({'running': False})
+        payload = service.frame()
+        payload['running'] = True
+        return Response(payload)
 
+    def post(self, request, project_id):
+        project = self.get_project(project_id)
+
+        # Materialize the working copy from the database if this
+        # environment doesn't have the project files on disk yet.
         try:
-            project = self.get_project(project_id)
+            from ..services.project_files_service import ensure_working_copy
+            ensure_working_copy(project)
+        except Exception as hydrate_err:
+            logger.warning(f"Could not ensure working copy before preview: {hydrate_err}")
 
-            # Materialize the working copy from the database if this
-            # environment doesn't have the project files on disk yet.
-            try:
-                from ..services.project_files_service import ensure_working_copy
-                ensure_working_copy(project)
-            except Exception as hydrate_err:
-                logger.warning(f"Could not ensure working copy before preview: {hydrate_err}")
-
-            preview_service = PreviewService(project)
-            result = preview_service.start_preview()
-
-            response_data = {
-                'success': result.get('success', False),
-                'preview_url': result.get('preview_url'),
-                'message': result.get('message', 'Preview server operation completed')
-            }
-
-            return Response(response_data)
-        except APIException:
-            raise
+        viewport = request.data.get('viewport') or {}
+        try:
+            service = BrowserPreviewService(project)
+            payload = service.start(
+                viewport=(viewport.get('width'), viewport.get('height')) if viewport else None,
+                device_scale_factor=request.data.get('device_scale_factor'),
+            )
+            payload['running'] = True
+            return Response(payload)
         except Exception as e:
-            logger.error(f"Error starting preview server: {str(e)}")
-            # Preview is a DEBUG-only feature, so the real reason is safe to
-            # surface and saves a trip to the server logs.
+            logger.exception("Error starting browser preview")
+            # The failure reason concerns the user's own project (npm install
+            # output, missing scaffold, ...) and is what they need to fix it.
             return Response({
-                'success': False,
-                'error': f'Preview server failed to start: {str(e)}'
+                'running': False,
+                'error': f'Preview failed to start: {str(e)}'
             }, status=status.HTTP_503_SERVICE_UNAVAILABLE)
-    
+
     def delete(self, request, project_id):
         try:
-            project = self.get_project(project_id)
-            
-            preview_service = PreviewService(project)
-            result = preview_service.stop_preview()
-            
+            service = self.get_service(project_id)
+            result = service.stop()
             return Response(result)
         except APIException:
             raise
         except Exception:
-            logger.exception("Error stopping preview server")
+            logger.exception("Error stopping preview")
             raise
+
+
+class PreviewFrameView(BrowserPreviewBaseView):
+    """Poll the latest screenshot; `etag` elides an unchanged frame."""
+
+    def get(self, request, project_id):
+        service = self.get_service(project_id)
+        return Response(service.frame(etag=request.query_params.get('etag')))
+
+
+class PreviewInputView(BrowserPreviewBaseView):
+    """Forward a batch of mouse/keyboard/wheel events to the page."""
+
+    def post(self, request, project_id):
+        service = self.get_service(project_id)
+        return Response(service.dispatch_input(
+            request.data.get('events') or [],
+            etag=request.data.get('etag'),
+        ))
+
+
+class PreviewNavigateView(BrowserPreviewBaseView):
+    """Navigate the page: goto (path within the app), back, forward, reload."""
+
+    def post(self, request, project_id):
+        service = self.get_service(project_id)
+        return Response(service.navigate(
+            request.data.get('action') or 'goto',
+            path=request.data.get('path'),
+        ))
+
+
+class PreviewResizeView(BrowserPreviewBaseView):
+    """Match the browser viewport to the client's preview pane size."""
+
+    def post(self, request, project_id):
+        service = self.get_service(project_id)
+        return Response(service.resize(
+            request.data.get('width'),
+            request.data.get('height'),
+            device_scale_factor=request.data.get('device_scale_factor'),
+        ))
 
 @method_decorator(never_cache, name='dispatch')
 class CreateFileView(APIView):

--- a/backend/django/apps/Imagi/Build/services/browser_preview_service.py
+++ b/backend/django/apps/Imagi/Build/services/browser_preview_service.py
@@ -1,0 +1,674 @@
+"""
+Headless-browser preview for generated projects.
+
+The old preview handed the user's browser a ``http://localhost:<port>`` URL,
+which only works when Imagi itself runs on the user's machine. This service
+instead runs a real Chromium instance *next to* the project's dev servers,
+inside whatever machine/container hosts the Django backend, and drives it
+over the Chrome DevTools Protocol (CDP). The workspace UI receives JPEG
+frames and sends input events through the normal authenticated API, so the
+exact same setup works in local development and on Railway.
+
+Process model (mirrors PreviewService's): Chromium is a plain subprocess
+tracked by PID/state files beside the project directory. All page state
+(current URL, history, session storage) lives in Chromium itself, so any
+Django worker can serve any request by opening a short-lived CDP connection —
+nothing is held in worker memory.
+"""
+
+import base64
+import glob
+import hashlib
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import time
+
+import psutil
+import requests
+from django.conf import settings
+from websocket import create_connection, WebSocketException
+
+from .preview_service import (
+    BROWSER_PROFILE_SUFFIX,
+    BROWSER_STATE_SUFFIX,
+    PreviewService,
+)
+
+logger = logging.getLogger(__name__)
+
+# Per-project files this service writes beside the dev-server PID files
+# (cleanup-relevant suffixes live in preview_service so its sweeps cover them).
+BROWSER_PID_SUFFIX = '_browser.pid'
+BROWSER_LOG_SUFFIX = '_browser.log'
+
+# Defaults until the client reports its pane size.
+DEFAULT_VIEWPORT = (1280, 800)
+MIN_VIEWPORT, MAX_VIEWPORT = 320, 3840
+MAX_EVENTS_PER_REQUEST = 64
+
+# How long to wait for the Vite dev server to answer HTTP before pointing
+# Chromium at it. Vite itself is up in a couple of seconds; the generous
+# ceiling covers first-run dependency optimization.
+FRONTEND_READY_TIMEOUT = 90
+
+# CDP modifier bitmask (Alt=1, Ctrl=2, Meta=4, Shift=8) — the client sends
+# the mask directly; we only clamp it.
+MODIFIER_MASK = 0xF
+
+_MOUSE_EVENT_TYPES = {'mousePressed', 'mouseReleased', 'mouseMoved'}
+_MOUSE_BUTTONS = {'none', 'left', 'middle', 'right', 'back', 'forward'}
+_KEY_EVENT_TYPES = {'keyDown', 'keyUp'}
+
+
+class BrowserPreviewError(Exception):
+    """Raised for user-reportable browser preview failures."""
+
+
+class BrowserNotRunning(BrowserPreviewError):
+    """The browser session is not (or no longer) running."""
+
+
+class CdpError(BrowserPreviewError):
+    """A DevTools command failed."""
+
+
+class CdpConnection:
+    """Minimal synchronous Chrome DevTools Protocol client for one target.
+
+    Chromium supports multiple simultaneous CDP clients, so short-lived
+    per-request connections are safe even when several Django workers talk
+    to the same page at once.
+    """
+
+    def __init__(self, ws_url, timeout=15):
+        # suppress_origin: Chromium rejects DevTools websocket upgrades that
+        # carry a non-localhost Origin header.
+        self._ws = create_connection(ws_url, timeout=timeout, suppress_origin=True)
+        self._next_id = 0
+
+    def call(self, method, params=None):
+        self._next_id += 1
+        msg_id = self._next_id
+        self._ws.send(json.dumps({'id': msg_id, 'method': method, 'params': params or {}}))
+        # Responses interleave with protocol events; skip events until our
+        # reply arrives (the socket timeout bounds the wait).
+        while True:
+            payload = json.loads(self._ws.recv())
+            if payload.get('id') == msg_id:
+                if 'error' in payload:
+                    err = payload['error']
+                    raise CdpError(f"{method}: {err.get('message', 'unknown CDP error')}")
+                return payload.get('result', {})
+
+    def close(self):
+        try:
+            self._ws.close()
+        except Exception:
+            pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+
+class BrowserPreviewService:
+    """Drives a per-project headless Chromium for the workspace preview."""
+
+    def __init__(self, project):
+        self.project = project
+        # Reuse the dev-server manager: it owns the project's Django + Vite
+        # subprocesses and the pid-file conventions we extend here.
+        self.servers = PreviewService(project)
+        self.pid_dir = self.servers.pid_dir
+
+        name = project.name
+        self.pid_file = os.path.join(self.pid_dir, f"{name}{BROWSER_PID_SUFFIX}")
+        self.log_file = os.path.join(self.pid_dir, f"{name}{BROWSER_LOG_SUFFIX}")
+        self.state_file = os.path.join(self.pid_dir, f"{name}{BROWSER_STATE_SUFFIX}")
+        self.profile_dir = os.path.join(self.pid_dir, f"{name}{BROWSER_PROFILE_SUFFIX}")
+
+    # ------------------------------------------------------------------
+    # Session lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self, viewport=None, device_scale_factor=None):
+        """Ensure dev servers + Chromium are running and showing the app.
+
+        Idempotent: an already-healthy session is reused, so the workspace
+        can call this on every mount without restarting anything.
+        """
+        reap_idle_sessions()
+
+        server_state = self.servers.ensure_preview()
+        # The dev servers report a localhost preview URL; dual-stack projects
+        # point it at Vite, legacy single-Django projects at runserver.
+        app_url = (server_state.get('preview_url') or '').replace('localhost', '127.0.0.1').rstrip('/')
+        if not app_url:
+            app_url = f"http://127.0.0.1:{self.servers.frontend_port}"
+        self._wait_for_frontend(app_url)
+
+        state = self._load_state()
+        if viewport:
+            width, height = self._clamp_viewport(*viewport)
+        elif state and state.get('viewport'):
+            width, height = self._clamp_viewport(*state['viewport'])
+        else:
+            width, height = DEFAULT_VIEWPORT
+        dsf = self._clamp_dsf(
+            device_scale_factor
+            or (state or {}).get('device_scale_factor')
+            or 1
+        )
+
+        fresh = not (state and self._browser_alive(state))
+        if fresh:
+            # Opening the app URL directly keeps about:blank out of the
+            # page's history, so "back" never leads outside the app.
+            state = self._launch_chromium(width, height, dsf, app_url + '/')
+        else:
+            state['viewport'] = [width, height]
+
+        state['app_url'] = app_url
+        state['last_active'] = time.time()
+        self._save_state(state)
+
+        with self._page_connection(state) as (conn, target):
+            self._apply_viewport(conn, state)
+            current = target.get('url') or ''
+            # A reused browser may sit on a network error page from before
+            # the dev servers were (re)started; bring it back to the app.
+            if not fresh and not current.startswith(app_url):
+                conn.call('Page.navigate', {'url': app_url + '/'})
+                time.sleep(0.3)  # let the first paint land in the frame below
+            status = self._status_payload(conn, state)
+            self._attach_frame(conn, status, None)
+
+        status['servers'] = server_state.get('message', '')
+        return status
+
+    def stop(self):
+        """Stop Chromium and the project's dev servers."""
+        self._kill_browser()
+        return self.servers.stop_preview()
+
+    def is_running(self):
+        state = self._load_state()
+        return bool(state and self._browser_alive(state))
+
+    # ------------------------------------------------------------------
+    # Interaction (each call opens a short-lived CDP connection)
+    # ------------------------------------------------------------------
+
+    def frame(self, etag=None):
+        """Return the current screenshot (unless it matches ``etag``) + nav state."""
+        state = self._require_state(touch=True)
+        with self._page_connection(state) as (conn, _target):
+            self._apply_viewport(conn, state)
+            payload = self._status_payload(conn, state)
+            self._attach_frame(conn, payload, etag)
+        return payload
+
+    def dispatch_input(self, events, etag=None):
+        """Forward a batch of mouse/keyboard/wheel events, then return a frame."""
+        if not isinstance(events, list) or len(events) > MAX_EVENTS_PER_REQUEST:
+            raise BrowserPreviewError('Invalid input event batch.')
+
+        state = self._require_state(touch=True)
+        width, height = state.get('viewport', DEFAULT_VIEWPORT)
+        with self._page_connection(state) as (conn, _target):
+            self._apply_viewport(conn, state)
+            for event in events:
+                method, params = self._translate_event(event, width, height)
+                conn.call(method, params)
+            payload = self._status_payload(conn, state)
+            self._attach_frame(conn, payload, etag)
+        return payload
+
+    def navigate(self, action, path=None):
+        """goto/back/forward/reload, then return a frame."""
+        state = self._require_state(touch=True)
+        app_url = state.get('app_url', '')
+        with self._page_connection(state) as (conn, _target):
+            self._apply_viewport(conn, state)
+            if action == 'goto':
+                # Only paths on the project's own frontend are addressable
+                # from the URL bar; the preview is not a general browser.
+                clean = self._normalize_path(path)
+                conn.call('Page.navigate', {'url': app_url + clean})
+            elif action in ('back', 'forward'):
+                history = conn.call('Page.getNavigationHistory')
+                index = history.get('currentIndex', 0) + (1 if action == 'forward' else -1)
+                entries = history.get('entries', [])
+                if 0 <= index < len(entries):
+                    conn.call('Page.navigateToHistoryEntry', {'entryId': entries[index]['id']})
+            elif action == 'reload':
+                conn.call('Page.reload', {'ignoreCache': False})
+            else:
+                raise BrowserPreviewError(f"Unknown navigation action: {action}")
+
+            # Give the navigation a beat to paint before the first frame.
+            time.sleep(0.15)
+            payload = self._status_payload(conn, state)
+            self._attach_frame(conn, payload, None)
+        return payload
+
+    def resize(self, width, height, device_scale_factor=None):
+        """Adopt the client pane's size (CSS pixels)."""
+        state = self._require_state(touch=True)
+        state['viewport'] = list(self._clamp_viewport(width, height))
+        if device_scale_factor:
+            state['device_scale_factor'] = self._clamp_dsf(device_scale_factor)
+        self._save_state(state)
+        with self._page_connection(state) as (conn, _target):
+            self._apply_viewport(conn, state)
+        return {'viewport': state['viewport']}
+
+    # ------------------------------------------------------------------
+    # Chromium process management
+    # ------------------------------------------------------------------
+
+    def _launch_chromium(self, width, height, dsf, initial_url='about:blank'):
+        executable = find_chromium()
+        if not executable:
+            raise BrowserPreviewError(
+                'No Chromium/Chrome executable found. Install Chromium or set '
+                'BROWSER_PREVIEW_EXECUTABLE to a browser binary.'
+            )
+
+        self._kill_browser(keep_profile=True)
+
+        cdp_port = self.servers._find_available_port_excluding(9300, 9400)
+        os.makedirs(self.profile_dir, exist_ok=True)
+
+        # --no-sandbox: the preview renders the user's own generated app, and
+        # that same code already runs unsandboxed in this container via the
+        # dev servers, so the browser sandbox (which cannot run as root in
+        # containers) adds no isolation here.
+        args = [
+            executable,
+            '--headless',
+            f'--remote-debugging-port={cdp_port}',
+            '--remote-debugging-address=127.0.0.1',
+            f'--user-data-dir={self.profile_dir}',
+            f'--window-size={width},{height}',
+            f'--force-device-scale-factor={dsf}',
+            '--no-first-run',
+            '--no-default-browser-check',
+            '--disable-dev-shm-usage',
+            '--disable-gpu',
+            '--disable-background-networking',
+            '--mute-audio',
+            '--no-sandbox',
+            initial_url,
+        ]
+
+        logger.info(f"Launching preview browser for {self.project.name} on CDP port {cdp_port}")
+        with open(self.log_file, 'w') as log_fh:
+            process = subprocess.Popen(args, stdout=log_fh, stderr=subprocess.STDOUT)
+
+        with open(self.pid_file, 'w') as f:
+            f.write(str(process.pid))
+
+        state = {
+            'cdp_port': cdp_port,
+            'pid': process.pid,
+            'viewport': [width, height],
+            'device_scale_factor': dsf,
+            'last_active': time.time(),
+        }
+
+        # Wait for the DevTools endpoint to accept connections.
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            if process.poll() is not None:
+                tail = self.servers._read_log_tail(self.log_file)
+                raise BrowserPreviewError(f"Browser exited on startup: {tail}")
+            try:
+                requests.get(f'http://127.0.0.1:{cdp_port}/json/version', timeout=2)
+                self._save_state(state)
+                return state
+            except requests.RequestException:
+                time.sleep(0.25)
+
+        raise BrowserPreviewError('Browser did not expose its DevTools endpoint in time.')
+
+    def _kill_browser(self, keep_profile=False):
+        self.servers._kill_from_pid_file(self.pid_file)
+        state = self._load_state()
+        if state and state.get('cdp_port'):
+            self.servers._kill_by_port(state['cdp_port'])
+        try:
+            os.remove(self.state_file)
+        except OSError:
+            pass
+        if not keep_profile:
+            shutil.rmtree(self.profile_dir, ignore_errors=True)
+
+    def _browser_alive(self, state):
+        pid, port = state.get('pid'), state.get('cdp_port')
+        if not pid or not port:
+            return False
+        try:
+            proc = psutil.Process(pid)
+            if not proc.is_running():
+                return False
+        except psutil.NoSuchProcess:
+            return False
+        try:
+            requests.get(f'http://127.0.0.1:{port}/json/version', timeout=2)
+        except requests.RequestException:
+            return False
+        return True
+
+    def _wait_for_frontend(self, app_url):
+        """Block until the Vite dev server answers HTTP."""
+        deadline = time.time() + FRONTEND_READY_TIMEOUT
+        last_error = None
+        while time.time() < deadline:
+            try:
+                requests.get(app_url + '/', timeout=3)
+                return
+            except requests.RequestException as e:
+                last_error = e
+                time.sleep(0.5)
+        raise BrowserPreviewError(
+            f"The project's dev server did not become reachable: {last_error}"
+        )
+
+    # ------------------------------------------------------------------
+    # CDP helpers
+    # ------------------------------------------------------------------
+
+    def _page_connection(self, state):
+        """Context manager yielding (CdpConnection, target-info) for the app page."""
+        port = state['cdp_port']
+        try:
+            targets = requests.get(f'http://127.0.0.1:{port}/json/list', timeout=5).json()
+        except (requests.RequestException, ValueError) as e:
+            raise BrowserNotRunning(f'Browser session is not reachable: {e}')
+
+        page = next(
+            (t for t in targets
+             if t.get('type') == 'page' and not t.get('url', '').startswith('devtools://')),
+            None,
+        )
+        if not page:
+            # All tabs closed (e.g. the page crashed) — open a fresh one.
+            try:
+                page = requests.put(
+                    f'http://127.0.0.1:{port}/json/new?{state.get("app_url", "about:blank")}',
+                    timeout=5,
+                ).json()
+            except (requests.RequestException, ValueError) as e:
+                raise BrowserNotRunning(f'Could not open a browser tab: {e}')
+
+        class _Ctx:
+            def __enter__(ctx):
+                try:
+                    ctx.conn = CdpConnection(page['webSocketDebuggerUrl'])
+                except (WebSocketException, OSError, KeyError) as e:
+                    raise BrowserNotRunning(f'Could not attach to browser page: {e}')
+                return ctx.conn, page
+
+            def __exit__(ctx, *exc):
+                ctx.conn.close()
+
+        return _Ctx()
+
+    def _apply_viewport(self, conn, state):
+        # Emulation overrides can be tied to a DevTools session, and our
+        # connections are per-request — re-applying is cheap and idempotent.
+        width, height = state.get('viewport', DEFAULT_VIEWPORT)
+        conn.call('Emulation.setDeviceMetricsOverride', {
+            'width': int(width),
+            'height': int(height),
+            'deviceScaleFactor': float(state.get('device_scale_factor', 1)),
+            'mobile': False,
+        })
+
+    def _attach_frame(self, conn, payload, etag):
+        shot = conn.call('Page.captureScreenshot', {'format': 'jpeg', 'quality': 70})
+        data = shot.get('data', '')
+        digest = hashlib.sha1(base64.b64decode(data)).hexdigest() if data else ''
+        payload['etag'] = digest
+        if etag and etag == digest:
+            payload['frame'] = None  # unchanged since the client's last frame
+        else:
+            payload['frame'] = data
+
+    def _status_payload(self, conn, state):
+        history = conn.call('Page.getNavigationHistory')
+        entries = history.get('entries', [])
+        index = history.get('currentIndex', 0)
+        current = entries[index] if 0 <= index < len(entries) else {}
+        url = current.get('url', '')
+        return {
+            'path': self._display_path(url, state.get('app_url', '')),
+            'title': current.get('title', ''),
+            'can_go_back': index > 0,
+            'can_go_forward': index < len(entries) - 1,
+            'viewport': state.get('viewport', list(DEFAULT_VIEWPORT)),
+            'device_scale_factor': state.get('device_scale_factor', 1),
+        }
+
+    def _translate_event(self, event, width, height):
+        """Validate one client input event and map it onto a CDP command."""
+        if not isinstance(event, dict):
+            raise BrowserPreviewError('Malformed input event.')
+        kind = event.get('kind')
+        modifiers = int(event.get('modifiers') or 0) & MODIFIER_MASK
+
+        if kind == 'mouse':
+            etype = event.get('type')
+            if etype not in _MOUSE_EVENT_TYPES:
+                raise BrowserPreviewError(f'Unsupported mouse event: {etype}')
+            button = event.get('button', 'none')
+            if button not in _MOUSE_BUTTONS:
+                button = 'none'
+            return 'Input.dispatchMouseEvent', {
+                'type': etype,
+                'x': max(0, min(float(event.get('x') or 0), width)),
+                'y': max(0, min(float(event.get('y') or 0), height)),
+                'button': button,
+                'buttons': int(event.get('buttons') or 0),
+                'clickCount': max(0, min(int(event.get('clickCount') or 0), 3)),
+                'modifiers': modifiers,
+            }
+
+        if kind == 'wheel':
+            return 'Input.dispatchMouseEvent', {
+                'type': 'mouseWheel',
+                'x': max(0, min(float(event.get('x') or 0), width)),
+                'y': max(0, min(float(event.get('y') or 0), height)),
+                'deltaX': float(event.get('deltaX') or 0),
+                'deltaY': float(event.get('deltaY') or 0),
+                'modifiers': modifiers,
+            }
+
+        if kind == 'key':
+            etype = event.get('type')
+            if etype not in _KEY_EVENT_TYPES:
+                raise BrowserPreviewError(f'Unsupported key event: {etype}')
+            text = event.get('text') or ''
+            params = {
+                # keyDown without text produces no character input; CDP calls
+                # that variant rawKeyDown (this mirrors what Puppeteer sends).
+                'type': etype if etype == 'keyUp' else ('keyDown' if text else 'rawKeyDown'),
+                'key': str(event.get('key') or '')[:32],
+                'code': str(event.get('code') or '')[:32],
+                'modifiers': modifiers,
+                'windowsVirtualKeyCode': int(event.get('keyCode') or 0),
+                'nativeVirtualKeyCode': int(event.get('keyCode') or 0),
+            }
+            if text and etype == 'keyDown':
+                params['text'] = text[:8]
+            return 'Input.dispatchKeyEvent', params
+
+        raise BrowserPreviewError(f'Unsupported input kind: {kind}')
+
+    # ------------------------------------------------------------------
+    # State files
+    # ------------------------------------------------------------------
+
+    def _require_state(self, touch=False):
+        state = self._load_state()
+        if not state or not self._browser_alive(state):
+            raise BrowserNotRunning('The preview browser is not running.')
+        if touch:
+            # last_active drives idle reaping; throttle rewrites to one per 30s.
+            now = time.time()
+            if now - state.get('last_active', 0) > 30:
+                state['last_active'] = now
+                self._save_state(state)
+        return state
+
+    def _load_state(self):
+        try:
+            with open(self.state_file, 'r') as f:
+                state = json.load(f)
+        except (OSError, ValueError):
+            return None
+        return state if isinstance(state, dict) else None
+
+    def _save_state(self, state):
+        try:
+            with open(self.state_file, 'w') as f:
+                json.dump(state, f)
+        except OSError as e:
+            logger.warning(f"Could not save browser preview state: {e}")
+
+    # ------------------------------------------------------------------
+    # Validation helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _clamp_viewport(width, height):
+        try:
+            width, height = int(width), int(height)
+        except (TypeError, ValueError):
+            return DEFAULT_VIEWPORT
+        return (
+            max(MIN_VIEWPORT, min(width, MAX_VIEWPORT)),
+            max(MIN_VIEWPORT, min(height, MAX_VIEWPORT)),
+        )
+
+    @staticmethod
+    def _clamp_dsf(value):
+        try:
+            return max(1.0, min(float(value), 3.0))
+        except (TypeError, ValueError):
+            return 1.0
+
+    @staticmethod
+    def _normalize_path(path):
+        clean = (path or '/').strip()
+        if not clean.startswith('/'):
+            clean = '/' + clean
+        # Reject anything that could escape onto another origin
+        # (protocol-relative //host, backslash tricks, embedded schemes).
+        if clean.startswith('//') or '\\' in clean or '://' in clean:
+            raise BrowserPreviewError('Only paths within the project can be opened.')
+        return clean
+
+    @staticmethod
+    def _display_path(url, app_url):
+        """Map the internal dev-server URL to the path shown in the UI."""
+        if app_url and url.startswith(app_url):
+            return url[len(app_url):] or '/'
+        if not url or url == 'about:blank':
+            return '/'
+        return url  # off-origin (page-initiated) navigation: show it verbatim
+
+
+def find_chromium():
+    """Locate a Chromium/Chrome binary, preferring explicit configuration."""
+    configured = getattr(settings, 'BROWSER_PREVIEW_EXECUTABLE', '') or ''
+    if configured:
+        return configured if os.path.exists(configured) else shutil.which(configured)
+
+    for name in ('chromium', 'chromium-browser', 'google-chrome-stable', 'google-chrome'):
+        found = shutil.which(name)
+        if found:
+            return found
+
+    mac_paths = (
+        '/Applications/Chromium.app/Contents/MacOS/Chromium',
+        '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    )
+    for path in mac_paths:
+        if os.path.exists(path):
+            return path
+
+    # Playwright-managed browsers (present in some dev/CI environments).
+    browsers_root = os.environ.get('PLAYWRIGHT_BROWSERS_PATH')
+    if browsers_root:
+        pattern = 'chrome.exe' if sys.platform == 'win32' else 'chrome'
+        for candidate in sorted(glob.glob(os.path.join(browsers_root, 'chromium-*', '*', pattern)), reverse=True):
+            if os.access(candidate, os.X_OK):
+                return candidate
+
+    return None
+
+
+def reap_idle_sessions():
+    """Shut down preview sessions (browser + dev servers) idle past the limit.
+
+    Runs opportunistically when any preview starts. Works purely from the
+    per-project files on disk so it needs no database access and covers
+    every user's projects.
+    """
+    timeout = getattr(settings, 'BROWSER_PREVIEW_IDLE_TIMEOUT', 1800)
+    if not timeout:
+        return
+
+    root = getattr(settings, 'PROJECTS_ROOT', None)
+    if not root or not os.path.isdir(root):
+        return
+
+    now = time.time()
+    for state_file in glob.glob(os.path.join(root, '*', f'*{BROWSER_STATE_SUFFIX}')):
+        try:
+            with open(state_file, 'r') as f:
+                state = json.load(f)
+            if not isinstance(state, dict):
+                continue
+            if now - state.get('last_active', 0) < timeout:
+                continue
+
+            prefix = state_file[:-len(BROWSER_STATE_SUFFIX)]
+            logger.info(f"Reaping idle preview session: {os.path.basename(prefix)}")
+            # Browser first, then the dev servers recorded by PreviewService.
+            _kill_pid_file(prefix + BROWSER_PID_SUFFIX)
+            _kill_pid_file(prefix + '_frontend.pid')
+            _kill_pid_file(prefix + '_backend.pid')
+            for leftover in (state_file, prefix + '_preview_ports.json'):
+                try:
+                    os.remove(leftover)
+                except OSError:
+                    pass
+            shutil.rmtree(prefix + BROWSER_PROFILE_SUFFIX, ignore_errors=True)
+        except Exception as e:
+            logger.warning(f"Could not reap preview session {state_file}: {e}")
+
+
+def _kill_pid_file(pid_file):
+    if not os.path.exists(pid_file):
+        return
+    try:
+        with open(pid_file, 'r') as f:
+            pid = int(f.read().strip())
+        process = psutil.Process(pid)
+        for proc in process.children(recursive=True) + [process]:
+            PreviewService._stop_process(proc)
+    except (OSError, ValueError, psutil.NoSuchProcess, psutil.AccessDenied):
+        pass
+    try:
+        os.remove(pid_file)
+    except OSError:
+        pass

--- a/backend/django/apps/Imagi/Build/services/pages_service.py
+++ b/backend/django/apps/Imagi/Build/services/pages_service.py
@@ -1,0 +1,128 @@
+"""
+Derive the navigable pages of a generated project from its Vue routers.
+
+The workspace preview shows an app/page menu. It used to guess route paths
+from view-component filenames, which breaks as soon as a router maps a view
+somewhere unconventional. This service reads each app's actual
+``router/index.ts`` from the project's working copy instead, so the menu
+always reflects the routes the running app really serves.
+
+The router files are TypeScript, but the generated (and agent-edited) ones
+are formulaic enough that a small brace-depth scanner recovers the route
+tree without a real parser: ``path:`` entries nested more deeply than a
+previous entry are children and get joined onto their parent's path, exactly
+as vue-router does.
+"""
+
+import logging
+import os
+import re
+
+logger = logging.getLogger(__name__)
+
+APPS_SUBDIR = os.path.join('frontend', 'vuejs', 'src', 'apps')
+
+_TOKEN_RE = re.compile(
+    r"(?P<open>\{)"
+    r"|(?P<close>\})"
+    r"|path:\s*(?P<pq>['\"])(?P<path>[^'\"]*)(?P=pq)"
+    r"|component:\s*(?P<component>[^,\n}]+)"
+)
+_IMPORT_RE = re.compile(r"import\s+(\w+)\s+from\s+['\"]([^'\"]+)['\"]")
+
+
+def list_app_pages(project):
+    """Return [{name, title, pages: [{title, path}]}] for every app with routes."""
+    apps_root = os.path.join(project.project_path or '', APPS_SUBDIR)
+    if not os.path.isdir(apps_root):
+        return []
+
+    apps = []
+    for app_name in sorted(os.listdir(apps_root)):
+        router_file = os.path.join(apps_root, app_name, 'router', 'index.ts')
+        if not os.path.isfile(router_file):
+            continue
+        try:
+            with open(router_file, 'r', encoding='utf-8') as f:
+                source = f.read()
+            pages = _parse_router(source)
+        except Exception as e:
+            logger.warning(f"Could not parse router for app '{app_name}': {e}")
+            continue
+        if pages:
+            apps.append({
+                'name': app_name,
+                'title': _humanize(app_name),
+                'pages': pages,
+            })
+    return apps
+
+
+def _parse_router(source):
+    """Extract concrete leaf routes (path + display title) from router source."""
+    imports = dict(_IMPORT_RE.findall(source))
+
+    depth = 0
+    stack = []   # [(depth, full_path)] of enclosing route entries
+    entries = []  # [{'path': ..., 'component': None|str}] in document order
+
+    for token in _TOKEN_RE.finditer(source):
+        if token.group('open'):
+            depth += 1
+        elif token.group('close'):
+            depth -= 1
+        elif token.group('path') is not None:
+            while stack and stack[-1][0] >= depth:
+                stack.pop()
+            parent = stack[-1][1] if stack else ''
+            full = _join_paths(parent, token.group('path'))
+            stack.append((depth, full))
+            entries.append({'path': full, 'component': None})
+        elif token.group('component') and entries and entries[-1]['component'] is None:
+            entries[-1]['component'] = token.group('component').strip()
+
+    pages = []
+    seen = set()
+    for entry in entries:
+        path = entry['path']
+        component = entry['component'] or ''
+        # Only routes that render a view are navigable pages: this skips
+        # layout-only parents (whose component lives outside views/) and
+        # grouping entries with no component at all.
+        source_ref = imports.get(component, component)
+        if 'views/' not in source_ref.replace('\\', '/'):
+            continue
+        # Dynamic segments and catch-alls aren't directly addressable.
+        if ':' in path or '*' in path:
+            continue
+        # Stripe return pages (from the Sell payment templates) only make
+        # sense mid-checkout; don't offer them as navigable pages.
+        if 'CheckoutReturn' in source_ref:
+            continue
+        if path in seen:
+            continue
+        seen.add(path)
+        pages.append({'title': _page_title(path), 'path': path})
+    return pages
+
+
+def _join_paths(parent, child):
+    """Join a nested route path onto its parent the way vue-router does."""
+    if child.startswith('/'):
+        return child or '/'
+    if not child:
+        return parent or '/'
+    return (parent.rstrip('/') or '') + '/' + child
+
+
+def _page_title(path):
+    segment = path.rstrip('/').rsplit('/', 1)[-1]
+    if not segment:
+        return 'Home'
+    return _humanize(segment)
+
+
+def _humanize(value):
+    spaced = re.sub(r'([a-z0-9])([A-Z])', r'\1 \2', value)
+    spaced = re.sub(r'[-_]+', ' ', spaced).strip()
+    return ' '.join(word.capitalize() for word in spaced.split())

--- a/backend/django/apps/Imagi/Build/services/preview_service.py
+++ b/backend/django/apps/Imagi/Build/services/preview_service.py
@@ -2,6 +2,7 @@
 Service for project preview operations in the Builder app.
 """
 
+import contextlib
 import subprocess
 import os
 import sys
@@ -17,12 +18,61 @@ logger = logging.getLogger(__name__)
 # npm install for a freshly scaffolded frontend can legitimately take minutes
 NPM_INSTALL_TIMEOUT = 600
 
+# Lock directory created inside a generated frontend while npm install runs
+# there, so concurrent installers (the background install kicked off at
+# project creation and a preview start that finds node_modules missing)
+# serialize instead of corrupting node_modules under each other.
+NPM_INSTALL_LOCK_DIRNAME = '.imagi_npm_install.lock'
+
+
+@contextlib.contextmanager
+def npm_install_lock(frontend_path, timeout=NPM_INSTALL_TIMEOUT):
+    """Serialize npm installs for one frontend across processes and threads.
+
+    Uses an atomic mkdir as the lock. Locks whose directory looks older than
+    a full install could take are treated as leftovers from a crashed
+    installer and stolen. If the lock cannot be acquired within ``timeout``,
+    we proceed anyway — attempting the install beats failing outright.
+    """
+    lock_dir = os.path.join(frontend_path, NPM_INSTALL_LOCK_DIRNAME)
+    deadline = time.time() + timeout
+    acquired = False
+    while time.time() < deadline:
+        try:
+            os.mkdir(lock_dir)
+            acquired = True
+            break
+        except FileExistsError:
+            try:
+                if time.time() - os.path.getmtime(lock_dir) > timeout + 300:
+                    os.rmdir(lock_dir)
+                    continue
+            except OSError:
+                pass
+            time.sleep(1)
+        except OSError:
+            break
+    if not acquired:
+        logger.warning(f"Proceeding without npm install lock for {frontend_path}")
+    try:
+        yield
+    finally:
+        if acquired:
+            try:
+                os.rmdir(lock_dir)
+            except OSError:
+                pass
+
 # The per-project files this service keeps beside the project directory, by
 # filename suffix. They are named after project.name, not the timestamped
-# directory, so deleting the directory does not remove them.
-PID_SUFFIXES = ('_frontend.pid', '_backend.pid', '_server.pid')  # _server.pid predates dual-stack
-LOG_SUFFIXES = ('_frontend.log', '_backend.log')
+# directory, so deleting the directory does not remove them. The _browser.*
+# files belong to BrowserPreviewService (which imports these constants);
+# they are listed here so cleanup sweeps the whole preview session.
+PID_SUFFIXES = ('_frontend.pid', '_backend.pid', '_server.pid', '_browser.pid')  # _server.pid predates dual-stack
+LOG_SUFFIXES = ('_frontend.log', '_backend.log', '_browser.log')
 PORTS_SUFFIX = '_preview_ports.json'
+BROWSER_STATE_SUFFIX = '_browser.json'
+BROWSER_PROFILE_SUFFIX = '_browser_profile'
 
 
 class PreviewService:
@@ -46,6 +96,32 @@ class PreviewService:
         # draining would freeze the servers once the pipe buffer fills.
         self.frontend_log_file = os.path.join(self.pid_dir, f"{project.name}_frontend.log")
         self.backend_log_file = os.path.join(self.pid_dir, f"{project.name}_backend.log")
+
+    def ensure_preview(self):
+        """Start the dev servers only if a healthy preview is not already up.
+
+        start_preview() always tears down and relaunches; this variant lets
+        callers (the browser preview, a workspace re-mount) reattach to a
+        running session instead of paying the restart cost.
+        """
+        state = self._load_port_state()
+        if state:
+            backend_port = state.get('backend_port')
+            frontend_port = state.get('frontend_port')
+            backend_ok = bool(backend_port) and self._port_in_use(backend_port)
+            # Legacy single-Django projects have no frontend server.
+            frontend_ok = not frontend_port or self._port_in_use(frontend_port)
+            if backend_ok and frontend_ok:
+                self.backend_port = backend_port
+                if frontend_port:
+                    self.frontend_port = frontend_port
+                port = frontend_port or backend_port
+                return {
+                    'success': True,
+                    'preview_url': f"http://localhost:{port}",
+                    'message': 'Development servers already running',
+                }
+        return self.start_preview()
 
     def start_preview(self):
         """Start both frontend and backend development servers."""
@@ -254,7 +330,10 @@ class PreviewService:
             # Start Vite development server
             with open(self.frontend_log_file, 'w') as log_fh:
                 process = subprocess.Popen(
-                    [npm, 'run', 'dev', '--', '--port', str(self.frontend_port), '--host'],
+                    # Bind to loopback only: the preview is consumed by the
+                    # headless browser running on this same host, never
+                    # directly by the user's machine.
+                    [npm, 'run', 'dev', '--', '--port', str(self.frontend_port), '--host', '127.0.0.1'],
                     cwd=frontend_path,
                     stdout=log_fh,
                     stderr=subprocess.STDOUT,
@@ -291,18 +370,26 @@ class PreviewService:
         the preview cannot start without dependencies, and the caller reports
         progress/failure to the user.
         """
-        if os.path.isdir(os.path.join(frontend_path, 'node_modules')):
+        node_modules = os.path.join(frontend_path, 'node_modules')
+        installing = os.path.isdir(os.path.join(frontend_path, NPM_INSTALL_LOCK_DIRNAME))
+        # An existing node_modules is only trustworthy when no install is in
+        # flight; otherwise fall through and wait on the lock.
+        if os.path.isdir(node_modules) and not installing:
             return None
 
-        logger.info(f"node_modules missing - running npm install in {frontend_path}")
+        logger.info(f"node_modules missing or being installed - ensuring npm install in {frontend_path}")
         try:
-            result = subprocess.run(
-                [npm, 'install'],
-                cwd=frontend_path,
-                capture_output=True,
-                text=True,
-                timeout=NPM_INSTALL_TIMEOUT,
-            )
+            with npm_install_lock(frontend_path):
+                # Even if the install we waited on finished, run npm install
+                # ourselves: it is a fast no-op on a complete node_modules and
+                # repairs a partial one left by a failed/killed installer.
+                result = subprocess.run(
+                    [npm, 'install'],
+                    cwd=frontend_path,
+                    capture_output=True,
+                    text=True,
+                    timeout=NPM_INSTALL_TIMEOUT,
+                )
         except subprocess.TimeoutExpired:
             return f"npm install timed out after {NPM_INSTALL_TIMEOUT} seconds"
 
@@ -508,7 +595,7 @@ class PreviewService:
                 except Exception as e:
                     logger.warning(f"Error stopping process from {name}{suffix}: {e}")
 
-            for suffix in LOG_SUFFIXES + (PORTS_SUFFIX,):
+            for suffix in LOG_SUFFIXES + (PORTS_SUFFIX, BROWSER_STATE_SUFFIX):
                 path = os.path.join(self.pid_dir, f"{name}{suffix}")
                 if not os.path.exists(path):
                     continue
@@ -517,6 +604,8 @@ class PreviewService:
                     logger.info(f"Deleted project file: {path}")
                 except OSError as e:
                     logger.warning(f"Failed to delete project file {path}: {e}")
+
+            shutil.rmtree(os.path.join(self.pid_dir, f"{name}{BROWSER_PROFILE_SUFFIX}"), ignore_errors=True)
 
     def _stop_vuejs_frontend(self, port=None):
         """Stop VueJS frontend server."""

--- a/backend/django/apps/Imagi/ProjectManager/services/project_creation_service.py
+++ b/backend/django/apps/Imagi/ProjectManager/services/project_creation_service.py
@@ -204,12 +204,16 @@ class ProjectCreationService:
         def install_dependencies_background():
             try:
                 logger.info(f"Background: Installing npm dependencies in: {frontend_path}")
-                
-                # Run npm install in the frontend directory
-                result = subprocess.run([
-                    'npm', 'install'
-                ], cwd=frontend_path, check=True, capture_output=True, text=True)
-                
+
+                # Serialize with any preview start that also finds
+                # node_modules missing — concurrent npm installs corrupt
+                # each other's node_modules.
+                from apps.Imagi.Build.services.preview_service import npm_install_lock
+                with npm_install_lock(frontend_path):
+                    result = subprocess.run([
+                        'npm', 'install'
+                    ], cwd=frontend_path, check=True, capture_output=True, text=True)
+
                 logger.info(f"Background: npm install completed successfully in {frontend_path}")
                 logger.debug(f"Background: npm install output: {result.stdout}")
                 

--- a/backend/django/imagi/settings.py
+++ b/backend/django/imagi/settings.py
@@ -272,6 +272,17 @@ _DEFAULT_PROJECTS_ROOT = (
 )
 PROJECTS_ROOT = os.environ.get('PROJECTS_ROOT', _DEFAULT_PROJECTS_ROOT)
 
+# Build workspace browser preview. A headless Chromium runs on this host next
+# to each previewed project's dev servers; the workspace streams frames and
+# forwards input through the API, so the setup is identical in development
+# and production (the Docker image installs Chromium and sets the path).
+# When empty, common Chrome/Chromium install locations are searched.
+BROWSER_PREVIEW_EXECUTABLE = os.environ.get('BROWSER_PREVIEW_EXECUTABLE', '')
+
+# Preview sessions (browser + dev servers) idle longer than this many seconds
+# are shut down opportunistically when another preview starts. 0 disables.
+BROWSER_PREVIEW_IDLE_TIMEOUT = int(os.environ.get('BROWSER_PREVIEW_IDLE_TIMEOUT', '1800'))
+
 
 # Marketing / Twilio
 # Public base URL Twilio uses for webhooks (delivery status callbacks and

--- a/frontend/vuejs/env.d.ts
+++ b/frontend/vuejs/env.d.ts
@@ -2,6 +2,7 @@
 
 declare module '*.vue' {
   import type { DefineComponent } from 'vue'
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
   const component: DefineComponent<{}, {}, any>
   export default component
 }

--- a/frontend/vuejs/eslint.config.ts
+++ b/frontend/vuejs/eslint.config.ts
@@ -1,0 +1,39 @@
+import { globalIgnores } from 'eslint/config'
+import { defineConfigWithVueTs, vueTsConfigs } from '@vue/eslint-config-typescript'
+import pluginVue from 'eslint-plugin-vue'
+import pluginOxlint from 'eslint-plugin-oxlint'
+import skipFormatting from 'eslint-config-prettier'
+
+export default defineConfigWithVueTs(
+  {
+    name: 'app/files-to-lint',
+    files: ['**/*.{ts,mts,tsx,vue}'],
+  },
+
+  globalIgnores(['**/dist/**', '**/dist-ssr/**', '**/coverage/**', '**/node_modules/**']),
+
+  pluginVue.configs['flat/essential'],
+  vueTsConfigs.recommended,
+
+  // Rules covered by oxlint (which runs first in `npm run lint`) are
+  // disabled here so the two linters don't double-report.
+  ...pluginOxlint.configs['flat/recommended'],
+  skipFormatting,
+
+  {
+    name: 'app/rule-overrides',
+    rules: {
+      // `any` is used deliberately at API boundaries throughout this codebase.
+      '@typescript-eslint/no-explicit-any': 'off',
+      // Multi-word names are a convention we don't follow for view components
+      // (e.g. Login.vue, Register.vue routed views).
+      'vue/multi-word-component-names': 'off',
+      // Many older components still use plain <script>; don't force a mass
+      // TypeScript conversion.
+      'vue/block-lang': ['error', { script: { lang: 'ts', allowNoLang: true } }],
+      // Existing debt: surfaced without failing the build. New unused vars
+      // still show up in lint output.
+      '@typescript-eslint/no-unused-vars': 'warn',
+    },
+  },
+)

--- a/frontend/vuejs/src/apps/auth/views/Login.vue
+++ b/frontend/vuejs/src/apps/auth/views/Login.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="space-y-6">
-    <Form v-slot="{ errors: formErrors, submitCount, submitForm, values }" class="space-y-5" @submit="onSubmit">
+    <Form v-slot="{ submitCount }" class="space-y-5" @submit="onSubmit">
       <!-- Username input with premium styling -->
       <div class="relative group">
         <Field name="username" rules="login_username" :validateOnBlur="false" v-slot="{ errorMessage, field }">

--- a/frontend/vuejs/src/apps/auth/views/Register.vue
+++ b/frontend/vuejs/src/apps/auth/views/Register.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="space-y-6">
-    <Form v-slot="{ errors: formErrors, submitCount: formSubmitCount }" class="space-y-5" @submit="handleSubmit">
+    <Form v-slot="{ submitCount: formSubmitCount }" class="space-y-5" @submit="handleSubmit">
       <!-- Username input with premium styling -->
       <div class="relative group">
         <Field name="username" rules="required|username" :validateOnBlur="false" v-slot="{ errorMessage, field }">

--- a/frontend/vuejs/src/apps/home/components/organisms/navigation/HomeNavbar.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/navigation/HomeNavbar.vue
@@ -87,7 +87,6 @@ import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/shared/stores/auth'
 import { useAuth } from '@/apps/auth'
 import BaseNavbar from '@/shared/components/organisms/navigation/BaseNavbar.vue'
-import IconButton from '@/apps/home/components/atoms/buttons/IconButton.vue'
 import HomeNavbarButton from '@/apps/home/components/atoms/buttons/HomeNavbarButton.vue'
 import HomeNavbarDropdownButton from '@/apps/home/components/atoms/buttons/HomeNavbarDropdownButton.vue'
 
@@ -95,7 +94,6 @@ export default defineComponent({
   name: 'HomeNavbar',
   components: {
     BaseNavbar,
-    IconButton,
     HomeNavbarButton,
     HomeNavbarDropdownButton
   },

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/chat/ChatMessagesList.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/chat/ChatMessagesList.vue
@@ -10,7 +10,7 @@
   <div ref="messagesContainer" class="chat-messages">
     <TransitionGroup name="message-fade">
       <div
-        v-for="(message, index) in messages"
+        v-for="message in messages"
         :key="message.timestamp"
         class="message-block"
         :class="message.role === 'user' ? 'message-user' : 'message-assistant'"

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
@@ -210,7 +210,7 @@ function ensureValidMessages(messages: any[]): AIMessage[] {
   const validMessages = filteredMessages
     .filter(m => m && typeof m === 'object' && m.role)
     .map(m => {
-      let content = m.content || ''
+      const content = m.content || ''
       const messageId = m.id || `msg-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`
       
       return {

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspacePreview.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspacePreview.vue
@@ -1,130 +1,191 @@
 <template>
   <div class="relative w-full h-full flex flex-col bg-white dark:bg-[#0a0a0a]">
-    <!-- Loading state -->
-    <div
-      v-if="isLoading"
-      class="flex-1 flex flex-col items-center justify-center gap-3 text-blue-950/60 dark:text-white/60"
-    >
-      <i class="fas fa-spinner fa-spin text-2xl"></i>
-      <span class="text-sm font-medium">Starting preview server…</span>
-    </div>
+    <!-- Toolbar -->
+    <div class="flex flex-col gap-2 px-3 py-2 border-b border-blue-200/60 dark:border-white/[0.08] bg-blue-50/50 dark:bg-white/[0.02]">
+      <div class="flex items-center gap-2 flex-wrap">
+        <button
+          type="button"
+          @click="goBack"
+          :disabled="!canGoBack || phase !== 'ready'"
+          title="Back"
+          class="inline-flex items-center justify-center w-9 h-9 shrink-0 rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-blue-950/70 dark:text-white/70 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          <i class="fas fa-arrow-left text-sm"></i>
+        </button>
 
-    <!-- Error state -->
-    <div
-      v-else-if="error"
-      class="flex-1 flex flex-col items-center justify-center gap-4 px-8 text-center"
-    >
-      <div class="w-12 h-12 bg-red-50 dark:bg-red-900/10 border border-red-200 dark:border-red-800/30 rounded-xl flex items-center justify-center">
-        <i class="fas fa-exclamation-triangle text-red-600 dark:text-red-400"></i>
-      </div>
-      <p class="text-sm text-blue-950/70 dark:text-white/70 max-w-md">{{ error }}</p>
-      <button
-        @click="loadPreview"
-        class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-sm font-medium text-blue-950/70 dark:text-white/70 transition-colors"
-      >
-        <i class="fas fa-sync-alt text-xs"></i>
-        Retry
-      </button>
-    </div>
+        <button
+          type="button"
+          @click="goForward"
+          :disabled="!canGoForward || phase !== 'ready'"
+          title="Forward"
+          class="inline-flex items-center justify-center w-9 h-9 shrink-0 rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-blue-950/70 dark:text-white/70 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          <i class="fas fa-arrow-right text-sm"></i>
+        </button>
 
-    <!-- Ready state: app + page selectors + iframe -->
-    <template v-else-if="previewUrl">
-      <div class="flex flex-col gap-2 px-3 py-2 border-b border-blue-200/60 dark:border-white/[0.08] bg-blue-50/50 dark:bg-white/[0.02]">
-        <div class="flex items-center gap-2 flex-wrap">
+        <button
+          type="button"
+          @click="reload"
+          title="Refresh page"
+          class="inline-flex items-center justify-center w-9 h-9 shrink-0 rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-blue-950/70 dark:text-white/70 transition-colors"
+        >
+          <i class="fas fa-sync-alt text-sm" :class="{ 'fa-spin': phase === 'starting' }"></i>
+        </button>
+
+        <button
+          type="button"
+          @click="goHome"
+          title="Go to home page"
+          class="inline-flex items-center justify-center w-9 h-9 shrink-0 rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-blue-950/70 dark:text-white/70 transition-colors"
+        >
+          <i class="fas fa-home text-sm"></i>
+        </button>
+
+        <!-- Combined App / Page selector -->
+        <div class="relative flex-1 min-w-[12rem]" ref="menuRoot">
           <button
             type="button"
-            @click="reload"
-            title="Refresh page"
-            class="inline-flex items-center justify-center w-9 h-9 shrink-0 rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-blue-950/70 dark:text-white/70 transition-colors"
+            @click="menuOpen = !menuOpen"
+            :disabled="apps.length === 0"
+            class="w-full flex items-center gap-2 rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] focus:border-blue-400 dark:focus:border-blue-300/40 outline-none py-2 pl-3 pr-9 text-sm font-medium text-blue-950 dark:text-white/90 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            <i class="fas fa-sync-alt text-sm"></i>
+            <i class="fas fa-cube text-xs text-blue-950/50 dark:text-white/50 shrink-0"></i>
+            <span class="truncate flex-1 text-left">{{ triggerLabel }}</span>
+            <span class="truncate max-w-[10rem] text-xs text-blue-950/40 dark:text-white/40 font-normal hidden sm:block">{{ currentPath }}</span>
+            <i class="fas fa-chevron-down absolute right-3 top-1/2 -translate-y-1/2 text-xs text-blue-950/50 dark:text-white/40 pointer-events-none"></i>
           </button>
 
-          <button
-            type="button"
-            @click="goHome"
-            title="Go to home page"
-            class="inline-flex items-center justify-center w-9 h-9 shrink-0 rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-blue-950/70 dark:text-white/70 transition-colors"
+          <div
+            v-if="menuOpen && apps.length > 0"
+            class="absolute z-20 mt-1 left-0 min-w-[14rem] rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-[#0f0f0f] shadow-lg py-1"
           >
-            <i class="fas fa-home text-sm"></i>
-          </button>
-
-          <!-- Combined App / Page selector -->
-          <div class="relative flex-1 min-w-[12rem]" ref="menuRoot">
-            <button
-              type="button"
-              @click="menuOpen = !menuOpen"
-              :disabled="apps.length === 0"
-              class="w-full flex items-center gap-2 rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] focus:border-blue-400 dark:focus:border-blue-300/40 outline-none py-2 pl-3 pr-9 text-sm font-medium text-blue-950 dark:text-white/90 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              <i class="fas fa-cube text-xs text-blue-950/50 dark:text-white/50 shrink-0"></i>
-              <span class="truncate flex-1 text-left">{{ triggerLabel }}</span>
-              <i class="fas fa-chevron-down absolute right-3 top-1/2 -translate-y-1/2 text-xs text-blue-950/50 dark:text-white/40 pointer-events-none"></i>
-            </button>
-
             <div
-              v-if="menuOpen && apps.length > 0"
-              class="absolute z-20 mt-1 left-0 min-w-[14rem] rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-[#0f0f0f] shadow-lg py-1"
+              v-for="app in apps"
+              :key="app.name"
+              class="relative"
+              @mouseenter="onAppEnter(app.name)"
+              @mouseleave="onAppLeave(app.name)"
             >
+              <button
+                type="button"
+                @click="hoveredApp = hoveredApp === app.name ? '' : app.name"
+                class="w-full flex items-center justify-between gap-2 px-3 py-2 text-sm text-blue-950 dark:text-white/90 hover:bg-blue-50 dark:hover:bg-white/[0.05]"
+              >
+                <span class="flex items-center gap-2 truncate">
+                  <i class="fas fa-cube text-xs text-blue-950/50 dark:text-white/50"></i>
+                  {{ app.title }}
+                </span>
+                <i class="fas fa-chevron-right text-[10px] text-blue-950/40 dark:text-white/40"></i>
+              </button>
+
               <div
-                v-for="app in apps"
-                :key="app.name"
-                class="relative"
+                v-if="hoveredApp === app.name && app.pages.length"
+                class="absolute top-0 left-full ml-1 min-w-[14rem] rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-[#0f0f0f] shadow-lg py-1"
                 @mouseenter="onAppEnter(app.name)"
                 @mouseleave="onAppLeave(app.name)"
               >
                 <button
+                  v-for="page in app.pages"
+                  :key="page.path"
                   type="button"
-                  @click="hoveredApp = hoveredApp === app.name ? '' : app.name"
-                  class="w-full flex items-center justify-between gap-2 px-3 py-2 text-sm text-blue-950 dark:text-white/90 hover:bg-blue-50 dark:hover:bg-white/[0.05]"
+                  @click="onSelectPage(page.path)"
+                  :class="['w-full flex items-center gap-2 px-3 py-2 text-sm text-left',
+                           page.path === currentPath
+                             ? 'bg-blue-50 dark:bg-white/[0.08] text-blue-950 dark:text-white'
+                             : 'text-blue-950/70 dark:text-white/80 hover:bg-blue-50 dark:hover:bg-white/[0.05]']"
                 >
-                  <span class="flex items-center gap-2 truncate">
-                    <i class="fas fa-cube text-xs text-blue-950/50 dark:text-white/50"></i>
-                    {{ app.title }}
-                  </span>
-                  <i class="fas fa-chevron-right text-[10px] text-blue-950/40 dark:text-white/40"></i>
+                  <i class="fas fa-file-alt text-xs text-blue-950/50 dark:text-white/50"></i>
+                  <span class="truncate">{{ page.title }}</span>
                 </button>
-
-                <div
-                  v-if="hoveredApp === app.name && app.pages.length"
-                  class="absolute top-0 left-full ml-1 min-w-[14rem] rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-[#0f0f0f] shadow-lg py-1"
-                  @mouseenter="onAppEnter(app.name)"
-                  @mouseleave="onAppLeave(app.name)"
-                >
-                  <button
-                    v-for="page in app.pages"
-                    :key="page.path"
-                    type="button"
-                    @click="onSelectPage(page.path)"
-                    :class="['w-full flex items-center gap-2 px-3 py-2 text-sm text-left',
-                             page.path === currentPath
-                               ? 'bg-blue-50 dark:bg-white/[0.08] text-blue-950 dark:text-white'
-                               : 'text-blue-950/70 dark:text-white/80 hover:bg-blue-50 dark:hover:bg-white/[0.05]']"
-                  >
-                    <i class="fas fa-file-alt text-xs text-blue-950/50 dark:text-white/50"></i>
-                    <span class="truncate">{{ page.title }}</span>
-                  </button>
-                </div>
               </div>
             </div>
           </div>
-
         </div>
+
+      </div>
+    </div>
+
+    <!-- Screen: frames from the remote browser, input forwarded back -->
+    <div
+      ref="screenRef"
+      tabindex="0"
+      class="relative flex-1 min-h-0 bg-white outline-none overflow-hidden"
+      @pointerdown="onPointerDown"
+      @pointermove="onPointerMove"
+      @pointerup="onPointerUp"
+      @wheel.prevent="onWheel"
+      @keydown="onKeyDown"
+      @keyup="onKeyUp"
+      @contextmenu.prevent
+    >
+      <img
+        v-if="frameSrc"
+        :src="frameSrc"
+        alt=""
+        draggable="false"
+        class="w-full h-full select-none pointer-events-none"
+        style="object-fit: fill;"
+      />
+
+      <!-- Starting overlay -->
+      <div
+        v-if="phase === 'starting'"
+        class="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-white/90 dark:bg-[#0a0a0a]/90 text-blue-950/60 dark:text-white/60"
+      >
+        <i class="fas fa-spinner fa-spin text-2xl"></i>
+        <span class="text-sm font-medium">Starting preview…</span>
+        <span class="text-xs text-blue-950/40 dark:text-white/40 max-w-xs text-center">
+          The first start can take a few minutes while your project's dependencies install.
+        </span>
       </div>
 
-      <iframe
-        :key="iframeKey"
-        :src="iframeSrc"
-        class="flex-1 w-full border-0 bg-white"
-        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
-      ></iframe>
-    </template>
+      <!-- Error overlay -->
+      <div
+        v-else-if="phase === 'error'"
+        class="absolute inset-0 flex flex-col items-center justify-center gap-4 px-8 text-center bg-white dark:bg-[#0a0a0a]"
+      >
+        <div class="w-12 h-12 bg-red-50 dark:bg-red-900/10 border border-red-200 dark:border-red-800/30 rounded-xl flex items-center justify-center">
+          <i class="fas fa-exclamation-triangle text-red-600 dark:text-red-400"></i>
+        </div>
+        <p class="text-sm text-blue-950/70 dark:text-white/70 max-w-md break-words">{{ error }}</p>
+        <button
+          @click="startPreview"
+          class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-sm font-medium text-blue-950/70 dark:text-white/70 transition-colors"
+        >
+          <i class="fas fa-sync-alt text-xs"></i>
+          Retry
+        </button>
+      </div>
+
+      <!-- Stopped overlay (session ended, e.g. idle shutdown or restart) -->
+      <div
+        v-else-if="phase === 'stopped'"
+        class="absolute inset-0 flex flex-col items-center justify-center gap-4 px-8 text-center bg-white/95 dark:bg-[#0a0a0a]/95"
+      >
+        <div class="w-12 h-12 bg-blue-50 dark:bg-white/[0.05] border border-blue-200/60 dark:border-white/[0.08] rounded-xl flex items-center justify-center">
+          <i class="fas fa-pause text-blue-600 dark:text-blue-300"></i>
+        </div>
+        <p class="text-sm text-blue-950/70 dark:text-white/70 max-w-md">The preview session has stopped.</p>
+        <button
+          @click="startPreview"
+          class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-sm font-medium text-blue-950/70 dark:text-white/70 transition-colors"
+        >
+          <i class="fas fa-play text-xs"></i>
+          Start preview
+        </button>
+      </div>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, watch, computed, onMounted, onBeforeUnmount } from 'vue'
-import { PreviewService } from '../../../services/previewService'
+import {
+  PreviewService,
+  PreviewNotRunningError,
+  type PreviewFrame,
+  type PreviewInputEvent,
+} from '../../../services/previewService'
 import { useAgentStore } from '../../../stores/agentStore'
 import type { ProjectFile } from '../../../types/components'
 
@@ -134,32 +195,320 @@ const props = defineProps<{
 
 const store = useAgentStore()
 
-const isLoading = ref(false)
+type Phase = 'idle' | 'starting' | 'ready' | 'stopped' | 'error'
+
+const phase = ref<Phase>('idle')
 const error = ref<string | null>(null)
-const previewUrl = ref<string | null>(null)
-const iframeKey = ref(0)
+const frameSrc = ref<string | null>(null)
+const etag = ref<string | undefined>(undefined)
 const currentPath = ref('/')
+const canGoBack = ref(false)
+const canGoForward = ref(false)
+// Size of the remote browser viewport in CSS pixels; kept in sync with the
+// pane so client coordinates map 1:1 onto page coordinates.
+const viewport = ref<[number, number]>([1280, 800])
+
 const selectedApp = ref('')
-const selectedPath = ref('/')
 const menuOpen = ref(false)
 const hoveredApp = ref('')
 const menuRoot = ref<HTMLElement | null>(null)
+const screenRef = ref<HTMLElement | null>(null)
 let leaveTimer: number | null = null
 
-const baseOrigin = computed(() => {
-  if (!previewUrl.value) return ''
-  try {
-    return new URL(previewUrl.value).origin
-  } catch {
-    return previewUrl.value
-  }
-})
+// ---------------------------------------------------------------------------
+// Session lifecycle + frame polling
+// ---------------------------------------------------------------------------
 
-const iframeSrc = computed(() => {
-  if (!previewUrl.value) return ''
-  if (!baseOrigin.value) return previewUrl.value
-  return baseOrigin.value + normalizePath(currentPath.value)
-})
+let pollTimer: number | null = null
+let resizeTimer: number | null = null
+let observer: ResizeObserver | null = null
+let lastActivityAt = 0
+let disposed = false
+
+const deviceScaleFactor = Math.min(window.devicePixelRatio || 1, 2)
+
+function paneSize(): { width: number; height: number } {
+  const rect = screenRef.value?.getBoundingClientRect()
+  return {
+    width: Math.max(320, Math.round(rect?.width || 1280)),
+    height: Math.max(320, Math.round(rect?.height || 800)),
+  }
+}
+
+function applyFrame(f: PreviewFrame) {
+  if (f.frame) {
+    frameSrc.value = `data:image/jpeg;base64,${f.frame}`
+  }
+  if (f.etag) etag.value = f.etag
+  if (typeof f.path === 'string') currentPath.value = f.path
+  canGoBack.value = !!f.can_go_back
+  canGoForward.value = !!f.can_go_forward
+  if (f.viewport) viewport.value = f.viewport
+  syncSelectionFromCurrent()
+}
+
+async function startPreview() {
+  if (!props.projectId || phase.value === 'starting') return
+  phase.value = 'starting'
+  error.value = null
+  try {
+    const result = await PreviewService.start(props.projectId, paneSize(), deviceScaleFactor)
+    if (disposed) return
+    applyFrame(result)
+    phase.value = 'ready'
+    schedulePoll(200)
+  } catch (e) {
+    if (disposed) return
+    // Keep the failure local to this component — never call store.setError, or
+    // the workspace-level error path can navigate the user back to /projects.
+    phase.value = 'error'
+    error.value = e instanceof Error ? e.message : 'Preview failed to start.'
+  }
+}
+
+function markSessionStopped() {
+  phase.value = 'stopped'
+}
+
+function schedulePoll(delay?: number) {
+  if (pollTimer) window.clearTimeout(pollTimer)
+  if (disposed) return
+  const active = Date.now() - lastActivityAt < 4000
+  pollTimer = window.setTimeout(pollFrame, delay ?? (active ? 350 : 1500))
+}
+
+async function pollFrame() {
+  if (disposed || phase.value !== 'ready') return
+  if (document.hidden || inputInFlight) {
+    schedulePoll(1000)
+    return
+  }
+  try {
+    const f = await PreviewService.frame(props.projectId, etag.value)
+    applyFrame(f)
+  } catch (e) {
+    if (e instanceof PreviewNotRunningError) {
+      markSessionStopped()
+      return
+    }
+    // Transient failure (network hiccup): keep polling.
+  }
+  schedulePoll()
+}
+
+// ---------------------------------------------------------------------------
+// Input forwarding
+// ---------------------------------------------------------------------------
+
+let inputQueue: PreviewInputEvent[] = []
+let inputInFlight = false
+let flushTimer: number | null = null
+
+function modifiersFrom(e: MouseEvent | KeyboardEvent): number {
+  return (e.altKey ? 1 : 0) | (e.ctrlKey ? 2 : 0) | (e.metaKey ? 4 : 0) | (e.shiftKey ? 8 : 0)
+}
+
+function pageCoords(e: PointerEvent | WheelEvent): { x: number; y: number } {
+  const rect = screenRef.value?.getBoundingClientRect()
+  if (!rect || rect.width === 0 || rect.height === 0) return { x: 0, y: 0 }
+  const [vw, vh] = viewport.value
+  return {
+    x: Math.round(((e.clientX - rect.left) / rect.width) * vw * 100) / 100,
+    y: Math.round(((e.clientY - rect.top) / rect.height) * vh * 100) / 100,
+  }
+}
+
+function enqueue(event: PreviewInputEvent, immediate = false) {
+  if (phase.value !== 'ready') return
+  lastActivityAt = Date.now()
+  // Coalesce consecutive mouse moves so dragging doesn't flood the queue.
+  const last = inputQueue[inputQueue.length - 1]
+  if (event.type === 'mouseMoved' && last?.type === 'mouseMoved') {
+    inputQueue[inputQueue.length - 1] = event
+  } else if (event.kind === 'wheel' && last?.kind === 'wheel') {
+    last.deltaX = (last.deltaX || 0) + (event.deltaX || 0)
+    last.deltaY = (last.deltaY || 0) + (event.deltaY || 0)
+  } else {
+    inputQueue.push(event)
+  }
+  if (inputQueue.length > 64) inputQueue = inputQueue.slice(-64)
+  scheduleFlush(immediate ? 0 : 24)
+}
+
+function scheduleFlush(delay: number) {
+  if (flushTimer) return
+  flushTimer = window.setTimeout(flushInput, delay)
+}
+
+async function flushInput() {
+  flushTimer = null
+  if (inputInFlight || inputQueue.length === 0 || phase.value !== 'ready') return
+  const batch = inputQueue
+  inputQueue = []
+  inputInFlight = true
+  try {
+    const f = await PreviewService.sendInput(props.projectId, batch, etag.value)
+    applyFrame(f)
+  } catch (e) {
+    if (e instanceof PreviewNotRunningError) {
+      markSessionStopped()
+      return
+    }
+    // Drop the batch on transient failure; interaction continues from live state.
+  } finally {
+    inputInFlight = false
+  }
+  if (inputQueue.length > 0) scheduleFlush(0)
+  schedulePoll(250)
+}
+
+const BUTTON_NAMES: Array<'left' | 'middle' | 'right'> = ['left', 'middle', 'right']
+
+function onPointerDown(e: PointerEvent) {
+  screenRef.value?.focus()
+  if (phase.value !== 'ready') return
+  const { x, y } = pageCoords(e)
+  enqueue({
+    kind: 'mouse',
+    type: 'mousePressed',
+    x, y,
+    button: BUTTON_NAMES[e.button] || 'left',
+    buttons: e.buttons,
+    clickCount: Math.max(1, e.detail),
+    modifiers: modifiersFrom(e),
+  }, true)
+}
+
+function onPointerMove(e: PointerEvent) {
+  if (phase.value !== 'ready') return
+  const { x, y } = pageCoords(e)
+  enqueue({
+    kind: 'mouse',
+    type: 'mouseMoved',
+    x, y,
+    button: 'none',
+    buttons: e.buttons,
+    modifiers: modifiersFrom(e),
+  })
+}
+
+function onPointerUp(e: PointerEvent) {
+  if (phase.value !== 'ready') return
+  const { x, y } = pageCoords(e)
+  enqueue({
+    kind: 'mouse',
+    type: 'mouseReleased',
+    x, y,
+    button: BUTTON_NAMES[e.button] || 'left',
+    buttons: e.buttons,
+    clickCount: Math.max(1, e.detail),
+    modifiers: modifiersFrom(e),
+  }, true)
+}
+
+function onWheel(e: WheelEvent) {
+  if (phase.value !== 'ready') return
+  const { x, y } = pageCoords(e)
+  enqueue({
+    kind: 'wheel',
+    x, y,
+    deltaX: e.deltaX,
+    deltaY: e.deltaY,
+    modifiers: modifiersFrom(e),
+  })
+}
+
+function keyEvent(e: KeyboardEvent, type: 'keyDown' | 'keyUp'): PreviewInputEvent {
+  return {
+    kind: 'key',
+    type,
+    key: e.key,
+    code: e.code,
+    text: e.key.length === 1 ? e.key : e.key === 'Enter' ? '\r' : '',
+    keyCode: e.keyCode,
+    modifiers: modifiersFrom(e),
+  }
+}
+
+function onKeyDown(e: KeyboardEvent) {
+  if (phase.value !== 'ready') return
+  e.preventDefault()
+  e.stopPropagation()
+  enqueue(keyEvent(e, 'keyDown'), true)
+}
+
+function onKeyUp(e: KeyboardEvent) {
+  if (phase.value !== 'ready') return
+  e.preventDefault()
+  e.stopPropagation()
+  enqueue(keyEvent(e, 'keyUp'), true)
+}
+
+// ---------------------------------------------------------------------------
+// Navigation
+// ---------------------------------------------------------------------------
+
+async function doNavigate(action: 'goto' | 'back' | 'forward' | 'reload', path?: string) {
+  if (phase.value !== 'ready') return
+  lastActivityAt = Date.now()
+  try {
+    const f = await PreviewService.navigate(props.projectId, action, path)
+    applyFrame(f)
+    schedulePoll(300)
+  } catch (e) {
+    if (e instanceof PreviewNotRunningError) markSessionStopped()
+  }
+}
+
+function navigateTo(path: string) {
+  void doNavigate('goto', normalizePath(path))
+}
+
+function goBack() {
+  void doNavigate('back')
+}
+
+function goForward() {
+  void doNavigate('forward')
+}
+
+function goHome() {
+  navigateTo('/')
+}
+
+function reload() {
+  if (phase.value === 'ready') {
+    void doNavigate('reload')
+  } else if (phase.value !== 'starting') {
+    void startPreview()
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pane size -> remote viewport
+// ---------------------------------------------------------------------------
+
+function onPaneResized() {
+  if (resizeTimer) window.clearTimeout(resizeTimer)
+  resizeTimer = window.setTimeout(async () => {
+    if (disposed || phase.value !== 'ready') return
+    const { width, height } = paneSize()
+    const [vw, vh] = viewport.value
+    if (Math.abs(width - vw) < 4 && Math.abs(height - vh) < 4) return
+    try {
+      await PreviewService.resize(props.projectId, width, height, deviceScaleFactor)
+      viewport.value = [width, height]
+      etag.value = undefined // force a fresh frame at the new size
+      schedulePoll(100)
+    } catch (e) {
+      if (e instanceof PreviewNotRunningError) markSessionStopped()
+    }
+  }, 350)
+}
+
+// ---------------------------------------------------------------------------
+// App / page selector (derived from the project's view files)
+// ---------------------------------------------------------------------------
 
 interface Page {
   title: string
@@ -231,10 +580,6 @@ const pagesForSelectedApp = computed<Page[]>(() => {
   return app ? app.pages : []
 })
 
-const isPathInSelectedApp = computed(() =>
-  pagesForSelectedApp.value.some(p => p.path === currentPath.value)
-)
-
 function appNameFromPath(path: string): string | null {
   if (path === '/' || path === '') return apps.value.some(a => a.name === 'home') ? 'home' : null
   const m = path.match(/^\/([^/]+)/)
@@ -253,20 +598,6 @@ function normalizePath(input: string): string {
     }
   }
   return trimmed.startsWith('/') ? trimmed : '/' + trimmed
-}
-
-function navigateTo(path: string) {
-  const next = normalizePath(path)
-  if (next === currentPath.value) {
-    iframeKey.value++
-  } else {
-    currentPath.value = next
-  }
-  selectedPath.value = next
-  const appFromPath = appNameFromPath(next)
-  if (appFromPath && apps.value.some(a => a.name === appFromPath)) {
-    selectedApp.value = appFromPath
-  }
 }
 
 function onSelectPage(path: string) {
@@ -308,10 +639,6 @@ const triggerLabel = computed(() => {
   return 'Select page'
 })
 
-function goHome() {
-  navigateTo('/')
-}
-
 function syncSelectionFromCurrent() {
   const appFromPath = appNameFromPath(currentPath.value)
   if (appFromPath && apps.value.some(a => a.name === appFromPath)) {
@@ -319,73 +646,42 @@ function syncSelectionFromCurrent() {
   } else if (!selectedApp.value && apps.value.length > 0) {
     selectedApp.value = apps.value[0]!.name
   }
-  if (isPathInSelectedApp.value || pagesForSelectedApp.value.length === 0) {
-    selectedPath.value = currentPath.value
-  } else {
-    selectedPath.value = currentPath.value
-  }
 }
 
-async function loadPreview() {
-  if (!props.projectId) return
-  isLoading.value = true
-  error.value = null
-  try {
-    const response = await PreviewService.generatePreview(props.projectId)
-    if (response && response.previewUrl) {
-      previewUrl.value = response.previewUrl
-      try {
-        const u = new URL(response.previewUrl)
-        const initial = (u.pathname || '/') + u.search + u.hash
-        currentPath.value = initial
-      } catch {
-        currentPath.value = '/'
-      }
-      syncSelectionFromCurrent()
-      iframeKey.value++
-    } else {
-      error.value = 'Preview server failed to start.'
-    }
-  } catch (e) {
-    // Keep the failure local to this component — never call store.setError, or
-    // the workspace-level error path can navigate the user back to /projects.
-    error.value = e instanceof Error ? e.message : 'Preview server failed to start.'
-  } finally {
-    isLoading.value = false
-  }
-}
-
-function reload() {
-  if (previewUrl.value) {
-    iframeKey.value++
-  } else {
-    loadPreview()
-  }
-}
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
 
 onMounted(() => {
-  loadPreview()
   document.addEventListener('mousedown', onDocClick)
+  if (screenRef.value && typeof ResizeObserver !== 'undefined') {
+    observer = new ResizeObserver(onPaneResized)
+    observer.observe(screenRef.value)
+  }
+  void startPreview()
 })
 
 onBeforeUnmount(() => {
+  disposed = true
   document.removeEventListener('mousedown', onDocClick)
   if (leaveTimer) window.clearTimeout(leaveTimer)
+  if (pollTimer) window.clearTimeout(pollTimer)
+  if (resizeTimer) window.clearTimeout(resizeTimer)
+  if (flushTimer) window.clearTimeout(flushTimer)
+  observer?.disconnect()
 })
 
 watch(
   () => props.projectId,
   (next, prev) => {
     if (next && next !== prev) {
-      previewUrl.value = null
-      loadPreview()
+      frameSrc.value = null
+      etag.value = undefined
+      phase.value = 'idle'
+      void startPreview()
     }
   }
 )
-
-watch(currentPath, () => {
-  syncSelectionFromCurrent()
-})
 
 watch(apps, () => {
   if (!selectedApp.value && apps.value.length > 0) {
@@ -393,5 +689,7 @@ watch(apps, () => {
   }
 })
 
+// Kept for existing callers of this component's public API.
+const loadPreview = startPreview
 defineExpose({ reload, loadPreview, navigateTo })
 </script>

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspacePreview.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspacePreview.vue
@@ -45,7 +45,7 @@
         <div class="relative flex-1 min-w-[12rem]" ref="menuRoot">
           <button
             type="button"
-            @click="menuOpen = !menuOpen"
+            @click="onMenuToggle"
             :disabled="apps.length === 0"
             class="w-full flex items-center gap-2 rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] focus:border-blue-400 dark:focus:border-blue-300/40 outline-none py-2 pl-3 pr-9 text-sm font-medium text-blue-950 dark:text-white/90 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
           >
@@ -183,17 +183,14 @@ import { ref, watch, computed, onMounted, onBeforeUnmount } from 'vue'
 import {
   PreviewService,
   PreviewNotRunningError,
+  type PreviewApp,
   type PreviewFrame,
   type PreviewInputEvent,
 } from '../../../services/previewService'
-import { useAgentStore } from '../../../stores/agentStore'
-import type { ProjectFile } from '../../../types/components'
 
 const props = defineProps<{
   projectId: string
 }>()
-
-const store = useAgentStore()
 
 type Phase = 'idle' | 'starting' | 'ready' | 'stopped' | 'error'
 
@@ -257,6 +254,9 @@ async function startPreview() {
     applyFrame(result)
     phase.value = 'ready'
     schedulePoll(200)
+    // Starting may have scaffolded/hydrated the working copy the pages
+    // menu reads from, so fetch it (again) now.
+    void refreshPages()
   } catch (e) {
     if (disposed) return
     // Keep the failure local to this component — never call store.setError, or
@@ -507,75 +507,29 @@ function onPaneResized() {
 }
 
 // ---------------------------------------------------------------------------
-// App / page selector (derived from the project's view files)
+// App / page selector (read from the project's actual Vue routers)
 // ---------------------------------------------------------------------------
 
-interface Page {
-  title: string
-  path: string
-}
+const apps = ref<PreviewApp[]>([])
 
-interface AppEntry {
-  name: string
-  title: string
-  pages: Page[]
-}
-
-function toKebabCase(input: string): string {
-  return input
-    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
-    .replace(/\s+/g, '-')
-    .replace(/_+/g, '-')
-    .toLowerCase()
-}
-
-function humanize(input: string): string {
-  return input
-    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
-    .replace(/[-_]+/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim()
-    .replace(/\b\w/g, c => c.toUpperCase())
-}
-
-const apps = computed<AppEntry[]>(() => {
-  const files: ProjectFile[] = (store.files || []) as ProjectFile[]
-  const viewRegex = /(?:^|\/)(?:frontend\/vuejs\/)?src\/apps\/([^/]+)\/views\/([^/]+)\.vue$/i
-  const appMap = new Map<string, AppEntry>()
-
-  for (const file of files) {
-    if (!file?.path) continue
-    const match = file.path.match(viewRegex)
-    if (!match) continue
-    const appName = match[1]!
-    const viewName = match[2]!
-    const base = viewName.endsWith('View') ? viewName.slice(0, -4) : viewName
-
-    // Stripe return pages (from the Sell payment templates) only make
-    // sense mid-checkout; don't offer them as navigable pages.
-    if (base === 'CheckoutReturn') continue
-
-    const slug = toKebabCase(base)
-    // HomeView in home -> '/', StoreView in store -> '/store' (an app's
-    // namesake view is routed at the app root, not /<app>/<app>).
-    const path = appName === 'home' && slug === 'home'
-      ? '/'
-      : slug === appName ? `/${appName}` : `/${appName}/${slug}`
-
-    let app = appMap.get(appName)
-    if (!app) {
-      app = { name: appName, title: humanize(appName), pages: [] }
-      appMap.set(appName, app)
-    }
-    if (!app.pages.some(p => p.path === path)) {
-      app.pages.push({ title: humanize(base), path })
-    }
+async function refreshPages() {
+  if (!props.projectId) return
+  try {
+    apps.value = await PreviewService.pages(props.projectId)
+    syncSelectionFromCurrent()
+  } catch {
+    // Keep whatever menu we had; the preview itself is unaffected.
   }
+}
 
-  return Array.from(appMap.values()).sort((a, b) => a.title.localeCompare(b.title))
-})
+function onMenuToggle() {
+  menuOpen.value = !menuOpen.value
+  // Routes may have changed since the last fetch (the agent edits routers);
+  // refresh in the background whenever the menu opens.
+  if (menuOpen.value) void refreshPages()
+}
 
-const pagesForSelectedApp = computed<Page[]>(() => {
+const pagesForSelectedApp = computed(() => {
   const app = apps.value.find(a => a.name === selectedApp.value)
   return app ? app.pages : []
 })
@@ -658,6 +612,7 @@ onMounted(() => {
     observer = new ResizeObserver(onPaneResized)
     observer.observe(screenRef.value)
   }
+  void refreshPages()
   void startPreview()
 })
 
@@ -678,6 +633,8 @@ watch(
       frameSrc.value = null
       etag.value = undefined
       phase.value = 'idle'
+      apps.value = []
+      void refreshPages()
       void startPreview()
     }
   }

--- a/frontend/vuejs/src/apps/imagi/build/services/modelsService.ts
+++ b/frontend/vuejs/src/apps/imagi/build/services/modelsService.ts
@@ -3,7 +3,7 @@ import type { AIModel, ModelConfig } from '../types/services'
 import { AI_MODELS, MODEL_CONFIGS } from '../types/services'
 
 // Static variables for rate limiting
-let requestCounts: Map<string, number> = new Map()
+const requestCounts: Map<string, number> = new Map()
 let lastResetTime: number = Date.now()
 const RESET_INTERVAL = 60000 // 1 minute
 

--- a/frontend/vuejs/src/apps/imagi/build/services/previewService.ts
+++ b/frontend/vuejs/src/apps/imagi/build/services/previewService.ts
@@ -1,67 +1,163 @@
 import api from '@/shared/services/api'
 
 /**
- * Service for handling preview functionality
+ * Client for the browser-based project preview.
+ *
+ * The backend runs the project's dev servers plus a headless Chromium on its
+ * own host and exposes it through these endpoints: the workspace polls JPEG
+ * frames and forwards input events, so the preview works the same whether
+ * Imagi runs locally or in production.
  */
+
+/** One user-input event forwarded to the remote browser page. */
+export interface PreviewInputEvent {
+  kind: 'mouse' | 'wheel' | 'key'
+  type?: 'mousePressed' | 'mouseReleased' | 'mouseMoved' | 'keyDown' | 'keyUp'
+  x?: number
+  y?: number
+  button?: 'none' | 'left' | 'middle' | 'right'
+  buttons?: number
+  clickCount?: number
+  deltaX?: number
+  deltaY?: number
+  key?: string
+  code?: string
+  text?: string
+  keyCode?: number
+  modifiers?: number
+}
+
+/** Snapshot of the remote page: navigation state plus (optionally) a frame. */
+export interface PreviewFrame {
+  running?: boolean
+  /** Base64 JPEG. Null when it matched the etag we already have. */
+  frame?: string | null
+  etag?: string
+  path?: string
+  title?: string
+  can_go_back?: boolean
+  can_go_forward?: boolean
+  viewport?: [number, number]
+  device_scale_factor?: number
+  error?: string
+}
+
+/** Thrown when the backend reports the session is gone (HTTP 409). */
+export class PreviewNotRunningError extends Error {
+  constructor(message = 'The preview session is not running.') {
+    super(message)
+    this.name = 'PreviewNotRunningError'
+  }
+}
+
+// Starting can scaffold + npm-install a fresh project, which takes minutes.
+const START_TIMEOUT_MS = 600_000
+
+function rethrow(error: any): never {
+  if (error?.response?.status === 409) {
+    throw new PreviewNotRunningError(error.response?.data?.error)
+  }
+  const data = error?.response?.data
+  const message =
+    (typeof data?.error === 'string' && data.error) ||
+    (typeof data?.detail === 'string' && data.detail) ||
+    (error instanceof Error ? error.message : 'Preview request failed')
+  throw new Error(message)
+}
+
 export const PreviewService = {
-  /**
-   * Generate a preview for a project
-   * 
-   * @param projectId - The ID of the project to preview
-   * @returns Promise with the preview URL
-   */
-  async generatePreview(projectId: string): Promise<{ previewUrl: string }> {
+  /** Ensure dev servers + browser are running; idempotent. */
+  async start(
+    projectId: string,
+    viewport?: { width: number; height: number },
+    deviceScaleFactor?: number
+  ): Promise<PreviewFrame> {
     try {
-      const response = await api.get(`/v1/builder/${projectId}/preview/`);
-      return {
-        previewUrl: response.data.preview_url
-      };
-    } catch (error: any) {
-      if (error?.response?.status === 503) {
-        // The backend includes the actual failure reason in dev
-        throw new Error(error.response?.data?.error || 'Preview server failed to start.');
-      }
-      throw new Error(`Failed to generate preview: ${this.formatError(error)}`);
+      const response = await api.post(
+        `/v1/builder/${projectId}/preview/`,
+        { viewport, device_scale_factor: deviceScaleFactor },
+        { timeout: START_TIMEOUT_MS }
+      )
+      return response.data
+    } catch (error) {
+      rethrow(error)
     }
   },
-  
-  /**
-   * Format an error object or string into a readable message
-   * 
-   * @param error - The error to format
-   * @returns Formatted error message
-   */
-  formatError(error: any): string {
-    if (error instanceof Error) {
-      return error.message;
-    } else if (typeof error === 'string') {
-      return error;
-    } else if (error && error.response && error.response.data) {
-      const data = error.response.data;
-      
-      if (data.detail) {
-        return data.detail;
-      } else if (data.message) {
-        return data.message;
-      } else if (data.error) {
-        return data.error;
-      } else if (typeof data === 'string') {
-        return data;
-      } else {
-        try {
-          return JSON.stringify(data);
-        } catch (e) {
-          return 'Unknown error occurred';
-        }
-      }
-    } else if (error && error.message) {
-      return error.message;
-    } else {
-      try {
-        return JSON.stringify(error);
-      } catch (e) {
-        return 'Unknown error occurred';
-      }
+
+  /** Current session state; running=false when nothing is up (never throws 409). */
+  async status(projectId: string): Promise<PreviewFrame> {
+    try {
+      const response = await api.get(`/v1/builder/${projectId}/preview/`)
+      return response.data
+    } catch (error) {
+      rethrow(error)
     }
-  }
-} 
+  },
+
+  async stop(projectId: string): Promise<void> {
+    await api.delete(`/v1/builder/${projectId}/preview/`)
+  },
+
+  /** Poll the latest frame; pass the previous etag to skip unchanged frames. */
+  async frame(projectId: string, etag?: string): Promise<PreviewFrame> {
+    try {
+      const response = await api.get(`/v1/builder/${projectId}/preview/frame/`, {
+        params: etag ? { etag } : undefined,
+      })
+      return response.data
+    } catch (error) {
+      rethrow(error)
+    }
+  },
+
+  /** Forward a batch of input events; the response includes a fresh frame. */
+  async sendInput(
+    projectId: string,
+    events: PreviewInputEvent[],
+    etag?: string
+  ): Promise<PreviewFrame> {
+    try {
+      const response = await api.post(`/v1/builder/${projectId}/preview/input/`, {
+        events,
+        etag,
+      })
+      return response.data
+    } catch (error) {
+      rethrow(error)
+    }
+  },
+
+  async navigate(
+    projectId: string,
+    action: 'goto' | 'back' | 'forward' | 'reload',
+    path?: string
+  ): Promise<PreviewFrame> {
+    try {
+      const response = await api.post(`/v1/builder/${projectId}/preview/navigate/`, {
+        action,
+        path,
+      })
+      return response.data
+    } catch (error) {
+      rethrow(error)
+    }
+  },
+
+  /** Keep the remote viewport in sync with the preview pane's CSS size. */
+  async resize(
+    projectId: string,
+    width: number,
+    height: number,
+    deviceScaleFactor?: number
+  ): Promise<void> {
+    try {
+      await api.post(`/v1/builder/${projectId}/preview/resize/`, {
+        width,
+        height,
+        device_scale_factor: deviceScaleFactor,
+      })
+    } catch (error) {
+      rethrow(error)
+    }
+  },
+}

--- a/frontend/vuejs/src/apps/imagi/build/services/previewService.ts
+++ b/frontend/vuejs/src/apps/imagi/build/services/previewService.ts
@@ -42,6 +42,19 @@ export interface PreviewFrame {
   error?: string
 }
 
+/** One navigable page of the previewed app, read from its actual router. */
+export interface PreviewPage {
+  title: string
+  path: string
+}
+
+/** One app of the previewed project with its navigable pages. */
+export interface PreviewApp {
+  name: string
+  title: string
+  pages: PreviewPage[]
+}
+
 /** Thrown when the backend reports the session is gone (HTTP 409). */
 export class PreviewNotRunningError extends Error {
   constructor(message = 'The preview session is not running.') {
@@ -96,6 +109,16 @@ export const PreviewService = {
 
   async stop(projectId: string): Promise<void> {
     await api.delete(`/v1/builder/${projectId}/preview/`)
+  },
+
+  /** The project's apps and pages, derived from its real Vue routers. */
+  async pages(projectId: string): Promise<PreviewApp[]> {
+    try {
+      const response = await api.get(`/v1/builder/${projectId}/pages/`)
+      return response.data?.apps || []
+    } catch (error) {
+      rethrow(error)
+    }
   },
 
   /** Poll the latest frame; pass the previous etag to skip unchanged frames. */

--- a/frontend/vuejs/src/apps/imagi/build/stores/agentStore.ts
+++ b/frontend/vuejs/src/apps/imagi/build/stores/agentStore.ts
@@ -111,7 +111,7 @@ export const useAgentStore = defineStore('agent', {
 
         // Pick active: remembered id from localStorage, else first non-archived
         const remembered = localStorage.getItem(`activeAgentInstance_${projectId}`)
-        let activeConvId: number | null = remembered ? Number(remembered) : null
+        const activeConvId: number | null = remembered ? Number(remembered) : null
         let picked = this.instances.find(i => i.conversationId === activeConvId && !i.archivedAt)
         if (!picked) {
           picked = this.instances.find(i => !i.archivedAt) || this.instances[0]

--- a/frontend/vuejs/src/apps/payments/components/molecules/summaries/OrderSummary/OrderSummary.vue
+++ b/frontend/vuejs/src/apps/payments/components/molecules/summaries/OrderSummary/OrderSummary.vue
@@ -13,7 +13,7 @@
     <div class="border-t border-dark-700 pt-4">
       <div class="flex justify-between items-center">
         <p class="text-gray-400">{{ totalLabel }}</p>
-        <p class="text-2xl font-bold text-primary-400">{{ formatCurrency(total) }}</p>
+        <p class="text-2xl font-bold text-primary-400">{{ formatCurrency(displayTotal) }}</p>
       </div>
     </div>
   </div>
@@ -57,7 +57,7 @@ export default defineComponent({
 
     return {
       formatCurrency,
-      total: computedTotal
+      displayTotal: computedTotal
     }
   }
 })


### PR DESCRIPTION
The build workspace preview used to hand the client a
http://localhost:<port> URL for an iframe, which only works when Imagi
runs on the user's own machine — in production the endpoint simply
refused. The preview now runs a real Chromium next to the project's dev
servers on the backend host and drives it over the Chrome DevTools
Protocol, with the workspace streaming JPEG frames and forwarding
mouse/keyboard/wheel input through the normal authenticated API. The
same setup therefore works identically in development and on Railway.

Backend:
- BrowserPreviewService: per-project headless Chromium subprocess
  (PID/state files beside the dev-server files), a minimal CDP client
  over websocket-client, and ops for frames (etag-elided screenshots),
  input dispatch, navigation (app-origin paths only), viewport resize,
  and idle-session reaping. Page state lives in Chromium itself, so any
  gunicorn worker can serve any request.
- Preview API: POST/GET/DELETE /preview/ (start, status, stop) plus
  /preview/frame|input|navigate|resize/; the DEBUG-only gate is gone.
- PreviewService: ensure_preview() reuses healthy dev servers instead
  of restarting them; Vite now binds to 127.0.0.1 only; cleanup sweeps
  the browser files too.
- npm installs are serialized with an on-disk lock so the background
  install from project creation and a first preview start can no longer
  corrupt node_modules under each other.
- Docker image installs Node 22 and Chromium so generated projects run
  their dev servers in the backend container in production.

Frontend:
- WorkspacePreview is now an interactive remote-browser pane: frames
  render into the pane, pointer/keyboard/wheel events are forwarded
  (with move/wheel coalescing), polling adapts to activity, the pane
  size syncs to the remote viewport, and back/forward join the
  reload/home/page-menu toolbar.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017VPcPfKfXNqRhC8YaFdj7B