### PR TITLE
Polish agent instance: shimmer status, empty state, ghost controls

### DIFF
--- a/frontend/vuejs/src/apps/imagi/build/components/__tests__/ChatConversation.spec.ts
+++ b/frontend/vuejs/src/apps/imagi/build/components/__tests__/ChatConversation.spec.ts
@@ -11,8 +11,8 @@ const assistant = (content: string): AIMessage => ({
 })
 
 const indicatorText = (wrapper: ReturnType<typeof mount>) => {
-  const indicator = wrapper.find('.typing-indicator')
-  return indicator.exists() ? indicator.element.parentElement?.textContent?.trim() : null
+  const indicator = wrapper.find('.agent-status')
+  return indicator.exists() ? indicator.element.textContent?.trim() : null
 }
 
 describe('ChatConversation activity indicator', () => {

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/chat/ChatConversation.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/chat/ChatConversation.vue
@@ -4,7 +4,13 @@
     <div ref="messagesContainer" class="flex-grow overflow-y-auto overflow-x-hidden px-4 py-6">
       <!-- Empty state -->
       <div v-if="!processedMessages.length" class="h-full flex flex-col items-center justify-center px-6 py-4 text-center min-h-0">
-        <!-- Empty state with no content -->
+        <div class="empty-icon flex items-center justify-center w-12 h-12 rounded-2xl mb-4">
+          <i class="fas fa-wand-magic-sparkles text-base"></i>
+        </div>
+        <h3 class="text-sm font-semibold text-blue-950/80 dark:text-white/85 mb-1.5">What should we build?</h3>
+        <p class="text-xs text-blue-950/45 dark:text-white/40 max-w-[230px] leading-relaxed">
+          Describe a page, feature, or change and the agent will build it into your project.
+        </p>
       </div>
       
       <template v-if="processedMessages.length > 0">
@@ -52,13 +58,9 @@
           <!-- Agent activity indicator. Hidden while the reply itself is
                streaming in — the growing message already shows progress. -->
           <div v-if="showActivityIndicator" class="msg-row assistant-response animate-fade-in">
-            <div class="flex items-center gap-2.5">
-              <div class="typing-indicator">
-                <span></span>
-                <span></span>
-                <span></span>
-              </div>
-              <span class="text-sm text-blue-950/50 dark:text-blue-100/50">{{ props.statusText || 'Working…' }}</span>
+            <div class="agent-status flex items-center gap-2.5">
+              <span class="status-orb"></span>
+              <span class="status-shimmer text-sm font-medium">{{ props.statusText || 'Working…' }}</span>
             </div>
           </div>
         </div>
@@ -416,47 +418,100 @@ const copyToClipboard = (code: string) => {
   background: rgba(255, 255, 255, 0.15);
 }
 
-/* Typing indicator */
-.typing-indicator {
-  display: flex;
-  align-items: center;
-  gap: 3px;
-}
-
-.typing-indicator span {
-  height: 5px;
-  width: 5px;
-  background: theme('colors.blue.400');
-  display: block;
+/* Agent activity indicator: a softly breathing orb next to status text with
+   a light shimmer sweeping across it. */
+.status-orb {
+  flex-shrink: 0;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
-  animation: typing 1.4s infinite ease-in-out both;
+  background: radial-gradient(circle at 30% 30%, #93c5fd, #3b82f6);
+  box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.35);
+  animation: orb-breathe 2s ease-in-out infinite;
 }
 
-.dark .typing-indicator span {
-  background: theme('colors.blue.300');
+.dark .status-orb {
+  background: radial-gradient(circle at 30% 30%, #bfdbfe, #60a5fa);
+  box-shadow: 0 0 0 0 rgba(147, 197, 253, 0.3);
 }
 
-.typing-indicator span:nth-child(1) {
-  animation-delay: 0s;
-}
-
-.typing-indicator span:nth-child(2) {
-  animation-delay: 0.2s;
-}
-
-.typing-indicator span:nth-child(3) {
-  animation-delay: 0.4s;
-}
-
-@keyframes typing {
-  0%, 80%, 100% {
-    transform: scale(0.8);
-    opacity: 0.5;
+@keyframes orb-breathe {
+  0%, 100% {
+    transform: scale(0.9);
+    box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.35);
   }
-  40% {
-    transform: scale(1.2);
-    opacity: 1;
+  50% {
+    transform: scale(1);
+    box-shadow: 0 0 0 5px rgba(59, 130, 246, 0);
   }
+}
+
+.status-shimmer {
+  background-image: linear-gradient(
+    100deg,
+    rgba(23, 37, 84, 0.4) 20%,
+    rgba(59, 130, 246, 0.95) 50%,
+    rgba(23, 37, 84, 0.4) 80%
+  );
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: shimmer-sweep 2.2s linear infinite;
+}
+
+.dark .status-shimmer {
+  background-image: linear-gradient(
+    100deg,
+    rgba(255, 255, 255, 0.35) 20%,
+    rgba(255, 255, 255, 0.95) 50%,
+    rgba(255, 255, 255, 0.35) 80%
+  );
+  background-size: 200% 100%;
+}
+
+@keyframes shimmer-sweep {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .status-orb,
+  .status-shimmer {
+    animation: none;
+  }
+
+  .status-shimmer {
+    background-clip: unset;
+    -webkit-background-clip: unset;
+    background-image: none;
+    color: rgba(23, 37, 84, 0.55);
+  }
+
+  .dark .status-shimmer {
+    color: rgba(255, 255, 255, 0.6);
+  }
+}
+
+/* Empty state icon: soft baby-blue tile matching the site's primary button */
+.empty-icon {
+  color: theme('colors.blue.900');
+  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
+  box-shadow:
+    0 1px 2px rgba(30, 58, 138, 0.12),
+    0 6px 14px -4px rgba(30, 58, 138, 0.18),
+    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75);
+}
+
+.dark .empty-icon {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.4),
+    0 6px 14px -4px rgba(0, 0, 0, 0.45),
+    inset 0 1px 1px 0 rgba(255, 255, 255, 0.6);
 }
 
 /* Prose styling for dark mode */

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
@@ -48,7 +48,7 @@
     <div class="shrink-0 bg-white dark:bg-[#0a0a0a] transition-colors duration-300">
       <div class="px-2 pt-1 pb-3">
         <!-- Input shell: textarea on top, controls toolbar below -->
-        <div class="chat-input-shell rounded-xl bg-blue-50/50 dark:bg-white/[0.03] border border-blue-200/70 dark:border-white/[0.08]">
+        <div class="chat-input-shell rounded-2xl bg-blue-50/40 dark:bg-white/[0.03] border border-blue-100 dark:border-white/[0.08] shadow-sm">
           <textarea
             ref="promptTextarea"
             v-model="prompt"
@@ -308,16 +308,17 @@ async function handleEffortSelect(effort: ReasoningEffort) {
   color: rgba(255, 255, 255, 0.85);
 }
 
-/* Enhanced dropdown select */
+/* Ghost dropdown select: quiet until hovered, so the input shell stays the
+   focal point */
 .dropdown-select {
   background-image: url('data:image/svg+xml;charset=UTF-8,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 24 24%27 fill=%27none%27 stroke=%27rgba(107,114,128,0.8)%27 stroke-width=%272.5%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27%3e%3cpolyline points=%276 9 12 15 18 9%27%3e%3c/polyline%3e%3c/svg%3e');
   background-repeat: no-repeat;
   background-position: right 0.55rem center;
   background-size: 0.85em;
-  background-color: rgba(255, 255, 255, 0.9);
-  border: 1px solid rgba(191, 219, 254, 0.9);
-  color: rgb(23, 37, 84);
-  font-weight: 600;
+  background-color: transparent;
+  border: 1px solid transparent;
+  color: rgba(23, 37, 84, 0.75);
+  font-weight: 500;
   letter-spacing: 0.01em;
   padding: 0.3rem 1.5rem 0.3rem 0.6rem;
   border-radius: 0.5rem;
@@ -326,10 +327,7 @@ async function handleEffortSelect(effort: ReasoningEffort) {
   appearance: none;
   -webkit-appearance: none;
   -moz-appearance: none;
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.04),
-    inset 0 1px 0 rgba(255, 255, 255, 0.6);
-  transition: all 0.18s ease;
+  transition: background-color 0.18s ease, color 0.18s ease, box-shadow 0.18s ease;
   outline: none;
 }
 
@@ -339,47 +337,26 @@ async function handleEffortSelect(effort: ReasoningEffort) {
 
 .dark .dropdown-select {
   background-image: url('data:image/svg+xml;charset=UTF-8,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 24 24%27 fill=%27none%27 stroke=%27rgba(255,255,255,0.6)%27 stroke-width=%272.5%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27%3e%3cpolyline points=%276 9 12 15 18 9%27%3e%3c/polyline%3e%3c/svg%3e');
-  background-color: rgba(255, 255, 255, 0.04);
-  border-color: rgba(255, 255, 255, 0.1);
-  color: rgba(255, 255, 255, 0.85);
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.25),
-    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  color: rgba(255, 255, 255, 0.65);
 }
 
 .dropdown-select:hover {
-  background-color: rgba(239, 246, 255, 1);
-  border-color: rgba(147, 197, 253, 0.95);
+  background-color: rgba(219, 234, 254, 0.5);
   color: rgb(23, 37, 84);
-  box-shadow:
-    0 2px 6px rgba(30, 58, 138, 0.08),
-    inset 0 1px 0 rgba(255, 255, 255, 0.7);
 }
 
 .dark .dropdown-select:hover {
   background-color: rgba(255, 255, 255, 0.07);
-  border-color: rgba(255, 255, 255, 0.18);
   color: rgba(255, 255, 255, 0.95);
-  box-shadow:
-    0 2px 6px rgba(0, 0, 0, 0.35),
-    inset 0 1px 0 rgba(255, 255, 255, 0.08);
 }
 
-.dropdown-select:focus,
 .dropdown-select:focus-visible {
-  border-color: rgba(59, 130, 246, 0.55);
-  box-shadow:
-    0 0 0 3px rgba(59, 130, 246, 0.15),
-    inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.35);
   outline: none;
 }
 
-.dark .dropdown-select:focus,
 .dark .dropdown-select:focus-visible {
-  border-color: rgba(147, 197, 253, 0.5);
-  box-shadow:
-    0 0 0 3px rgba(147, 197, 253, 0.18),
-    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  box-shadow: 0 0 0 2px rgba(147, 197, 253, 0.35);
 }
 
 


### PR DESCRIPTION
## Summary

Follow-up polish pass on the Build workspace agent instance (after #68), keeping the design minimal, sleek, and elegant:

- **Activity indicator** — the "Thinking… / Reading project files… / Editing project files…" line is now a softly breathing blue orb next to status text with a light shimmer sweeping across it (Claude-style), replacing the three bouncing dots. Both animations are disabled under `prefers-reduced-motion`, falling back to static muted text.
- **Empty conversation state** — instead of a completely blank pane, a new instance now shows a minimal welcome: a soft baby-blue gradient icon tile (matching the site's primary button treatment), a "What should we build?" heading, and one line of guidance.
- **Input area** — the input shell is softer (`rounded-2xl`, lighter border, subtle shadow), and the model/effort dropdowns switch from heavy bordered boxes to quiet ghost controls that only surface a tinted background on hover, so the message field stays the focal point.

## Testing

- `vitest` — all 5 `ChatConversation` tests pass (spec helper updated to target the new `.agent-status` markup)
- `npm run type-check` — clean
- Visually verified with Playwright screenshots at sidebar width: full conversation with live status indicator and empty state, in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThmCSpZS21assY68a1mQ3c

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThmCSpZS21assY68a1mQ3c)_