### PR TITLE
Center the mobile view switcher, smooth preview scrolling, and fill the app to the pane width

### DIFF
--- a/frontend/vuejs/src/apps/imagi/build/components/molecules/display/AccountBalanceDisplay.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/molecules/display/AccountBalanceDisplay.vue
@@ -118,7 +118,6 @@ onBeforeUnmount(() => {
 .account-balance-display {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   transition: all 0.3s ease;
-  margin-right: 1.5rem;
 }
 
 /* Card base */

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspacePreview.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspacePreview.vue
@@ -258,6 +258,12 @@ async function startPreview() {
     applyFrame(result)
     phase.value = 'ready'
     schedulePoll(200)
+    // The size passed to start() can be stale — measured before the pane was
+    // laid out, which falls back to a desktop width and makes the app render
+    // its desktop layout squished into a phone. The ResizeObserver won't fix
+    // it because the pane size never actually changes, so re-assert the
+    // viewport against the now-laid-out pane once we're ready.
+    requestAnimationFrame(() => void ensureViewportMatchesPane())
     // Starting may have scaffolded/hydrated the working copy the pages
     // menu reads from, so fetch it (again) now.
     void refreshPages()
@@ -371,23 +377,80 @@ const BUTTON_NAMES: Array<'left' | 'middle' | 'right'> = ['left', 'middle', 'rig
 // A touch drag scrolls the previewed app (forwarded as wheel deltas) the way a
 // finger scrolls a native page, instead of being sent as a mouse drag. A touch
 // that barely moves is treated as a tap and forwarded as a click so buttons and
-// links still work.
-const TOUCH_TAP_SLOP = 8 // page px of travel before a touch becomes a scroll
+// links still work. When the finger lifts we keep emitting decaying wheel
+// deltas (momentum) so the page glides to a stop instead of stopping dead —
+// the streamed preview has no native inertial scrolling of its own.
+const TOUCH_TAP_SLOP = 8       // page px of travel before a touch becomes a scroll
+const INERTIA_FRICTION = 0.94  // fraction of velocity kept each animation frame
+const INERTIA_MIN_SPEED = 0.03 // px/ms; the glide ends below this
+const INERTIA_MAX_SPEED = 4     // px/ms; caps a hard flick so it stays controllable
 let touchDrag: {
   pointerId: number
   startX: number
   startY: number
   lastX: number
   lastY: number
+  lastT: number
+  vx: number
+  vy: number
   scrolling: boolean
+  stoppedInertia: boolean
 } | null = null
+
+let inertiaRaf: number | null = null
+let inertiaX = 0
+let inertiaY = 0
+let inertiaVx = 0
+let inertiaVy = 0
+let inertiaLastT = 0
+
+function stopInertia() {
+  if (inertiaRaf !== null) {
+    cancelAnimationFrame(inertiaRaf)
+    inertiaRaf = null
+  }
+}
+
+function startInertia(x: number, y: number, vx: number, vy: number) {
+  stopInertia()
+  inertiaX = x
+  inertiaY = y
+  inertiaVx = Math.max(-INERTIA_MAX_SPEED, Math.min(vx, INERTIA_MAX_SPEED))
+  inertiaVy = Math.max(-INERTIA_MAX_SPEED, Math.min(vy, INERTIA_MAX_SPEED))
+  if (Math.hypot(inertiaVx, inertiaVy) < INERTIA_MIN_SPEED) return
+  inertiaLastT = performance.now()
+  const step = () => {
+    inertiaRaf = null
+    if (disposed || phase.value !== 'ready') return
+    const now = performance.now()
+    const dt = Math.min(32, now - inertiaLastT)
+    inertiaLastT = now
+    inertiaVx *= INERTIA_FRICTION
+    inertiaVy *= INERTIA_FRICTION
+    if (Math.hypot(inertiaVx, inertiaVy) < INERTIA_MIN_SPEED) return
+    // Same convention as a drag: wheel delta is opposite the finger travel.
+    enqueue({ kind: 'wheel', x: inertiaX, y: inertiaY, deltaX: -inertiaVx * dt, deltaY: -inertiaVy * dt, modifiers: 0 })
+    inertiaRaf = requestAnimationFrame(step)
+  }
+  inertiaRaf = requestAnimationFrame(step)
+}
 
 function onPointerDown(e: PointerEvent) {
   screenRef.value?.focus()
   if (phase.value !== 'ready') return
   const { x, y } = pageCoords(e)
   if (e.pointerType === 'touch') {
-    touchDrag = { pointerId: e.pointerId, startX: x, startY: y, lastX: x, lastY: y, scrolling: false }
+    const stoppedInertia = inertiaRaf !== null
+    stopInertia()
+    touchDrag = {
+      pointerId: e.pointerId,
+      startX: x, startY: y,
+      lastX: x, lastY: y,
+      lastT: e.timeStamp,
+      vx: 0, vy: 0,
+      scrolling: false,
+      stoppedInertia,
+    }
     try { screenRef.value?.setPointerCapture(e.pointerId) } catch {}
     return
   }
@@ -415,9 +478,14 @@ function onPointerMove(e: PointerEvent) {
     if (touchDrag.scrolling && (dx !== 0 || dy !== 0)) {
       // Wheel delta is opposite the finger travel: drag up -> scroll down.
       enqueue({ kind: 'wheel', x, y, deltaX: -dx, deltaY: -dy, modifiers: 0 })
+      // Track a smoothed finger velocity (px/ms) to seed the release glide.
+      const dt = Math.max(1, e.timeStamp - touchDrag.lastT)
+      touchDrag.vx = touchDrag.vx * 0.7 + (dx / dt) * 0.3
+      touchDrag.vy = touchDrag.vy * 0.7 + (dy / dt) * 0.3
     }
     touchDrag.lastX = x
     touchDrag.lastY = y
+    touchDrag.lastT = e.timeStamp
     return
   }
   enqueue({
@@ -434,10 +502,14 @@ function onPointerUp(e: PointerEvent) {
   if (phase.value !== 'ready') return
   const { x, y } = pageCoords(e)
   if (touchDrag && e.pointerId === touchDrag.pointerId) {
-    const wasTap = !touchDrag.scrolling
+    const drag = touchDrag
     touchDrag = null
     try { screenRef.value?.releasePointerCapture(e.pointerId) } catch {}
-    if (wasTap) {
+    if (drag.scrolling) {
+      // Let the page keep gliding from the finger's release velocity.
+      startInertia(drag.lastX, drag.lastY, drag.vx, drag.vy)
+    } else if (!drag.stoppedInertia) {
+      // A genuine tap (not a tap that just halted a glide) becomes a click.
       enqueue({ kind: 'mouse', type: 'mousePressed', x, y, button: 'left', buttons: 1, clickCount: 1, modifiers: modifiersFrom(e) }, true)
       enqueue({ kind: 'mouse', type: 'mouseReleased', x, y, button: 'left', buttons: 0, clickCount: 1, modifiers: modifiersFrom(e) }, true)
     }
@@ -543,22 +615,27 @@ function reload() {
 // Pane size -> remote viewport
 // ---------------------------------------------------------------------------
 
+// Resize the remote browser to match the pane's current CSS size, so the
+// previewed app renders (and fills) at the real display width. No-op when it
+// already matches.
+async function ensureViewportMatchesPane() {
+  if (disposed || phase.value !== 'ready') return
+  const { width, height } = paneSize()
+  const [vw, vh] = viewport.value
+  if (Math.abs(width - vw) < 4 && Math.abs(height - vh) < 4) return
+  try {
+    await PreviewService.resize(props.projectId, width, height, deviceScaleFactor)
+    viewport.value = [width, height]
+    etag.value = undefined // force a fresh frame at the new size
+    schedulePoll(100)
+  } catch (e) {
+    if (e instanceof PreviewNotRunningError) markSessionStopped()
+  }
+}
+
 function onPaneResized() {
   if (resizeTimer) window.clearTimeout(resizeTimer)
-  resizeTimer = window.setTimeout(async () => {
-    if (disposed || phase.value !== 'ready') return
-    const { width, height } = paneSize()
-    const [vw, vh] = viewport.value
-    if (Math.abs(width - vw) < 4 && Math.abs(height - vh) < 4) return
-    try {
-      await PreviewService.resize(props.projectId, width, height, deviceScaleFactor)
-      viewport.value = [width, height]
-      etag.value = undefined // force a fresh frame at the new size
-      schedulePoll(100)
-    } catch (e) {
-      if (e instanceof PreviewNotRunningError) markSessionStopped()
-    }
-  }, 350)
+  resizeTimer = window.setTimeout(() => void ensureViewportMatchesPane(), 350)
 }
 
 // ---------------------------------------------------------------------------
@@ -678,6 +755,7 @@ onBeforeUnmount(() => {
   if (pollTimer) window.clearTimeout(pollTimer)
   if (resizeTimer) window.clearTimeout(resizeTimer)
   if (flushTimer) window.clearTimeout(flushTimer)
+  stopInertia()
   observer?.disconnect()
 })
 

--- a/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
+++ b/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
@@ -37,12 +37,13 @@
         </div>
       </template>
 
-      <!-- Mobile-only view switcher: fill the screen with one view at a time.
-           Lives on the left (next to the logo) so it never overlaps the
-           balance in the top-right corner on narrow screens. -->
-      <template #navbar-left="{ setSidebarCollapsed }">
+      <!-- Mobile-only view switcher, centered in the navbar: the logo sits in
+           the top-left corner and the balance in the top-right, with this
+           switcher (agent manager / instance / browser) centered between them.
+           One view fills the screen at a time. -->
+      <template #navbar-center="{ setSidebarCollapsed }">
         <div
-          class="md:hidden ml-2 flex items-center gap-0.5 rounded-lg border border-blue-100 dark:border-white/[0.08] bg-blue-50/70 dark:bg-white/[0.05] p-0.5"
+          class="md:hidden flex items-center gap-0.5 rounded-lg border border-blue-100 dark:border-white/[0.08] bg-blue-50/70 dark:bg-white/[0.05] p-0.5"
           role="tablist"
           aria-label="Workspace view"
         >

--- a/frontend/vuejs/src/shared/layouts/DashboardLayout.vue
+++ b/frontend/vuejs/src/shared/layouts/DashboardLayout.vue
@@ -116,8 +116,9 @@
             </div>
           </template>
           <template #right>
-            <!-- Pass through the navbar-right slot with proper spacing -->
-            <div class="flex items-center justify-end pe-6">
+            <!-- Pass through the navbar-right slot; sits flush in the corner
+                 (mirroring the logo on the left) with no extra end padding. -->
+            <div class="flex items-center justify-end">
               <slot
                 name="navbar-right"
                 :isSidebarCollapsed="isSidebarCollapsed"


### PR DESCRIPTION
Follow-up to #61 (merged), refining the mobile workspace navbar and the browser preview.

## 1. Navbar layout: logo left / switcher centered / balance right
Restored a symmetric navbar on mobile:
- The Imagi logo stays in the **top-left** corner.
- The **Agents / Chat / Preview** view switcher moved back to the **navbar center** so it's centered between the logo and the balance.
- The **account balance** now sits flush in the **top-right** corner, mirroring the logo. Its right margin and the navbar's end padding were removed so it reaches the corner; with the balance further right, the centered switcher no longer overlaps it on narrow screens.

## 2. Smoother preview scrolling (momentum)
Touch scrolling stopped dead when the finger lifted and felt choppy. Added **inertia**: on release the previewed page keeps gliding from the finger's velocity and decelerates with friction, so scrolling feels natural. A tap that halts a glide stops it without also firing a click (mirroring native behavior).

## 3. App fills the pane width
The preview could render at the desktop default viewport (when the pane was measured before layout settled) and stay stuck there — because the `ResizeObserver` never re-fires when the pane size doesn't actually change — leaving the desktop layout squished into a phone. The remote viewport is now **re-asserted against the laid-out pane once the preview is ready**, so the app renders and fills at the real display width. The resize logic was extracted into a shared `ensureViewportMatchesPane()`.

## Changed files
- `frontend/vuejs/src/apps/imagi/build/views/Workspace.vue` — center the mobile view switcher
- `frontend/vuejs/src/shared/layouts/DashboardLayout.vue` — remove navbar-right end padding
- `frontend/vuejs/src/apps/imagi/build/components/molecules/display/AccountBalanceDisplay.vue` — remove right margin so the balance sits in the corner
- `frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspacePreview.vue` — scroll momentum + viewport re-sync on ready

## Testing
- `npm run type-check`, `npm run build-only` — pass
- `npx vitest run` — 56 pass (the 15 reported errors are a pre-existing jsdom `scrollTo` stub in `ChatConversation.vue`, unrelated)

Best verified on a phone: confirm the centered switcher / corner balance, the scroll glide, and that the app fills side-to-side. If it still doesn't fill after the viewport re-sync, the remaining cause would be the generated app's own non-responsive CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nD5vTekRYpF1PjsA2hwYm

---
_Generated by [Claude Code](https://claude.ai/code/session_018nD5vTekRYpF1PjsA2hwYm)_