### PR TITLE
Make build workspace responsive on mobile and slim the preview address bar

### DIFF
--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/AgentManagerPanel.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/AgentManagerPanel.vue
@@ -10,8 +10,8 @@
     <!-- Header -->
     <div class="shrink-0 px-2 py-2 border-b border-blue-100 dark:border-white/[0.08] flex items-center justify-between">
       <div class="flex items-center gap-0.5">
-        <!-- Collapse -->
-        <div class="relative group">
+        <!-- Collapse (desktop only; mobile uses the navbar view switcher) -->
+        <div class="relative group max-md:hidden">
           <button
             class="flex items-center justify-center w-7 h-7 rounded-md text-blue-950/60 dark:text-white/70 hover:bg-blue-50 dark:hover:bg-white/[0.08] hover:text-blue-950 dark:hover:text-white transition-colors"
             @click="emit('collapse')"

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
@@ -2,7 +2,7 @@
   <div v-if="!isCollapsed" class="flex flex-col h-full bg-white dark:bg-[#0a0a0a] border-r border-blue-100 dark:border-white/[0.08] transition-colors duration-300">
     <!-- Header: manager toggle + instance title -->
     <div class="shrink-0 flex items-center gap-2 px-3 py-2 border-b border-blue-100 dark:border-white/[0.08]">
-      <div v-if="!isManagerOpen" class="relative group">
+      <div v-if="!isManagerOpen" class="relative group max-md:hidden">
         <button
           class="flex items-center justify-center w-8 h-8 rounded-md text-blue-950/60 dark:text-white/60 hover:bg-blue-50 dark:hover:bg-white/[0.08] hover:text-blue-950 dark:hover:text-white transition-colors duration-200"
           @click="$emit('toggleManager')"
@@ -18,7 +18,7 @@
       <div class="flex-1 min-w-0 text-xs font-semibold text-blue-950/80 dark:text-white/80 truncate">
         {{ activeInstance?.title || 'New instance' }}
       </div>
-      <div v-if="onCollapseSidebar" class="relative group shrink-0">
+      <div v-if="onCollapseSidebar" class="relative group shrink-0 max-md:hidden">
         <button
           class="flex items-center justify-center w-8 h-8 rounded-md text-blue-950/60 dark:text-white/60 hover:bg-blue-50 dark:hover:bg-white/[0.08] hover:text-blue-950 dark:hover:text-white transition-colors duration-200"
           @click="onCollapseSidebar()"

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspacePreview.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspacePreview.vue
@@ -1,16 +1,16 @@
 <template>
   <div class="relative w-full h-full flex flex-col bg-white dark:bg-[#0a0a0a]">
     <!-- Toolbar -->
-    <div class="flex flex-col gap-2 px-3 py-2 border-b border-blue-200/60 dark:border-white/[0.08] bg-blue-50/50 dark:bg-white/[0.02]">
-      <div class="flex items-center gap-2 flex-wrap">
+    <div class="flex flex-col gap-2 px-3 py-1.5 border-b border-blue-200/60 dark:border-white/[0.08] bg-blue-50/50 dark:bg-white/[0.02]">
+      <div class="flex items-center gap-1.5 flex-wrap">
         <button
           type="button"
           @click="goBack"
           :disabled="!canGoBack || phase !== 'ready'"
           title="Back"
-          class="inline-flex items-center justify-center w-9 h-9 shrink-0 rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-blue-950/70 dark:text-white/70 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          class="inline-flex items-center justify-center w-8 h-8 shrink-0 rounded-full border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-blue-950/60 dark:text-white/60 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          <i class="fas fa-arrow-left text-sm"></i>
+          <i class="fas fa-arrow-left text-xs"></i>
         </button>
 
         <button
@@ -18,46 +18,46 @@
           @click="goForward"
           :disabled="!canGoForward || phase !== 'ready'"
           title="Forward"
-          class="inline-flex items-center justify-center w-9 h-9 shrink-0 rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-blue-950/70 dark:text-white/70 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          class="inline-flex items-center justify-center w-8 h-8 shrink-0 rounded-full border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-blue-950/60 dark:text-white/60 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          <i class="fas fa-arrow-right text-sm"></i>
+          <i class="fas fa-arrow-right text-xs"></i>
         </button>
 
         <button
           type="button"
           @click="reload"
           title="Refresh page"
-          class="inline-flex items-center justify-center w-9 h-9 shrink-0 rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-blue-950/70 dark:text-white/70 transition-colors"
+          class="inline-flex items-center justify-center w-8 h-8 shrink-0 rounded-full border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-blue-950/60 dark:text-white/60 transition-colors"
         >
-          <i class="fas fa-sync-alt text-sm" :class="{ 'fa-spin': phase === 'starting' }"></i>
+          <i class="fas fa-sync-alt text-xs" :class="{ 'fa-spin': phase === 'starting' }"></i>
         </button>
 
         <button
           type="button"
           @click="goHome"
           title="Go to home page"
-          class="inline-flex items-center justify-center w-9 h-9 shrink-0 rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-blue-950/70 dark:text-white/70 transition-colors"
+          class="inline-flex items-center justify-center w-8 h-8 shrink-0 rounded-full border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-blue-950/60 dark:text-white/60 transition-colors"
         >
-          <i class="fas fa-home text-sm"></i>
+          <i class="fas fa-home text-xs"></i>
         </button>
 
-        <!-- Combined App / Page selector -->
-        <div class="relative flex-1 min-w-[12rem]" ref="menuRoot">
+        <!-- Combined App / Page selector — slender address bar -->
+        <div class="relative flex-1 min-w-[8rem]" ref="menuRoot">
           <button
             type="button"
             @click="onMenuToggle"
             :disabled="apps.length === 0"
-            class="w-full flex items-center gap-2 rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] focus:border-blue-400 dark:focus:border-blue-300/40 outline-none py-2 pl-3 pr-9 text-sm font-medium text-blue-950 dark:text-white/90 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            class="group w-full flex items-center gap-2 h-8 rounded-full border border-blue-200/60 dark:border-white/[0.08] bg-white/80 dark:bg-white/[0.04] hover:bg-blue-50 dark:hover:bg-white/[0.07] focus:border-blue-400 dark:focus:border-blue-300/40 focus:ring-2 focus:ring-blue-400/15 outline-none pl-3 pr-8 text-[13px] font-medium text-blue-950 dark:text-white/90 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            <i class="fas fa-cube text-xs text-blue-950/50 dark:text-white/50 shrink-0"></i>
+            <i class="fas fa-cube text-[10px] text-blue-950/40 dark:text-white/40 shrink-0"></i>
             <span class="truncate flex-1 text-left">{{ triggerLabel }}</span>
-            <span class="truncate max-w-[10rem] text-xs text-blue-950/40 dark:text-white/40 font-normal hidden sm:block">{{ currentPath }}</span>
-            <i class="fas fa-chevron-down absolute right-3 top-1/2 -translate-y-1/2 text-xs text-blue-950/50 dark:text-white/40 pointer-events-none"></i>
+            <span class="truncate max-w-[10rem] text-[11px] text-blue-950/35 dark:text-white/35 font-normal hidden sm:block">{{ currentPath }}</span>
+            <i class="fas fa-chevron-down absolute right-3 top-1/2 -translate-y-1/2 text-[10px] text-blue-950/40 dark:text-white/35 pointer-events-none transition-transform duration-200" :class="{ 'rotate-180': menuOpen }"></i>
           </button>
 
           <div
             v-if="menuOpen && apps.length > 0"
-            class="absolute z-20 mt-1 left-0 min-w-[14rem] rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-[#0f0f0f] shadow-lg py-1"
+            class="absolute z-20 mt-1.5 left-0 min-w-[14rem] rounded-xl border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-[#0f0f0f] shadow-xl py-1"
           >
             <div
               v-for="app in apps"

--- a/frontend/vuejs/src/apps/imagi/build/layouts/BuilderLayout.vue
+++ b/frontend/vuejs/src/apps/imagi/build/layouts/BuilderLayout.vue
@@ -5,17 +5,18 @@
     :wide="!extraWide"
     :extra-wide="extraWide"
     compact-top
+    mobile-overlay
   >
     <template #sidebar-content="{ isSidebarCollapsed, toggleSidebar }">
       <slot name="sidebar-content" :collapsed="isSidebarCollapsed" :toggle-sidebar="toggleSidebar"></slot>
     </template>
-    
-    <!-- Pass through any navbar-right content from parent -->
-    <template #navbar-center>
-      <slot name="navbar-center"></slot>
+
+    <!-- Pass through any navbar content from parent, forwarding sidebar controls -->
+    <template #navbar-center="slotProps">
+      <slot name="navbar-center" v-bind="slotProps"></slot>
     </template>
-    <template #navbar-right>
-      <slot name="navbar-right"></slot>
+    <template #navbar-right="slotProps">
+      <slot name="navbar-right" v-bind="slotProps"></slot>
     </template>
 
     <div class="flex flex-col h-full w-full">

--- a/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
+++ b/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
@@ -16,12 +16,14 @@
       <template #sidebar-content="{ collapsed, toggleSidebar }">
         <div v-if="!collapsed" class="flex h-full">
           <AgentManagerPanel
-            v-if="isManagerOpen"
+            v-if="isManagerOpen || (isMobile && mobileView === 'manager')"
             class="w-56 shrink-0"
+            :class="mobileView === 'manager' ? 'max-md:w-full' : 'max-md:hidden'"
             @collapse="toggleManager"
           />
           <BuilderSidebarChat
             class="flex-1 min-w-0"
+            :class="mobileView === 'chat' ? 'max-md:w-full' : 'max-md:hidden'"
             :selected-app="null"
             :on-prompt-submit="handlePrompt"
             :on-model-select="handleModelSelect"
@@ -34,7 +36,36 @@
           />
         </div>
       </template>
-      
+
+      <!-- Mobile-only view switcher: fill the screen with one view at a time -->
+      <template #navbar-center="{ setSidebarCollapsed }">
+        <div
+          class="md:hidden flex items-center gap-0.5 rounded-lg border border-blue-100 dark:border-white/[0.08] bg-blue-50/70 dark:bg-white/[0.05] p-0.5"
+          role="tablist"
+          aria-label="Workspace view"
+        >
+          <button
+            v-for="opt in mobileViewOptions"
+            :key="opt.value"
+            type="button"
+            role="tab"
+            :aria-selected="mobileView === opt.value"
+            :aria-label="opt.label"
+            :title="opt.label"
+            @click="selectMobileView(opt.value, setSidebarCollapsed)"
+            :class="[
+              'flex items-center justify-center rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors',
+              mobileView === opt.value
+                ? 'bg-white dark:bg-white/[0.12] text-blue-700 dark:text-white shadow-sm'
+                : 'text-blue-950/55 dark:text-white/55 hover:text-blue-950 dark:hover:text-white'
+            ]"
+          >
+            <i :class="[opt.icon, 'text-sm']"></i>
+            <span class="sr-only">{{ opt.label }}</span>
+          </button>
+        </div>
+      </template>
+
       <!-- Account balance display in navbar right -->
       <template #navbar-right>
         <div class="flex items-center gap-3">
@@ -71,6 +102,7 @@ import { useAuthStore } from '@/shared/stores/auth'
 import { usePaymentStore } from '@/apps/payments/stores/payments'
 import { useBalanceStore } from '@/shared/stores/balance'
 import { useNotification } from '@/shared/composables/useNotification'
+import { useWindowSize } from '@/shared/composables/useWindowSize'
 
 // Builder Components
 import { BuilderLayout } from '@/apps/imagi/build/layouts'
@@ -126,6 +158,23 @@ function toggleManager() {
   try {
     localStorage.setItem(MANAGER_STORAGE_KEY, String(isManagerOpen.value))
   } catch {}
+}
+
+// Mobile view switcher: on phones the manager, chat and preview each fill the
+// screen one at a time instead of being crammed side by side.
+const { isMobile } = useWindowSize()
+type MobileView = 'manager' | 'chat' | 'browser'
+const mobileView = ref<MobileView>('chat')
+const mobileViewOptions: Array<{ value: MobileView; label: string; icon: string }> = [
+  { value: 'manager', label: 'Agents', icon: 'fas fa-layer-group' },
+  { value: 'chat', label: 'Chat', icon: 'fas fa-comment-dots' },
+  { value: 'browser', label: 'Preview', icon: 'fas fa-globe' },
+]
+function selectMobileView(view: MobileView, setSidebarCollapsed?: (collapsed: boolean) => void) {
+  mobileView.value = view
+  // The browser lives in the main content area, so it shows when the sidebar
+  // (manager + chat) is collapsed off-screen; manager/chat show when it's open.
+  setSidebarCollapsed?.(view === 'browser')
 }
 
 // Version history state and actions

--- a/frontend/vuejs/src/shared/layouts/DashboardLayout.vue
+++ b/frontend/vuejs/src/shared/layouts/DashboardLayout.vue
@@ -12,7 +12,9 @@
               ? 'w-[36rem] bg-white dark:bg-dark-950/95 backdrop-blur-md'
               : (wide
                 ? 'w-80 bg-white dark:bg-dark-950/95 backdrop-blur-md'
-                : 'w-72 bg-white dark:bg-dark-950/95 backdrop-blur-md'))
+                : 'w-72 bg-white dark:bg-dark-950/95 backdrop-blur-md')),
+          mobileOverlay ? 'max-md:top-16 max-md:w-full' : '',
+          mobileOverlay ? (isSidebarCollapsed ? 'max-md:-translate-x-full' : 'max-md:translate-x-0') : ''
         ]"
       >
         <!-- Logo and Brand -->
@@ -81,12 +83,18 @@
       <!-- Main content -->
       <div
         class="flex-1 flex flex-col min-h-screen transition-all duration-300 ease-in-out"
-        :class="[isSidebarCollapsed ? 'ml-16' : (extraWide ? 'ml-[36rem]' : (wide ? 'ml-80' : 'ml-72'))]"
+        :class="[
+          isSidebarCollapsed ? 'ml-16' : (extraWide ? 'ml-[36rem]' : (wide ? 'ml-80' : 'ml-72')),
+          mobileOverlay ? 'max-md:ml-0' : ''
+        ]"
       >
         <!-- Navbar -->
         <BaseNavbar
           class="fixed top-0 right-0 z-20 bg-white/80 dark:bg-dark-900/80 backdrop-blur-md border-b border-gray-200 dark:border-dark-800/70 shadow-sm"
-          :class="[isSidebarCollapsed ? 'left-16' : (extraWide ? 'left-[36rem]' : (wide ? 'left-80' : 'left-72'))]"
+          :class="[
+            isSidebarCollapsed ? 'left-16' : (extraWide ? 'left-[36rem]' : (wide ? 'left-80' : 'left-72')),
+            mobileOverlay ? 'max-md:left-0' : ''
+          ]"
         >
           <template #left>
             <!-- Navbar left section -->
@@ -94,13 +102,23 @@
           <template #center>
             <!-- Pass through a navbar-center slot for centered content -->
             <div class="flex items-center justify-center">
-              <slot name="navbar-center"></slot>
+              <slot
+                name="navbar-center"
+                :isSidebarCollapsed="isSidebarCollapsed"
+                :toggleSidebar="toggleSidebar"
+                :setSidebarCollapsed="setSidebarCollapsed"
+              ></slot>
             </div>
           </template>
           <template #right>
             <!-- Pass through the navbar-right slot with proper spacing -->
             <div class="flex items-center justify-end pe-6">
-              <slot name="navbar-right"></slot>
+              <slot
+                name="navbar-right"
+                :isSidebarCollapsed="isSidebarCollapsed"
+                :toggleSidebar="toggleSidebar"
+                :setSidebarCollapsed="setSidebarCollapsed"
+              ></slot>
             </div>
           </template>
         </BaseNavbar>
@@ -138,11 +156,16 @@ const props = defineProps<{
   wide?: boolean
   extraWide?: boolean
   compactTop?: boolean
+  // When true, the sidebar becomes a full-screen off-canvas overlay on mobile
+  // (< md) instead of squeezing the main content. Opt-in so other layouts keep
+  // their current behaviour.
+  mobileOverlay?: boolean
 }>()
 
 const wide = computed(() => !!props.wide)
 const extraWide = computed(() => !!props.extraWide)
 const compactTop = computed(() => !!props.compactTop)
+const mobileOverlay = computed(() => !!props.mobileOverlay)
 
 const route = useRoute()
 const router = useRouter()
@@ -163,8 +186,13 @@ const isActivePath = (item: NavigationItem): boolean => {
 
 // Toggle sidebar collapsed state
 const toggleSidebar = () => {
-  isSidebarCollapsed.value = !isSidebarCollapsed.value
-  
+  setSidebarCollapsed(!isSidebarCollapsed.value)
+}
+
+// Set the sidebar collapsed state directly (used by the mobile view switcher)
+const setSidebarCollapsed = (collapsed: boolean) => {
+  isSidebarCollapsed.value = collapsed
+
   // Save preference if storage key is provided
   if (props.storageKey) {
     localStorage.setItem(props.storageKey, isSidebarCollapsed.value ? 'true' : 'false')


### PR DESCRIPTION
Mobile responsiveness: on phones (< md) the agent manager, agent instance
chat, and browser preview no longer share the screen at once. A segmented
view switcher in the navbar lets one view fill the screen at a time.

- DashboardLayout gains an opt-in `mobileOverlay` prop: on < md the sidebar
  becomes a full-screen off-canvas overlay below the navbar and the main
  content drops its left margin so the browser preview fills the width.
  Desktop/tablet layout and the docs layout are unchanged.
- DashboardLayout exposes sidebar controls (setSidebarCollapsed/toggleSidebar)
  to the navbar slots so the workspace can drive the mobile view switch.
- Workspace adds the Agents / Chat / Preview switcher (icon-only, md:hidden)
  and shows a single sidebar sub-view at a time on mobile. Desktop-only
  collapse/toggle affordances are hidden on mobile.

Preview address bar: slimmed the combined app/page selector into a slender
pill (shorter height, rounded-full, lighter styling, animated chevron) and
made the navigation buttons smaller circular icons to match.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018nD5vTekRYpF1PjsA2hwYm