### PR TITLE
Keep the builder browser toolbar pinned below the navbar

### DIFF
--- a/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
+++ b/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
@@ -76,11 +76,12 @@
         </div>
       </template>
 
-      <!-- Clean Main Content Area - fills the viewport below the navbar.
-           Uses dynamic viewport height (dvh) so it fills correctly on mobile
-           as the browser chrome shows/hides, minus the 4rem navbar. -->
+      <!-- Clean Main Content Area - fills the space below the navbar. Sized
+           by the app-shell layout (h-full of the padded <main>) rather than a
+           viewport calc, so it can never disagree with the shell and leave
+           the page itself scrollable. -->
       <template #default="{ isSidebarCollapsed }">
-        <div class="flex flex-col w-full overflow-hidden bg-white dark:bg-[#0a0a0a] relative transition-colors duration-500 h-[calc(100dvh-4rem)]">
+        <div class="flex flex-col w-full h-full overflow-hidden bg-white dark:bg-[#0a0a0a] relative transition-colors duration-500">
           <!-- Enhanced Error State Display -->
           <WorkspaceError v-if="store.error" :error="store.error" @retry="retryProjectLoad" />
 

--- a/frontend/vuejs/src/shared/layouts/BaseLayout.vue
+++ b/frontend/vuejs/src/shared/layouts/BaseLayout.vue
@@ -1,6 +1,9 @@
 <!-- Base layout - Root wrapper for all layouts -->
 <template>
-  <div class="flex flex-col min-h-screen bg-white dark:bg-[#0a0a0a] transition-colors duration-300">
+  <!-- min-h-dvh (not min-h-screen): 100vh overshoots the visible viewport on
+       mobile while browser chrome is showing, which adds phantom page scroll
+       that drags fixed-navbar layouts out of alignment. -->
+  <div class="flex flex-col min-h-dvh bg-white dark:bg-[#0a0a0a] transition-colors duration-300">
     <!-- Custom scrollbar and focus styles using arbitrary values -->
     <div class="overflow-auto
                 [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar]:h-2

--- a/frontend/vuejs/src/shared/layouts/DashboardLayout.vue
+++ b/frontend/vuejs/src/shared/layouts/DashboardLayout.vue
@@ -1,7 +1,11 @@
 <!-- Dashboard layout for authenticated users -->
 <template>
   <BaseLayout>
-    <div class="min-h-screen flex">
+    <!-- App-shell views (the builder workspace) pin the shell to the dynamic
+         viewport height and clip overflow so the document itself can never
+         scroll — otherwise the vh/dvh mismatch on mobile leaves a few dozen
+         scrollable pixels that slide the content up under the fixed navbar. -->
+    <div class="flex" :class="appShell ? 'h-dvh overflow-hidden' : 'min-h-screen'">
       <!-- Sidebar -->
       <aside
         class="fixed inset-y-0 left-0 z-30 flex flex-col transition-all duration-300 ease-in-out border-r border-gray-200 dark:border-dark-800/70 shadow-xl"
@@ -82,8 +86,9 @@
 
       <!-- Main content -->
       <div
-        class="flex-1 flex flex-col min-h-screen transition-all duration-300 ease-in-out"
+        class="flex-1 flex flex-col transition-all duration-300 ease-in-out"
         :class="[
+          appShell ? 'h-full min-h-0 overflow-hidden' : 'min-h-screen',
           isSidebarCollapsed ? 'ml-16' : (extraWide ? 'ml-[36rem]' : (wide ? 'ml-80' : 'ml-72')),
           mobileOverlay ? 'max-md:ml-0' : ''
         ]"
@@ -130,7 +135,10 @@
         </BaseNavbar>
 
         <!-- Main content area -->
-        <main class="flex-1 flex flex-col relative pt-16 bg-white dark:bg-gradient-to-b dark:from-dark-950 dark:to-dark-900 overflow-hidden">
+        <main
+          class="flex-1 flex flex-col relative pt-16 bg-white dark:bg-gradient-to-b dark:from-dark-950 dark:to-dark-900 overflow-hidden"
+          :class="appShell ? 'min-h-0' : ''"
+        >
           <slot :isSidebarCollapsed="isSidebarCollapsed"></slot>
         </main>
 


### PR DESCRIPTION
The workspace sized itself with 100dvh while the page wrappers used
min-h-screen (100vh). On mobile, 100vh overshoots the visible viewport
while browser chrome is showing, so the document picked up a few dozen
scrollable pixels — scrolling slid the preview browser's toolbar up
underneath the fixed navbar until it disappeared.

Fix by making app-shell views a true non-scrolling shell:

- DashboardLayout: when appShell is set, pin the shell to h-dvh with
  overflow-hidden (and min-h-0 down the flex chain) so the document
  itself can never scroll.
- BaseLayout: min-h-screen -> min-h-dvh so the root wrapper matches the
  visible viewport instead of forcing 100vh of document height.
- Workspace: size the content area with h-full from the shell instead
  of an independent 100dvh calc that could disagree with it.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019ZqU37WWBarsLfnLq98Lcq