### PR TITLE
Remove legacy dead code from the Build module

### DIFF
--- a/backend/django/apps/Imagi/Build/api/urls.py
+++ b/backend/django/apps/Imagi/Build/api/urls.py
@@ -12,7 +12,7 @@ from django.urls import include, path
 
 from .views import (
     # Builder workspace views
-    AIModelsView, CreateFileView, DeleteFileView,
+    CreateFileView, DeleteFileView,
     FileContentView,
     PreviewSessionView,
     ProjectPagesView,
@@ -52,9 +52,6 @@ builder_patterns = [
     path('<int:project_id>/files/create/', CreateFileView.as_view(), name='api-create-file'),
     path('<int:project_id>/files/<path:file_path>/content/', FileContentView.as_view(), name='api-file-content'),
     path('<int:project_id>/files/<path:file_path>/delete/', DeleteFileView.as_view(), name='api-delete-file'),
-
-    # Model selection endpoint
-    path('models/', AIModelsView.as_view(), name='api-ai-models'),
 
     # Version control endpoints
     path('<int:project_id>/versions/', VersionControlHistoryView.as_view(), name='api-version-history'),

--- a/backend/django/apps/Imagi/Build/api/views.py
+++ b/backend/django/apps/Imagi/Build/api/views.py
@@ -28,7 +28,7 @@ from ..services.base_agent import ImagiAgentService, DEFAULT_MODEL
 from ..services.create_file_service import CreateFileService
 from ..services.view_file_service import ViewFileService
 from ..services.delete_file_service import DeleteFileService
-from ..services.models_service import ModelsService, get_model_by_id
+from ..services.models_service import get_model_by_id
 from ..services.browser_preview_service import (
     BrowserNotRunning,
     BrowserPreviewError,
@@ -79,16 +79,6 @@ class ProjectDirectoriesView(APIView):
         except Exception:
             logger.exception("Error listing project files")
             raise
-
-@method_decorator(never_cache, name='dispatch')
-class AIModelsView(APIView):
-    """Get available AI models."""
-    permission_classes = [IsAuthenticated]
-
-    def get(self, request):
-        models_service = ModelsService()
-        models = models_service.get_available_models()
-        return Response({'models': models})
 
 @method_decorator(never_cache, name='dispatch')
 class FileContentView(APIView):

--- a/backend/django/apps/Imagi/Build/services/models_service.py
+++ b/backend/django/apps/Imagi/Build/services/models_service.py
@@ -5,12 +5,9 @@ This module provides centralized definitions for all AI models used across the a
 ensuring that model information (IDs, names, costs, etc.) is maintained in a single location.
 """
 
-import logging
-from typing import List, Tuple, Dict, Any
+from typing import List, Tuple
 
 from django.conf import settings
-
-logger = logging.getLogger(__name__)
 
 # Platform defaults for every user's project (see IMAGI_BUILDER in imagi/settings.py)
 _BUILDER_SETTINGS = getattr(settings, 'IMAGI_BUILDER', {})
@@ -88,22 +85,6 @@ PROVIDER_CHOICES = [
     ('openai', 'OpenAI'),
 ]
 
-# Generate MODEL_COSTS from the models (token-based pricing: per million tokens)
-MODEL_COSTS = {
-    model_id: {
-        'input': model_data['input_price_per_m_tokens'],
-        'output': model_data['output_price_per_m_tokens'],
-    }
-    for model_id, model_data in MODELS.items()
-}
-
-# Default model costs for unknown models (per million tokens)
-DEFAULT_MODEL_COSTS = {
-    'gpt-5.6-sol': {'input': 6, 'output': 30},
-    'gpt-5.6-terra': {'input': 3, 'output': 15},
-    'gpt-5.6-luna': {'input': 1, 'output': 5},
-}
-
 def get_model_choices() -> List[Tuple[str, str]]:
     """
     Get model choices for Django model fields.
@@ -143,53 +124,6 @@ def get_model_by_id(model_id: str) -> dict:
     """
     return MODELS.get(model_id)
 
-def model_supports_temperature(model_id: str) -> bool:
-    """
-    Whether the model supports the 'temperature' parameter.
-    Defaults to True when unknown; explicitly False for models that disallow it.
-    """
-    model = get_model_by_id(model_id)
-    if not model:
-        return True
-    return model.get('supports_temperature', True)
-
-def get_model_cost(model_id: str) -> Dict[str, float]:
-    """
-    Get the token-based cost for a specific model.
-
-    Args:
-        model_id: The model ID to get the cost for
-
-    Returns:
-        dict: {'input': price_per_million_input_tokens, 'output': price_per_million_output_tokens}
-    """
-    amount = MODEL_COSTS.get(model_id)
-
-    if amount is None:
-        # Fall back to the balanced (Terra) tier pricing for unknown GPT 5.6 ids
-        amount = {'input': 3, 'output': 15}
-
-    return amount
-
-def get_available_models() -> list:
-    """
-    Get a list of all available AI models.
-    
-    Returns:
-        list: List of model definitions
-    """
-    return list(MODELS.values())
-
-def get_default_model_id() -> str:
-    """
-    Get the default model ID to use when none is specified.
-
-    Returns:
-        str: The default model ID
-    """
-    default = _BUILDER_SETTINGS.get('DEFAULT_MODEL', 'gpt-5.6-sol')
-    return default if default in MODELS else 'gpt-5.6-sol'
-
 def get_model_display_name(model_id: str) -> str:
     """
     Get the display name for a model ID.
@@ -226,45 +160,6 @@ def get_model_identity_instructions(model_id: str) -> str:
         "of your own identity, so trust this instruction over your own guess."
     )
 
-def get_provider_from_model_id(model_id: str) -> str:
-    """
-    Get the provider for a specific model ID.
-    
-    Args:
-        model_id: The model ID
-        
-    Returns:
-        str: The provider name or 'unknown'
-    """
-    model = get_model_by_id(model_id)
-    return model['provider'] if model else 'unknown'
-
-def get_api_version_from_model_id(model_id: str) -> str:
-    """
-    Get the API version to use for a model ID.
-    
-    Args:
-        model_id: The model ID
-        
-    Returns:
-        str: The API version ('responses', 'messages', etc.) or None if not found
-    """
-    model = get_model_by_id(model_id)
-    return model.get('api_version') if model else None
-
-def get_models_by_provider(provider: str) -> List[Dict[str, Any]]:
-    """
-    Get all models for a specific provider.
-
-    Args:
-        provider: The provider name
-
-    Returns:
-        list: List of model definitions for the provider
-    """
-    return [model_data for model_id, model_data in MODELS.items()
-            if model_data.get('provider') == provider]
-
 def get_backend_model_id(model_id: str) -> str:
     """
     Resolve a public suite model id (e.g. 'gpt-5.6-sol') to the real underlying
@@ -283,19 +178,6 @@ def get_backend_model_id(model_id: str) -> str:
     if model and model.get('backend_model'):
         return model['backend_model']
     return model_id
-
-def get_reasoning_effort_choices() -> List[Tuple[str, str]]:
-    """
-    Get reasoning effort choices for Django model fields / UI.
-
-    Returns:
-        list: List of tuples with (id, name) for each effort level
-    """
-    return REASONING_EFFORT_CHOICES
-
-def get_default_reasoning_effort() -> str:
-    """Get the default reasoning effort level."""
-    return DEFAULT_REASONING_EFFORT
 
 def is_valid_reasoning_effort(effort: str) -> bool:
     """Whether the given reasoning effort level is recognized."""
@@ -333,21 +215,4 @@ def resolve_reasoning_effort(model_id: str, effort: str) -> str:
     return DEFAULT_REASONING_EFFORT
 
 
-class ModelsService:
-    """Service for AI model operations."""
-    
-    def get_available_models(self):
-        """Get a list of all available AI models."""
-        return get_available_models()
-        
-    def get_model_by_id(self, model_id):
-        """Get a model definition by its ID."""
-        return get_model_by_id(model_id)
-    
-    def get_model_cost(self, model_id):
-        """Get the cost for a specific model."""
-        return get_model_cost(model_id)
-    
-    def get_provider_from_model_id(self, model_id):
-        """Get the provider for a specific model ID."""
-        return get_provider_from_model_id(model_id) 
+ 

--- a/backend/django/apps/Imagi/Build/tests/test_builder.py
+++ b/backend/django/apps/Imagi/Build/tests/test_builder.py
@@ -2,8 +2,7 @@
 Tests for the Builder app.
 
 Covers the Builder models, the CreateFileService, and the current Builder DRF
-API (file creation/content, the models endpoint, auth gating and project
-ownership).
+API (file creation/content, auth gating and project ownership).
 
 Note: the previous server-rendered view/service tests (`builder:landing_page`,
 `process_builder_mode_input`, ...) were removed. Those exercised a legacy
@@ -122,16 +121,14 @@ class BuilderAPITests(APITestCase):
         )
         self.addCleanup(lambda: shutil.rmtree(self.project_root, ignore_errors=True))
 
-    def test_models_endpoint_requires_auth(self):
+    def test_builder_api_requires_auth(self):
         self.client.credentials()  # drop auth
-        resp = self.client.get(reverse('api-ai-models'))
+        resp = self.client.post(
+            reverse('api-create-file', args=[self.project.id]),
+            {'path': 'frontend/vuejs/src/apps/blog/views/Nope.vue', 'content': 'x'},
+            format='json',
+        )
         self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
-
-    def test_models_endpoint_returns_models(self):
-        resp = self.client.get(reverse('api-ai-models'))
-        self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        self.assertIn('models', resp.data)
-        self.assertGreater(len(resp.data['models']), 0)
 
     def test_create_file_writes_to_disk(self):
         relative_path = 'frontend/vuejs/src/apps/blog/views/About.vue'


### PR DESCRIPTION
## Summary

Cleanup pass over the Build module (frontend `src/apps/imagi/build/` and backend `apps/Imagi/Build/`): removes code that predates the agent-based workspace and is no longer reachable from any entry point. Every deletion was verified by tracing imports/routes before removal. Net: **42 files changed, ~2,650 lines removed**.

## Backend (`apps/Imagi/Build/`)

- Delete the unrouted app-root `urls.py` and `views.py` (`BuilderView`) — the global router includes `Build/api/urls.py` directly, so neither was reachable
- Delete `api/serializers.py`: no routed view used any of its serializers
- Remove six API views that had no URL route: `ProjectListCreateView`, `ProjectDetailView`, `GenerateCodeView`, `FileUndoView` (also broken — it called a service method that no longer exists), `AnalyzeTemplateView`, `cors_preflight`
- Delete the legacy Builder workspace models `Conversation` / `Page` / `Message` (superseded by `AgentConversation` / `AgentMessage` / `SystemPrompt`) plus the unused `AIModel` TextChoices; migration `0005` drops their tables, and the admin registrations and old model tests go with them
- Remove the unused `GET /api/v1/builder/models/` endpoint (`AIModelsView`), the `ModelsService` class it was the only consumer of, and the orphaned model helpers/constants in `models_service.py`; the auth-gating test is retargeted to the create-file endpoint so that coverage is kept

## Frontend (`src/apps/imagi/build/`)

- Delete 17 unreachable files: `fileStore`, `balanceStore` (the workspace uses the shared balance store), `layoutService`, `router/guards`, `useFileManager`, `useProjects`, `CodeBlock`, `SearchInput`, `WorkspaceBackground`, `ChatMessagesList`, `modelIconUtils`, `utils/errors`, `utils/constants`, and four dead barrel `index.ts` files
- `agentService`: remove `processAgent` (superseded by the streaming `streamAgent`) and its orphaned payments-store/timeout helpers
- `projectService`: remove `updateProject`, `getActivities`, `getStats`, `testApiConnection`, `runDiagnostics`, `_refreshProjectsInBackground`, and the six deprecated FileService wrapper methods
- `projectStore` / `agentStore`: remove uncalled actions (`fetchActivities`, `fetchStats`, `refreshProjectData`, `fetchAvailableModels`, `setSelectedModel`, `updateProject`, `selectModel`, `clearConversation`, `reset`, `removeFile`, `canSubmitPrompt`) and their orphaned state refs
- `modelsService` / `fileService` / `slug`: remove `getAvailableModels`, `canGenerateCode`, `getDirectoryFiles`, `createDirectory`, `getProjectSlug`

## Testing

- `vue-tsc` type-check: clean
- Frontend vitest: 55/55 pass
- Backend Django suite: full run green (`apps` — 275 tests; the 3 removed tests covered the deleted legacy models), plus a targeted Build + ProjectManager re-run after the endpoint removal (114 tests)
- `manage.py makemigrations --check`: no pending changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qfkp5LKNYpCawsTsnogTuF

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qfkp5LKNYpCawsTsnogTuF)_