### PR TITLE
Polish agent manager design to match the instance chat panel

### DIFF
--- a/frontend/vuejs/src/apps/imagi/build/components/molecules/sidebar/AgentInstanceCard.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/molecules/sidebar/AgentInstanceCard.vue
@@ -3,9 +3,9 @@
     :class="[
       'group relative rounded-lg border px-2.5 py-2 cursor-pointer transition-all duration-200',
       isActive
-        ? 'border-blue-300 dark:border-blue-400/50 bg-blue-50/80 dark:bg-blue-400/[0.08] shadow-sm'
-        : 'border-blue-100 dark:border-white/[0.06] bg-blue-50/40 hover:bg-blue-50 dark:bg-white/[0.02] dark:hover:bg-white/[0.05]',
-      isArchived ? 'opacity-75' : ''
+        ? 'instance-card--active border-blue-300/80 dark:border-blue-400/40'
+        : 'border-blue-100 dark:border-white/[0.06] bg-blue-50/40 hover:bg-blue-50 hover:border-blue-200/90 dark:bg-white/[0.02] dark:hover:bg-white/[0.05] dark:hover:border-white/[0.1]',
+      isArchived ? 'opacity-70 hover:opacity-100' : ''
     ]"
     @click="emit('select')"
   >
@@ -25,7 +25,12 @@
         />
         <div
           v-else
-          class="text-xs font-semibold text-blue-950 dark:text-white/90 truncate"
+          :class="[
+            'text-xs truncate transition-colors duration-200',
+            isActive
+              ? 'font-semibold text-blue-950 dark:text-white'
+              : 'font-medium text-blue-950/80 dark:text-white/75 group-hover:text-blue-950 dark:group-hover:text-white/90'
+          ]"
         >
           {{ instance.title || 'Untitled instance' }}
         </div>
@@ -42,7 +47,7 @@
       <div ref="menuRef" class="relative shrink-0" @click.stop>
         <button
           :class="[
-            'w-6 h-6 flex items-center justify-center rounded transition-opacity hover:bg-blue-100 dark:hover:bg-white/[0.08] text-blue-950/50 dark:text-white/60',
+            'w-6 h-6 flex items-center justify-center rounded-md transition-opacity hover:bg-blue-100 dark:hover:bg-white/[0.08] text-blue-950/50 dark:text-white/60 hover:text-blue-950/80 dark:hover:text-white/90',
             menuOpen ? 'opacity-100 bg-blue-100 dark:bg-white/[0.08]' : 'opacity-0 group-hover:opacity-100 focus:opacity-100'
           ]"
           title="Options"
@@ -52,7 +57,7 @@
         </button>
         <div
           v-if="menuOpen"
-          class="absolute right-0 top-full mt-1 z-50 min-w-[130px] rounded-md border border-blue-100 dark:border-white/[0.08] bg-white dark:bg-[#161616] shadow-lg py-1"
+          class="absolute right-0 top-full mt-1 z-50 min-w-[140px] rounded-lg border border-blue-100 dark:border-white/[0.1] bg-white/95 dark:bg-[#161616]/95 backdrop-blur-sm shadow-xl shadow-blue-950/10 dark:shadow-black/40 py-1"
         >
           <button class="menu-item" @click.stop="onRename">
             <i class="fas fa-pen menu-item-icon"></i>
@@ -175,6 +180,22 @@ function relativeTime(iso: string): string {
 </script>
 
 <style scoped>
+/* Selected card - soft baby-blue wash matching the site's primary accent */
+.instance-card--active {
+  background: linear-gradient(155deg, rgba(219, 238, 255, 0.9) 0%, rgba(183, 221, 247, 0.45) 100%);
+  box-shadow:
+    0 1px 2px rgba(30, 58, 138, 0.08),
+    0 3px 8px -3px rgba(30, 58, 138, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.dark .instance-card--active {
+  background: linear-gradient(155deg, rgba(96, 165, 250, 0.14) 0%, rgba(96, 165, 250, 0.05) 100%);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
 .menu-item {
   display: flex;
   align-items: center;

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/AgentManagerPanel.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/AgentManagerPanel.vue
@@ -8,45 +8,54 @@
       @cancel="confirmModal.handleCancel"
     />
     <!-- Header -->
-    <div class="shrink-0 px-2 py-2 border-b border-blue-100 dark:border-white/[0.08] flex items-center justify-between">
-      <div class="flex items-center gap-0.5">
-        <!-- Collapse (desktop only; mobile uses the navbar view switcher) -->
-        <div class="relative group max-md:hidden">
-          <button
-            class="flex items-center justify-center w-7 h-7 rounded-md text-blue-950/60 dark:text-white/70 hover:bg-blue-50 dark:hover:bg-white/[0.08] hover:text-blue-950 dark:hover:text-white transition-colors"
-            @click="emit('collapse')"
-          >
-            <i class="fas fa-chevron-left text-xs"></i>
-          </button>
-          <div
-            class="pointer-events-none absolute left-0 top-full mt-1.5 z-50 whitespace-nowrap rounded-md bg-blue-950 dark:bg-white/95 px-2 py-1 text-[11px] font-medium text-white dark:text-blue-950 shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-150"
-          >
-            Collapse
-          </div>
-        </div>
-        <!-- Search -->
-        <div class="relative group">
-          <button
-            :class="[
-              'flex items-center justify-center w-7 h-7 rounded-md transition-colors',
-              showSearch
-                ? 'bg-blue-50 dark:bg-white/[0.08] text-blue-950 dark:text-white'
-                : 'text-blue-950/60 dark:text-white/70 hover:bg-blue-50 dark:hover:bg-white/[0.08] hover:text-blue-950 dark:hover:text-white'
-            ]"
-            @click="toggleSearch"
-          >
-            <i class="fas fa-search text-xs"></i>
-          </button>
-          <div
-            class="pointer-events-none absolute left-0 top-full mt-1.5 z-50 whitespace-nowrap rounded-md bg-blue-950 dark:bg-white/95 px-2 py-1 text-[11px] font-medium text-white dark:text-blue-950 shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-150"
-          >
-            Search chats
-          </div>
+    <div class="shrink-0 flex items-center gap-1 px-2 py-2 border-b border-blue-100 dark:border-white/[0.08]">
+      <!-- Collapse (desktop only; mobile uses the navbar view switcher) -->
+      <div class="relative group max-md:hidden">
+        <button
+          class="flex items-center justify-center w-7 h-7 rounded-md text-blue-950/60 dark:text-white/70 hover:bg-blue-50 dark:hover:bg-white/[0.08] hover:text-blue-950 dark:hover:text-white transition-colors"
+          @click="emit('collapse')"
+        >
+          <i class="fas fa-chevron-left text-xs"></i>
+        </button>
+        <div
+          class="pointer-events-none absolute left-0 top-full mt-1.5 z-50 whitespace-nowrap rounded-md bg-blue-950 dark:bg-white/95 px-2 py-1 text-[11px] font-medium text-white dark:text-blue-950 shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-150"
+        >
+          Collapse
         </div>
       </div>
+
+      <!-- Panel title -->
+      <div class="flex-1 min-w-0 flex items-center gap-2 pl-0.5">
+        <div class="agents-icon-chip flex items-center justify-center w-5 h-5 rounded-md shrink-0">
+          <i class="fas fa-layer-group text-[9px] text-blue-700 dark:text-blue-300"></i>
+        </div>
+        <span class="text-xs font-semibold text-blue-950/80 dark:text-white/80 truncate">Agents</span>
+      </div>
+
+      <!-- Search -->
       <div class="relative group">
         <button
-          class="flex items-center justify-center w-7 h-7 rounded-md bg-blue-50 hover:bg-blue-100 dark:bg-white/[0.05] dark:hover:bg-white/[0.1] text-blue-700 dark:text-white/80 transition-colors"
+          :class="[
+            'flex items-center justify-center w-7 h-7 rounded-md transition-colors',
+            showSearch
+              ? 'bg-blue-50 dark:bg-white/[0.08] text-blue-950 dark:text-white'
+              : 'text-blue-950/60 dark:text-white/70 hover:bg-blue-50 dark:hover:bg-white/[0.08] hover:text-blue-950 dark:hover:text-white'
+          ]"
+          @click="toggleSearch"
+        >
+          <i class="fas fa-search text-xs"></i>
+        </button>
+        <div
+          class="pointer-events-none absolute right-0 top-full mt-1.5 z-50 whitespace-nowrap rounded-md bg-blue-950 dark:bg-white/95 px-2 py-1 text-[11px] font-medium text-white dark:text-blue-950 shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-150"
+        >
+          Search chats
+        </div>
+      </div>
+
+      <!-- New agent instance -->
+      <div class="relative group">
+        <button
+          class="btn-new flex items-center justify-center w-7 h-7 rounded-md text-blue-950 border border-white/60 dark:border-white/30 transition-all duration-200"
           @click="handleCreate"
         >
           <i class="fas fa-plus text-xs"></i>
@@ -61,7 +70,7 @@
 
     <!-- Search input -->
     <div v-if="showSearch" class="shrink-0 px-2 py-2 border-b border-blue-100 dark:border-white/[0.08]">
-      <div class="flex items-center gap-2 rounded-md bg-blue-50 dark:bg-white/[0.05] px-2 py-1.5">
+      <div class="search-shell flex items-center gap-2 rounded-lg bg-blue-50/50 dark:bg-white/[0.03] border border-blue-200/70 dark:border-white/[0.08] px-2.5 py-1.5">
         <i class="fas fa-search text-[11px] text-blue-950/40 dark:text-white/40 shrink-0"></i>
         <input
           ref="searchInput"
@@ -84,21 +93,43 @@
     <!-- Instances list -->
     <div class="flex-1 min-h-0 overflow-y-auto px-2 py-2 space-y-1">
       <!-- Loading state -->
-      <div v-if="store.instancesLoading && store.instances.length === 0" class="text-xs text-blue-950/40 dark:text-white/40 px-2 py-4 text-center">
-        Loading...
+      <div
+        v-if="store.instancesLoading && store.instances.length === 0"
+        class="flex items-center justify-center gap-2 px-2 py-8 text-xs text-blue-950/40 dark:text-white/40"
+      >
+        <i class="fas fa-circle-notch fa-spin text-[11px]"></i>
+        <span>Loading agents…</span>
       </div>
 
       <!-- No search results -->
       <div
         v-else-if="showSearch && searchQuery.trim() && !hasResults"
-        class="text-xs text-blue-950/40 dark:text-white/40 px-2 py-4 text-center"
+        class="flex flex-col items-center px-4 py-8 text-center"
       >
-        No chats match "{{ searchQuery.trim() }}"
+        <div class="flex items-center justify-center w-9 h-9 rounded-full bg-blue-50 dark:bg-white/[0.05] border border-blue-100 dark:border-white/[0.08] mb-2.5">
+          <i class="fas fa-search text-xs text-blue-400 dark:text-white/40"></i>
+        </div>
+        <div class="text-xs font-medium text-blue-950/60 dark:text-white/50">No matching chats</div>
+        <div class="text-[11px] text-blue-950/40 dark:text-white/30 mt-1 break-all">
+          Nothing matches "{{ searchQuery.trim() }}"
+        </div>
+      </div>
+
+      <!-- Empty state -->
+      <div
+        v-else-if="!hasResults"
+        class="flex flex-col items-center px-4 py-8 text-center"
+      >
+        <div class="flex items-center justify-center w-9 h-9 rounded-full bg-blue-50 dark:bg-white/[0.05] border border-blue-100 dark:border-white/[0.08] mb-2.5">
+          <i class="fas fa-layer-group text-xs text-blue-400 dark:text-white/40"></i>
+        </div>
+        <div class="text-xs font-medium text-blue-950/60 dark:text-white/50">No agents yet</div>
+        <div class="text-[11px] text-blue-950/40 dark:text-white/30 mt-1">Create one with the + button above</div>
       </div>
 
       <!-- Active instances -->
       <template v-if="activeInstances.length > 0">
-        <div class="text-[10px] font-semibold uppercase tracking-wider text-blue-950/40 dark:text-white/40 px-2 py-1">
+        <div class="text-[10px] font-semibold uppercase tracking-wider text-blue-950/40 dark:text-white/40 px-2 pt-1 pb-1.5">
           Active
         </div>
         <InstanceCard
@@ -116,7 +147,7 @@
       <!-- Archived / past instances -->
       <template v-if="archivedInstances.length > 0">
         <button
-          class="w-full flex items-center justify-between px-2 py-2 mt-3 text-[10px] font-semibold uppercase tracking-wider text-blue-950/40 dark:text-white/40 hover:text-blue-950/70 dark:hover:text-white/70 transition-colors"
+          class="w-full flex items-center justify-between rounded-md px-2 py-2 mt-3 text-[10px] font-semibold uppercase tracking-wider text-blue-950/40 dark:text-white/40 hover:text-blue-950/70 dark:hover:text-white/70 hover:bg-blue-50/60 dark:hover:bg-white/[0.04] transition-colors"
           @click="showArchived = !showArchived"
         >
           <span>Past ({{ archivedInstances.length }})</span>
@@ -224,3 +255,60 @@ async function handleRename(id: string, title: string) {
   await store.renameInstance(id, title)
 }
 </script>
+
+<style scoped>
+/* Panel title chip - baby-blue accent matching the site's primary buttons */
+.agents-icon-chip {
+  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
+  box-shadow:
+    0 1px 2px rgba(30, 58, 138, 0.1),
+    inset 0 1px 1px 0 rgba(255, 255, 255, 0.7);
+}
+
+.dark .agents-icon-chip {
+  background: rgba(96, 165, 250, 0.12);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+/* Baby-blue "new agent" button - matching the chat's send button */
+.btn-new {
+  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
+  box-shadow:
+    0 1px 2px rgba(30, 58, 138, 0.14),
+    0 3px 8px -2px rgba(30, 58, 138, 0.16),
+    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
+    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.12);
+}
+
+.btn-new:hover {
+  filter: brightness(1.04);
+  box-shadow:
+    0 1px 2px rgba(30, 58, 138, 0.16),
+    0 5px 12px -2px rgba(30, 58, 138, 0.22),
+    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
+    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.12);
+}
+
+.dark .btn-new {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 3px 8px -2px rgba(0, 0, 0, 0.45),
+    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
+    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.18);
+}
+
+/* Search field focus ring - matching the chat input shell */
+.search-shell {
+  transition: border-color 0.18s ease, box-shadow 0.18s ease;
+}
+
+.search-shell:focus-within {
+  border-color: rgba(59, 130, 246, 0.55);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+}
+
+.dark .search-shell:focus-within {
+  border-color: rgba(147, 197, 253, 0.5);
+  box-shadow: 0 0 0 3px rgba(147, 197, 253, 0.18);
+}
+</style>


### PR DESCRIPTION
## Summary

Visual-only refresh of the agent manager sidebar (`AgentManagerPanel.vue` + `AgentInstanceCard.vue`) so it reads as one piece with the agent instance chat panel and the rest of the site. No functional changes — all props, emits, handlers, and store logic are untouched.

### Agent manager panel
- **Header** now carries an "Agents" title with a small baby-blue icon chip, giving the panel a clear identity. The layout mirrors the chat panel header (collapse control on the left, title in the middle, actions on the right).
- **New-instance button** picks up the same baby-blue gradient treatment (`#dbeeff → #b7ddf7 → #9ecdf3`) as the chat's send button, so the primary action stands out consistently.
- **Search field** matches the chat input shell: soft blue surface, `blue-200/70` border, and the shared 3px blue focus ring.
- **Loading, empty, and no-results states** get proper centered treatments (icon badge + label + hint) instead of bare text, including a new "No agents yet" empty state.

### Instance cards
- **Selected card** uses a soft baby-blue gradient wash with subtle inset highlight, echoing the site's primary accent.
- **Hover states** sharpen the card border and title color; archived cards regain full opacity on hover.
- **Options menu** gets the site's rounded, blurred dropdown styling (rounded-lg, backdrop blur, softer layered shadow).

All styling is done in both light and dark mode using the existing design tokens (`blue-950` ink, `blue-100`/`white/[0.08]` borders, `#0a0a0a` dark surface).

## Testing
- `npm run type-check` passes
- `eslint` on both changed files is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0185PDdoT3jLhFVMy9wbqvGz

---
_Generated by [Claude Code](https://claude.ai/code/session_0185PDdoT3jLhFVMy9wbqvGz)_