### PR TITLE
Fix the browser pane showing behind the workspace views on mobile

### DIFF
--- a/frontend/vuejs/src/apps/imagi/build/layouts/BuilderLayout.vue
+++ b/frontend/vuejs/src/apps/imagi/build/layouts/BuilderLayout.vue
@@ -23,9 +23,11 @@
       <slot name="navbar-right" v-bind="slotProps"></slot>
     </template>
 
-    <div class="flex flex-col h-full w-full">
-      <slot></slot>
-    </div>
+    <template #default="{ isSidebarCollapsed }">
+      <div class="flex flex-col h-full w-full">
+        <slot :isSidebarCollapsed="isSidebarCollapsed"></slot>
+      </div>
+    </template>
   </DashboardLayout>
 </template>
 

--- a/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
+++ b/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
@@ -29,7 +29,7 @@
             :on-model-select="handleModelSelect"
             :on-effort-select="handleEffortSelect"
             :on-example-prompt="handleExamplePrompt"
-            :on-collapse-sidebar="toggleSidebar"
+            :on-collapse-sidebar="() => collapseSidebar(toggleSidebar)"
             :is-collapsed="false"
             :is-manager-open="isManagerOpen"
             @toggle-manager="toggleManager"
@@ -79,15 +79,25 @@
       <!-- Clean Main Content Area - fills the viewport below the navbar.
            Uses dynamic viewport height (dvh) so it fills correctly on mobile
            as the browser chrome shows/hides, minus the 4rem navbar. -->
-      <div class="flex flex-col w-full overflow-hidden bg-white dark:bg-[#0a0a0a] relative transition-colors duration-500 h-[calc(100dvh-4rem)]">
-        <!-- Enhanced Error State Display -->
-        <WorkspaceError v-if="store.error" :error="store.error" @retry="retryProjectLoad" />
+      <template #default="{ isSidebarCollapsed }">
+        <div class="flex flex-col w-full overflow-hidden bg-white dark:bg-[#0a0a0a] relative transition-colors duration-500 h-[calc(100dvh-4rem)]">
+          <!-- Enhanced Error State Display -->
+          <WorkspaceError v-if="store.error" :error="store.error" @retry="retryProjectLoad" />
 
-        <!-- Main Layout - embedded preview server -->
-        <div v-else class="flex-1 flex flex-col h-full min-h-0 overflow-hidden relative">
-          <WorkspacePreview v-if="projectId" :project-id="projectId" class="flex-1 min-h-0" />
+          <!-- Main Layout - embedded preview server. On mobile the browser pane
+               is hidden (not unmounted, so the preview session stays warm)
+               whenever the manager/chat overlay is open, so it can never peek
+               out from behind that overlay. -->
+          <div v-else class="flex-1 flex flex-col h-full min-h-0 overflow-hidden relative">
+            <WorkspacePreview
+              v-if="projectId"
+              :project-id="projectId"
+              class="flex-1 min-h-0"
+              :class="isSidebarCollapsed ? '' : 'max-md:invisible'"
+            />
+          </div>
         </div>
-      </div>
+      </template>
     </BuilderLayout>
   </div>
 </template>
@@ -169,7 +179,13 @@ function toggleManager() {
 // screen one at a time instead of being crammed side by side.
 const { isMobile } = useWindowSize()
 type MobileView = 'manager' | 'chat' | 'browser'
-const mobileView = ref<MobileView>('chat')
+// The sidebar's collapsed state is persisted (see storage-key on
+// BuilderLayout). Start on the view that matches it, otherwise a reload after
+// choosing the browser would highlight "chat" while showing the browser.
+const mobileView = ref<MobileView>(
+  (typeof localStorage !== 'undefined' &&
+    localStorage.getItem('builderWorkspaceSidebarCollapsed') === 'true') ? 'browser' : 'chat'
+)
 const mobileViewOptions: Array<{ value: MobileView; label: string; icon: string }> = [
   { value: 'manager', label: 'Agents', icon: 'fas fa-layer-group' },
   { value: 'chat', label: 'Chat', icon: 'fas fa-comment-dots' },
@@ -180,6 +196,14 @@ function selectMobileView(view: MobileView, setSidebarCollapsed?: (collapsed: bo
   // The browser lives in the main content area, so it shows when the sidebar
   // (manager + chat) is collapsed off-screen; manager/chat show when it's open.
   setSidebarCollapsed?.(view === 'browser')
+}
+
+// Collapsing the sidebar from the chat header reveals the browser pane; keep
+// the mobile view switcher pointed at it so the highlighted tab (and the
+// browser pane's visibility) match what's on screen.
+function collapseSidebar(toggleSidebar: () => void) {
+  toggleSidebar()
+  if (isMobile.value) mobileView.value = 'browser'
 }
 
 // Version history state and actions

--- a/frontend/vuejs/src/shared/layouts/DashboardLayout.vue
+++ b/frontend/vuejs/src/shared/layouts/DashboardLayout.vue
@@ -13,7 +13,7 @@
               : (wide
                 ? 'w-80 bg-white dark:bg-dark-950/95 backdrop-blur-md'
                 : 'w-72 bg-white dark:bg-dark-950/95 backdrop-blur-md')),
-          mobileOverlay ? 'max-md:top-16 max-md:w-full' : '',
+          mobileOverlay ? 'max-md:top-16 max-md:w-full max-md:bg-white max-md:dark:bg-[#0a0a0a] max-md:backdrop-blur-none' : '',
           mobileOverlay ? (isSidebarCollapsed ? 'max-md:-translate-x-full' : 'max-md:translate-x-0') : ''
         ]"
       >
@@ -229,34 +229,9 @@ onMounted(() => {
 </script>
 
 <style scoped>
-.transition-all {
-  transition-property: all;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 300ms;
-}
-
-/* Ensure content fades smoothly */
-.overflow-hidden {
-  overflow: hidden;
-}
-
-/* Smooth width transitions */
-.w-56 {
-  width: 14rem;
-}
-
-.w-16 {
-  width: 4rem;
-}
-
-/* Smooth margin transitions */
-.ml-56 {
-  margin-left: 14rem;
-}
-
-.ml-16 {
-  margin-left: 4rem;
-}
+/* Note: never redefine Tailwind utilities (.w-16, .ml-16, ...) in here. Scoped
+   rules compile with a [data-v-*] attribute selector, so they out-rank
+   responsive variants like max-md:ml-0 and silently break them. */
 
 /* Ensure tooltips in collapsed sidebar are visible */
 aside {


### PR DESCRIPTION
DashboardLayout's scoped styles redefined Tailwind utilities (.ml-16,
.w-16, .ml-56, .w-56). Scoped rules compile with a [data-v-*] attribute
selector, so they out-ranked the responsive max-md:ml-0 / max-md:w-full
overrides on the builder's mobile overlay: with the sidebar collapsed the
main pane kept a 64px left margin, squeezing the browser preview behind a
dead sidebar-colored column. Remove the redefinitions (Tailwind already
provides these classes) and leave a warning comment.

Also make the mobile view switcher airtight:
- Hide (visibility, not unmount, so the preview session stays warm) the
  browser pane whenever the manager/chat overlay is open, so it can never
  bleed through the overlay's translucent backdrop-blur background.
- Give the overlay a fully opaque background under md.
- Start the switcher on the Preview tab when the persisted sidebar state
  is collapsed, instead of highlighting Chat while showing the browser.
- Collapsing the sidebar from the chat header now also selects the
  Preview tab on mobile so the switcher matches what's on screen.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016VDv6K7wPtBcaXnJZfMnkq