### PR TITLE
Smooth out scrolling in the workspace browser preview

### DIFF
--- a/backend/django/apps/Imagi/Build/services/browser_preview_service.py
+++ b/backend/django/apps/Imagi/Build/services/browser_preview_service.py
@@ -50,6 +50,12 @@ DEFAULT_VIEWPORT = (1280, 800)
 MIN_VIEWPORT, MAX_VIEWPORT = 320, 3840
 MAX_EVENTS_PER_REQUEST = 64
 
+# JPEG quality for streamed frames. Frames produced while the user is
+# scrolling or dragging trade a little fidelity for encode speed and payload
+# size — the next idle poll re-delivers a crisp frame of the settled page.
+FRAME_JPEG_QUALITY = 70
+MOTION_JPEG_QUALITY = 55
+
 # How long to wait for the Vite dev server to answer HTTP before pointing
 # Chromium at it. Vite itself is up in a couple of seconds; the generous
 # ceiling covers first-run dependency optimization.
@@ -221,13 +227,22 @@ class BrowserPreviewService:
 
         state = self._require_state(touch=True)
         width, height = state.get('viewport', DEFAULT_VIEWPORT)
+        # Scroll/drag batches arrive back-to-back while the user's gesture is
+        # in progress, so their frames prioritize latency over fidelity.
+        motion = any(
+            isinstance(e, dict) and (e.get('kind') == 'wheel' or e.get('type') == 'mouseMoved')
+            for e in events
+        )
         with self._page_connection(state) as (conn, _target):
             self._apply_viewport(conn, state)
             for event in events:
                 method, params = self._translate_event(event, width, height)
                 conn.call(method, params)
             payload = self._status_payload(conn, state)
-            self._attach_frame(conn, payload, etag)
+            self._attach_frame(
+                conn, payload, etag,
+                quality=MOTION_JPEG_QUALITY if motion else FRAME_JPEG_QUALITY,
+            )
         return payload
 
     def navigate(self, action, path=None):
@@ -320,6 +335,10 @@ class BrowserPreviewService:
             'pid': process.pid,
             'viewport': [width, height],
             'device_scale_factor': dsf,
+            # What the launch flags established; while the live viewport still
+            # matches, per-request emulation overrides are unnecessary.
+            'launch_viewport': [width, height],
+            'launch_device_scale_factor': dsf,
             'last_active': time.time(),
         }
 
@@ -422,18 +441,39 @@ class BrowserPreviewService:
         return _Ctx()
 
     def _apply_viewport(self, conn, state):
-        # Emulation overrides can be tied to a DevTools session, and our
-        # connections are per-request — re-applying is cheap and idempotent.
         width, height = state.get('viewport', DEFAULT_VIEWPORT)
+        dsf = float(state.get('device_scale_factor', 1))
+        # Chromium's launch flags already establish the launch-time viewport,
+        # so the emulation override is only needed once the pane has been
+        # resized away from it. Emulation overrides can be tied to a DevTools
+        # session and our connections are per-request, hence re-applying on
+        # every request — but each override forces a relayout, which makes
+        # frame streaming stutter, so skip it whenever launch flags suffice.
+        if (state.get('launch_viewport') == [int(width), int(height)]
+                and float(state.get('launch_device_scale_factor') or 0) == dsf):
+            return
         conn.call('Emulation.setDeviceMetricsOverride', {
             'width': int(width),
             'height': int(height),
-            'deviceScaleFactor': float(state.get('device_scale_factor', 1)),
+            'deviceScaleFactor': dsf,
             'mobile': False,
         })
 
-    def _attach_frame(self, conn, payload, etag):
-        shot = conn.call('Page.captureScreenshot', {'format': 'jpeg', 'quality': 70})
+    # Whether this Chromium accepts captureScreenshot's optimizeForSpeed
+    # param (Chrome 104+); flipped off on the first rejection.
+    _fast_screenshots = True
+
+    def _capture_screenshot(self, conn, quality):
+        params = {'format': 'jpeg', 'quality': int(quality)}
+        if BrowserPreviewService._fast_screenshots:
+            try:
+                return conn.call('Page.captureScreenshot', {**params, 'optimizeForSpeed': True})
+            except CdpError:
+                BrowserPreviewService._fast_screenshots = False
+        return conn.call('Page.captureScreenshot', params)
+
+    def _attach_frame(self, conn, payload, etag, quality=FRAME_JPEG_QUALITY):
+        shot = self._capture_screenshot(conn, quality)
         data = shot.get('data', '')
         digest = hashlib.sha1(base64.b64decode(data)).hexdigest() if data else ''
         payload['etag'] = digest

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspacePreview.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspacePreview.vue
@@ -127,6 +127,7 @@
         :src="frameSrc"
         alt=""
         draggable="false"
+        decoding="async"
         class="w-full h-full select-none pointer-events-none"
         style="object-fit: fill;"
       />
@@ -236,9 +237,28 @@ function paneSize(): { width: number; height: number } {
   }
 }
 
+// Frames are decoded off-screen before being shown, so the JPEG decode never
+// blocks the paint that displays it (decoding on the visible <img> stutters
+// scrolling). The sequence numbers keep a slow decode from replacing a newer
+// frame with an older one.
+let frameSeq = 0
+let shownFrameSeq = 0
+
+function showFrame(src: string) {
+  const seq = ++frameSeq
+  const img = new Image()
+  img.src = src
+  const show = () => {
+    if (disposed || seq <= shownFrameSeq) return
+    shownFrameSeq = seq
+    frameSrc.value = src
+  }
+  img.decode().then(show, show)
+}
+
 function applyFrame(f: PreviewFrame) {
   if (f.frame) {
-    frameSrc.value = `data:image/jpeg;base64,${f.frame}`
+    showFrame(`data:image/jpeg;base64,${f.frame}`)
   }
   if (f.etag) etag.value = f.etag
   if (typeof f.path === 'string') currentPath.value = f.path
@@ -284,13 +304,18 @@ function schedulePoll(delay?: number) {
   if (pollTimer) window.clearTimeout(pollTimer)
   if (disposed) return
   const active = Date.now() - lastActivityAt < 4000
-  pollTimer = window.setTimeout(pollFrame, delay ?? (active ? 350 : 1500))
+  pollTimer = window.setTimeout(pollFrame, delay ?? (active ? 120 : 1500))
 }
 
 async function pollFrame() {
   if (disposed || phase.value !== 'ready') return
-  if (document.hidden || inputInFlight) {
+  if (document.hidden) {
     schedulePoll(1000)
+    return
+  }
+  if (inputInFlight) {
+    // Input responses carry frames themselves; just check back in shortly.
+    schedulePoll(300)
     return
   }
   try {
@@ -342,7 +367,10 @@ function enqueue(event: PreviewInputEvent, immediate = false) {
     inputQueue.push(event)
   }
   if (inputQueue.length > 64) inputQueue = inputQueue.slice(-64)
-  scheduleFlush(immediate ? 0 : 24)
+  // Wheel events flush immediately: anything arriving while a batch is in
+  // flight coalesces into the next one anyway, so pre-batching them only adds
+  // latency between the gesture and the frame that shows it.
+  scheduleFlush(immediate || event.kind === 'wheel' ? 0 : 24)
 }
 
 function scheduleFlush(delay: number) {
@@ -369,7 +397,7 @@ async function flushInput() {
     inputInFlight = false
   }
   if (inputQueue.length > 0) scheduleFlush(0)
-  schedulePoll(250)
+  schedulePoll() // activity-based: quick while the user is interacting
 }
 
 const BUTTON_NAMES: Array<'left' | 'middle' | 'right'> = ['left', 'middle', 'right']
@@ -763,6 +791,7 @@ watch(
   () => props.projectId,
   (next, prev) => {
     if (next && next !== prev) {
+      shownFrameSeq = ++frameSeq // drop any frame still decoding for the old project
       frameSrc.value = null
       etag.value = undefined
       phase.value = 'idle'


### PR DESCRIPTION
## Summary

Scrolling in the Build workspace's browser preview felt choppy compared to the agent chat. The chat scrolls natively, while the preview is a streamed remote browser — each frame is a JPEG screenshot round-tripped over HTTP — so its smoothness is bounded by how fast that pipeline turns a wheel gesture into a fresh frame. This PR removes avoidable latency at every hop of that pipeline.

### Frontend (`WorkspacePreview.vue`)

- **Wheel input flushes immediately** instead of sitting in a 24ms batch. Events that arrive while a request is in flight still coalesce into the next batch, so this adds no flooding — it just gets the gesture to the page one round trip sooner.
- **Active polling at 120ms** (was 350ms) while the user is interacting, and the post-input poll follows the same activity-based cadence, so trailing animation/settling frames arrive quickly.
- **Off-screen frame decoding**: frames were previously decoded on the visible `<img>` at swap time, janking the main thread on every frame. They are now decoded in a hidden `Image` (plus `decoding="async"`) and only shown once ready, with sequence numbers so a slow decode can never replace a newer frame — including across project switches.

### Backend (`browser_preview_service.py`)

- **Skip the per-request `Emulation.setDeviceMetricsOverride`** while the viewport still matches what Chromium was launched with. This override cost an extra CDP round trip and could force a relayout on *every* frame and input request — a major stutter source. It's still re-applied per request once the pane has been resized away from the launch size (launch size/DSF are recorded in the session state file; sessions started before this change lack the fields and keep the old always-apply behavior).
- **`optimizeForSpeed` screenshots**, with a one-time fallback for older Chromium builds that reject the param.
- **Lower JPEG quality (55) for frames produced during scroll/drag batches**, trading a little transient fidelity for encode speed and payload size. The next idle poll re-delivers a crisp quality-70 frame of the settled page.

## Testing

- Backend: `python manage.py test apps.Imagi.Build` — 76 tests pass.
- Frontend: `npm test` — 55 tests pass (pre-existing unhandled-rejection noise in `ChatConversation.spec.ts` is untouched); `npm run type-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y6i85LuEb5A2vBL1fciEkG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y6i85LuEb5A2vBL1fciEkG)_