### PR TITLE
Make build workspace responsive on mobile and slim the preview address bar

### DIFF
--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspacePreview.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspacePreview.vue
@@ -57,7 +57,7 @@
 
           <div
             v-if="menuOpen && apps.length > 0"
-            class="absolute z-20 mt-1.5 left-0 min-w-[14rem] rounded-xl border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-[#0f0f0f] shadow-xl py-1"
+            class="absolute z-20 mt-1.5 left-0 max-md:left-auto max-md:right-0 min-w-[14rem] max-md:max-w-[calc(100vw-1.5rem)] rounded-xl border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-[#0f0f0f] shadow-xl py-1"
           >
             <div
               v-for="app in apps"
@@ -75,12 +75,15 @@
                   <i class="fas fa-cube text-xs text-blue-950/50 dark:text-white/50"></i>
                   {{ app.title }}
                 </span>
-                <i class="fas fa-chevron-right text-[10px] text-blue-950/40 dark:text-white/40"></i>
+                <i
+                  class="fas fa-chevron-right text-[10px] text-blue-950/40 dark:text-white/40 transition-transform duration-200"
+                  :class="{ 'max-md:rotate-90': hoveredApp === app.name }"
+                ></i>
               </button>
 
               <div
                 v-if="hoveredApp === app.name && app.pages.length"
-                class="absolute top-0 left-full ml-1 min-w-[14rem] rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-[#0f0f0f] shadow-lg py-1"
+                class="py-1 md:absolute md:top-0 md:left-full md:ml-1 md:min-w-[14rem] md:rounded-lg md:border md:border-blue-200/60 md:dark:border-white/[0.08] md:bg-white md:dark:bg-[#0f0f0f] md:shadow-lg max-md:ml-4 max-md:mt-0.5 max-md:mb-1 max-md:border-l max-md:border-blue-100 max-md:dark:border-white/[0.08]"
                 @mouseenter="onAppEnter(app.name)"
                 @mouseleave="onAppLeave(app.name)"
               >

--- a/frontend/vuejs/src/apps/imagi/build/layouts/BuilderLayout.vue
+++ b/frontend/vuejs/src/apps/imagi/build/layouts/BuilderLayout.vue
@@ -12,6 +12,9 @@
     </template>
 
     <!-- Pass through any navbar content from parent, forwarding sidebar controls -->
+    <template #navbar-left="slotProps">
+      <slot name="navbar-left" v-bind="slotProps"></slot>
+    </template>
     <template #navbar-center="slotProps">
       <slot name="navbar-center" v-bind="slotProps"></slot>
     </template>

--- a/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
+++ b/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
@@ -37,10 +37,12 @@
         </div>
       </template>
 
-      <!-- Mobile-only view switcher: fill the screen with one view at a time -->
-      <template #navbar-center="{ setSidebarCollapsed }">
+      <!-- Mobile-only view switcher: fill the screen with one view at a time.
+           Lives on the left (next to the logo) so it never overlaps the
+           balance in the top-right corner on narrow screens. -->
+      <template #navbar-left="{ setSidebarCollapsed }">
         <div
-          class="md:hidden flex items-center gap-0.5 rounded-lg border border-blue-100 dark:border-white/[0.08] bg-blue-50/70 dark:bg-white/[0.05] p-0.5"
+          class="md:hidden ml-2 flex items-center gap-0.5 rounded-lg border border-blue-100 dark:border-white/[0.08] bg-blue-50/70 dark:bg-white/[0.05] p-0.5"
           role="tablist"
           aria-label="Workspace view"
         >

--- a/frontend/vuejs/src/shared/layouts/DashboardLayout.vue
+++ b/frontend/vuejs/src/shared/layouts/DashboardLayout.vue
@@ -97,7 +97,12 @@
           ]"
         >
           <template #left>
-            <!-- Navbar left section -->
+            <slot
+              name="navbar-left"
+              :isSidebarCollapsed="isSidebarCollapsed"
+              :toggleSidebar="toggleSidebar"
+              :setSidebarCollapsed="setSidebarCollapsed"
+            ></slot>
           </template>
           <template #center>
             <!-- Pass through a navbar-center slot for centered content -->


### PR DESCRIPTION
## Summary

Two improvements to the build workspace, focused on mobile usability and the browser preview toolbar.

### 1. Responsive mobile layout — one view fills the screen
The workspace has three views: the **Agent Manager** (instance list), the **Agent Instance chat**, and the **Browser** preview. On desktop/iPad (≥ 768px) nothing changes — they stay side by side. On phones (< 768px) they no longer share the cramped screen at once:

- The sidebar (manager + chat) becomes a full-screen off-canvas overlay below the navbar, and the main content drops its left margin so the browser preview fills the width.
- A segmented **Agents / Chat / Preview** switcher (icon-only, `md:hidden`) lets one view fill the screen at a time.
- Desktop-only collapse/toggle affordances are hidden on mobile since the switcher governs navigation there.

This is done via an opt-in `mobileOverlay` prop on the shared `DashboardLayout` (the docs layout — the only other consumer — is untouched), which also exposes the sidebar controls to the navbar slots so the workspace can drive the switch.

### 2. Sleeker, slimmer preview address bar
In the browser preview toolbar, the combined app/page selector is now a slender pill (shorter height, `rounded-full`, lighter styling, animated chevron), and the back/forward/refresh/home buttons are smaller circular icon buttons to match.

## Follow-up fixes (review feedback)
- **Navbar overlap:** moved the mobile view switcher from the navbar center to the left (next to the logo) so it never overlaps the account balance in the top-right corner on narrow screens.
- **Off-screen page dropdown:** the preview's pages submenu (e.g. Log in, Register) previously flew out to the right and was clipped off-screen on mobile. It now stacks inline as an indented accordion on mobile (with the app chevron rotating to indicate expansion), while keeping the desktop right-side flyout. The app menu also anchors to the right and is width-capped on mobile so it stays on-screen.

## Changed files
- `frontend/vuejs/src/shared/layouts/DashboardLayout.vue` — opt-in mobile off-canvas overlay; expose `navbar-left`/`navbar-center`/`navbar-right` slot controls
- `frontend/vuejs/src/apps/imagi/build/layouts/BuilderLayout.vue` — enable `mobile-overlay`; forward navbar slots
- `frontend/vuejs/src/apps/imagi/build/views/Workspace.vue` — mobile view switcher + per-view visibility
- `frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/AgentManagerPanel.vue` — hide desktop-only collapse on mobile
- `frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue` — hide desktop-only toggles on mobile
- `frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspacePreview.vue` — slimmer address bar; mobile-friendly page dropdown

## Testing
- `npm run type-check` — passes
- `npm run build-only` — passes

Not yet verified in a running authenticated workspace (the live preview server isn't reachable in the dev environment), so a quick check on a phone is worthwhile to confirm the switcher placement and the page accordion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nD5vTekRYpF1PjsA2hwYm

---
_Generated by [Claude Code](https://claude.ai/code/session_018nD5vTekRYpF1PjsA2hwYm)_