### PR TITLE
Fill the workspace preview to the screen, fix touch scroll and page titles

### DIFF
--- a/backend/django/apps/Imagi/Build/services/pages_service.py
+++ b/backend/django/apps/Imagi/Build/services/pages_service.py
@@ -115,10 +115,22 @@ def _join_paths(parent, child):
     return (parent.rstrip('/') or '') + '/' + child
 
 
+# Concatenated route segments whose humanized form would read as one word
+# ("signin" -> "Signin"). Map them to their natural multi-word titles.
+_SEGMENT_ALIASES = {
+    'signin': 'Sign In',
+    'signup': 'Sign Up',
+    'signout': 'Sign Out',
+}
+
+
 def _page_title(path):
     segment = path.rstrip('/').rsplit('/', 1)[-1]
     if not segment:
         return 'Home'
+    alias = _SEGMENT_ALIASES.get(segment.lower())
+    if alias:
+        return alias
     return _humanize(segment)
 
 

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspacePreview.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspacePreview.vue
@@ -112,10 +112,11 @@
     <div
       ref="screenRef"
       tabindex="0"
-      class="relative flex-1 min-h-0 bg-white outline-none overflow-hidden"
+      class="relative flex-1 min-h-0 bg-white outline-none overflow-hidden touch-none"
       @pointerdown="onPointerDown"
       @pointermove="onPointerMove"
       @pointerup="onPointerUp"
+      @pointercancel="onPointerCancel"
       @wheel.prevent="onWheel"
       @keydown="onKeyDown"
       @keyup="onKeyUp"
@@ -367,10 +368,29 @@ async function flushInput() {
 
 const BUTTON_NAMES: Array<'left' | 'middle' | 'right'> = ['left', 'middle', 'right']
 
+// A touch drag scrolls the previewed app (forwarded as wheel deltas) the way a
+// finger scrolls a native page, instead of being sent as a mouse drag. A touch
+// that barely moves is treated as a tap and forwarded as a click so buttons and
+// links still work.
+const TOUCH_TAP_SLOP = 8 // page px of travel before a touch becomes a scroll
+let touchDrag: {
+  pointerId: number
+  startX: number
+  startY: number
+  lastX: number
+  lastY: number
+  scrolling: boolean
+} | null = null
+
 function onPointerDown(e: PointerEvent) {
   screenRef.value?.focus()
   if (phase.value !== 'ready') return
   const { x, y } = pageCoords(e)
+  if (e.pointerType === 'touch') {
+    touchDrag = { pointerId: e.pointerId, startX: x, startY: y, lastX: x, lastY: y, scrolling: false }
+    try { screenRef.value?.setPointerCapture(e.pointerId) } catch {}
+    return
+  }
   enqueue({
     kind: 'mouse',
     type: 'mousePressed',
@@ -385,6 +405,21 @@ function onPointerDown(e: PointerEvent) {
 function onPointerMove(e: PointerEvent) {
   if (phase.value !== 'ready') return
   const { x, y } = pageCoords(e)
+  if (touchDrag && e.pointerId === touchDrag.pointerId) {
+    const dx = x - touchDrag.lastX
+    const dy = y - touchDrag.lastY
+    if (!touchDrag.scrolling &&
+        Math.hypot(x - touchDrag.startX, y - touchDrag.startY) > TOUCH_TAP_SLOP) {
+      touchDrag.scrolling = true
+    }
+    if (touchDrag.scrolling && (dx !== 0 || dy !== 0)) {
+      // Wheel delta is opposite the finger travel: drag up -> scroll down.
+      enqueue({ kind: 'wheel', x, y, deltaX: -dx, deltaY: -dy, modifiers: 0 })
+    }
+    touchDrag.lastX = x
+    touchDrag.lastY = y
+    return
+  }
   enqueue({
     kind: 'mouse',
     type: 'mouseMoved',
@@ -398,6 +433,16 @@ function onPointerMove(e: PointerEvent) {
 function onPointerUp(e: PointerEvent) {
   if (phase.value !== 'ready') return
   const { x, y } = pageCoords(e)
+  if (touchDrag && e.pointerId === touchDrag.pointerId) {
+    const wasTap = !touchDrag.scrolling
+    touchDrag = null
+    try { screenRef.value?.releasePointerCapture(e.pointerId) } catch {}
+    if (wasTap) {
+      enqueue({ kind: 'mouse', type: 'mousePressed', x, y, button: 'left', buttons: 1, clickCount: 1, modifiers: modifiersFrom(e) }, true)
+      enqueue({ kind: 'mouse', type: 'mouseReleased', x, y, button: 'left', buttons: 0, clickCount: 1, modifiers: modifiersFrom(e) }, true)
+    }
+    return
+  }
   enqueue({
     kind: 'mouse',
     type: 'mouseReleased',
@@ -407,6 +452,13 @@ function onPointerUp(e: PointerEvent) {
     clickCount: Math.max(1, e.detail),
     modifiers: modifiersFrom(e),
   }, true)
+}
+
+function onPointerCancel(e: PointerEvent) {
+  if (touchDrag && e.pointerId === touchDrag.pointerId) {
+    touchDrag = null
+    try { screenRef.value?.releasePointerCapture(e.pointerId) } catch {}
+  }
 }
 
 function onWheel(e: WheelEvent) {

--- a/frontend/vuejs/src/apps/imagi/build/layouts/BuilderLayout.vue
+++ b/frontend/vuejs/src/apps/imagi/build/layouts/BuilderLayout.vue
@@ -6,6 +6,7 @@
     :extra-wide="extraWide"
     compact-top
     mobile-overlay
+    app-shell
   >
     <template #sidebar-content="{ isSidebarCollapsed, toggleSidebar }">
       <slot name="sidebar-content" :collapsed="isSidebarCollapsed" :toggle-sidebar="toggleSidebar"></slot>

--- a/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
+++ b/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
@@ -75,8 +75,10 @@
         </div>
       </template>
 
-      <!-- Clean Main Content Area - Matching Homepage -->
-      <div class="flex flex-col h-screen max-h-screen w-full overflow-x-hidden overflow-y-hidden bg-white dark:bg-[#0a0a0a] relative transition-colors duration-500">
+      <!-- Clean Main Content Area - fills the viewport below the navbar.
+           Uses dynamic viewport height (dvh) so it fills correctly on mobile
+           as the browser chrome shows/hides, minus the 4rem navbar. -->
+      <div class="flex flex-col w-full overflow-hidden bg-white dark:bg-[#0a0a0a] relative transition-colors duration-500 h-[calc(100dvh-4rem)]">
         <!-- Enhanced Error State Display -->
         <WorkspaceError v-if="store.error" :error="store.error" @retry="retryProjectLoad" />
 

--- a/frontend/vuejs/src/shared/layouts/DashboardLayout.vue
+++ b/frontend/vuejs/src/shared/layouts/DashboardLayout.vue
@@ -133,8 +133,8 @@
           <slot :isSidebarCollapsed="isSidebarCollapsed"></slot>
         </main>
 
-        <!-- Footer -->
-        <BaseFooter class="border-t border-gray-200 dark:border-dark-800/70 bg-gray-50 dark:bg-dark-900/50 backdrop-blur-sm" />
+        <!-- Footer (hidden for full-screen app-shell views like the builder) -->
+        <BaseFooter v-if="!appShell" class="border-t border-gray-200 dark:border-dark-800/70 bg-gray-50 dark:bg-dark-900/50 backdrop-blur-sm" />
       </div>
     </div>
   </BaseLayout>
@@ -165,12 +165,16 @@ const props = defineProps<{
   // (< md) instead of squeezing the main content. Opt-in so other layouts keep
   // their current behaviour.
   mobileOverlay?: boolean
+  // When true, this is a full-screen app shell (e.g. the builder workspace):
+  // the site footer is dropped so the content fills the viewport exactly.
+  appShell?: boolean
 }>()
 
 const wide = computed(() => !!props.wide)
 const extraWide = computed(() => !!props.extraWide)
 const compactTop = computed(() => !!props.compactTop)
 const mobileOverlay = computed(() => !!props.mobileOverlay)
+const appShell = computed(() => !!props.appShell)
 
 const route = useRoute()
 const router = useRouter()


### PR DESCRIPTION
Follow-up to #60 (merged), addressing three issues in the build workspace — mostly noticed on mobile, but the fixes apply across screen sizes.

## 1. Browser view now fills the screen
The large site footer sat below the preview, making the workspace page taller than the viewport — so the browser view looked boxed-in and the page scrolled instead of the app.
- Added an opt-in `app-shell` prop to the shared `DashboardLayout` (set by `BuilderLayout`) that drops the site footer for full-screen views. The docs layout keeps its footer.
- The workspace content now sizes to `calc(100dvh - 4rem)`, filling the area below the navbar exactly. Using `dvh` (dynamic viewport height) keeps it correct on mobile as the browser chrome shows/hides.

## 2. Touch scrolling in the preview
A touch drag was forwarded to the previewed app as a **mouse drag** (selecting/dragging), making it nearly impossible to scroll on a phone.
- Touch drags are now translated into **wheel/scroll events**, so the app scrolls under the finger like a native page.
- A quick tap is still forwarded as a **click**, so buttons and links work.
- The screen uses `touch-action: none` with pointer capture so drags track cleanly. Mouse/trackpad behavior is unchanged.

## 3. "Signin" → "Sign In" in the page dropdown
The preview's page dropdown showed the run-together route name `signin` as "Signin". The backend page-title humanizer now maps `signin`/`signup`/`signout` to their natural two-word titles ("Sign In", "Sign Up", "Sign Out"). `login`/`register` are unaffected.

## Changed files
- `frontend/vuejs/src/shared/layouts/DashboardLayout.vue` — `app-shell` prop hides the footer for full-screen views
- `frontend/vuejs/src/apps/imagi/build/layouts/BuilderLayout.vue` — enable `app-shell`
- `frontend/vuejs/src/apps/imagi/build/views/Workspace.vue` — content fills `calc(100dvh - 4rem)`
- `frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspacePreview.vue` — touch drag-to-scroll / tap-to-click
- `backend/django/apps/Imagi/Build/services/pages_service.py` — two-word titles for sign in/up/out

## Testing
- `npm run type-check`, `npm run build-only` — pass
- `npx vitest run` — 56 pass (the 15 reported errors are a pre-existing jsdom `scrollTo` stub in `ChatConversation.vue`, unrelated to this change)
- Backend humanizer verified: `signin` → "Sign In", `login` → "Login", `register` → "Register"

Not verified in a running authenticated workspace with a live preview server (not reachable in the dev environment), so a check on a phone is worthwhile to confirm the fill and touch scrolling feel right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nD5vTekRYpF1PjsA2hwYm

---
_Generated by [Claude Code](https://claude.ai/code/session_018nD5vTekRYpF1PjsA2hwYm)_