### PR TITLE
Speed up project creation and gate the workspace during the initial build

### DIFF
--- a/backend/django/apps/Imagi/Build/services/project_files_service.py
+++ b/backend/django/apps/Imagi/Build/services/project_files_service.py
@@ -26,6 +26,8 @@ Design
 import logging
 import os
 
+from django.db import transaction
+
 from apps.Imagi.Build.models import ProjectFile
 
 logger = logging.getLogger(__name__)
@@ -185,21 +187,26 @@ def import_project_from_disk(project, prune: bool = True) -> dict:
 
     seen = set()
     synced = 0
-    for root, dirs, filenames in os.walk(project_root):
-        dirs[:] = sorted(d for d in dirs if d not in SKIP_DIRS and not d.startswith('.'))
-        for filename in sorted(filenames):
-            abs_path = os.path.join(root, filename)
-            rel_path = _normalize_rel_path(os.path.relpath(abs_path, project_root))
-            if not is_syncable_path(rel_path):
-                continue
-            if record_file(project, rel_path) is not None:
-                seen.add(rel_path)
-                synced += 1
+    # Batch every per-file upsert into a single transaction. Without this each
+    # record_file() auto-commits on its own — one fsync per file — which makes
+    # importing a freshly scaffolded project (hundreds of files) needlessly
+    # slow, especially on SQLite. One commit at the end instead of hundreds.
+    with transaction.atomic():
+        for root, dirs, filenames in os.walk(project_root):
+            dirs[:] = sorted(d for d in dirs if d not in SKIP_DIRS and not d.startswith('.'))
+            for filename in sorted(filenames):
+                abs_path = os.path.join(root, filename)
+                rel_path = _normalize_rel_path(os.path.relpath(abs_path, project_root))
+                if not is_syncable_path(rel_path):
+                    continue
+                if record_file(project, rel_path) is not None:
+                    seen.add(rel_path)
+                    synced += 1
 
-    pruned = 0
-    if prune:
-        stale = ProjectFile.objects.filter(project=project).exclude(path__in=seen)
-        pruned, _ = stale.delete()
+        pruned = 0
+        if prune:
+            stale = ProjectFile.objects.filter(project=project).exclude(path__in=seen)
+            pruned, _ = stale.delete()
 
     logger.info(f"Imported project {project.id} from disk: {synced} files synced, {pruned} stale rows pruned")
     return {'synced': synced, 'pruned': pruned}

--- a/backend/django/apps/Imagi/ProjectManager/services/project_creation_service.py
+++ b/backend/django/apps/Imagi/ProjectManager/services/project_creation_service.py
@@ -243,14 +243,26 @@ class ProjectCreationService:
     def _create_django_backend(self, backend_path, unique_name, project_name, project_description):
         """Create Django backend with DRF"""
         logger.info(f"Creating Django backend at: {backend_path}")
-        
-        # Use Python module runner to invoke Django's startproject and create the basic project structure
-        # This creates the Django project inside the backend_path directory
-        subprocess.run([
-            sys.executable, '-m', 'django', 'startproject',
-            unique_name,  # Project name
-            backend_path  # Destination directory - Django project files will be created here
-        ], check=True)
+
+        # Scaffold the Django project in-process. Django is already imported in
+        # this worker, so calling startproject via call_command skips the cold
+        # start of a second Python interpreter (importing Django from scratch)
+        # that `python -m django startproject` would pay on every create — the
+        # single biggest chunk of project-creation latency. Fall back to the
+        # subprocess form only if the in-process call fails for some reason.
+        try:
+            from django.core.management import call_command
+            call_command('startproject', unique_name, backend_path)
+        except Exception as e:
+            logger.warning(
+                "In-process startproject failed (%s); falling back to subprocess",
+                e,
+            )
+            subprocess.run([
+                sys.executable, '-m', 'django', 'startproject',
+                unique_name,  # Project name
+                backend_path  # Destination directory - Django project files will be created here
+            ], check=True)
         
         # The backend is API-only: no Django templates/ or static/ scaffolding —
         # all UI lives in the Vue frontend. Keep media/ for file uploads.

--- a/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
+++ b/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
@@ -109,6 +109,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { useAgentStore } from '../stores/agentStore'
 import { useBuilderMode } from '../composables/useBuilderMode'
 import { useProjectStore } from '../stores/projectStore'
+import { ProjectService } from '../services/projectService'
 import { AgentService } from '../services/agentService'
 import { FileService } from '../services/fileService'
 import { BuilderCreationService } from '../services/builderCreationService'
@@ -771,7 +772,31 @@ onMounted(async () => {
       // Handle localStorage errors silently and continue
       console.warn('Error checking deleted projects list:', e)
     }
-    
+
+    // Gate: the workspace must not open while the initial AI build is still
+    // running, or the user would land in a half-built project. Check the
+    // authoritative status and, if it's still generating, bounce back to the
+    // project hub where the "Building your app" state is shown. This is the
+    // backstop for direct URLs / refreshes; the hub's Build card also blocks
+    // navigation while building.
+    try {
+      const status = await ProjectService.getProjectStatus(projectId.value)
+      if (status.generation_status === 'generating') {
+        const { showNotification } = useNotification()
+        showNotification({
+          type: 'info',
+          message: `Imagi is still building "${foundProject.name}". We'll open the workspace as soon as it's ready.`,
+          duration: 4000
+        })
+        router.replace({ name: 'project-hub', params: { projectName: projectNameSlug } })
+        return
+      }
+    } catch (e) {
+      // If the status check fails, don't block entry — fall through and load
+      // the workspace as normal rather than trapping the user.
+      console.warn('Could not verify initial build status; opening workspace anyway:', e)
+    }
+
     // Critical request - project must be loaded first and only once
     try {
       const project = await executeOnce('fetchProject', () => {

--- a/frontend/vuejs/src/apps/imagi/project-manager/components/organisms/hub/ToolCategoryCard.vue
+++ b/frontend/vuejs/src/apps/imagi/project-manager/components/organisms/hub/ToolCategoryCard.vue
@@ -5,55 +5,109 @@
   links either to the app builder or to the generic coming-soon tool page.
 -->
 <template>
-  <router-link
-    :to="target"
-    class="crisp-card group relative flex flex-col items-center text-center h-full px-6 pt-8 pb-6 rounded-2xl bg-white dark:bg-white/[0.05] border transition-all duration-300 hover:-translate-y-1"
-    :class="accent.cardBorder"
-    :title="tool.name"
+  <component
+    :is="isBuildLocked ? 'div' : 'router-link'"
+    :to="isBuildLocked ? undefined : target"
+    class="crisp-card group relative flex flex-col items-center text-center h-full px-6 pt-8 pb-6 rounded-2xl border transition-all duration-300"
+    :class="[
+      isBuildLocked
+        ? 'building-card cursor-progress bg-white dark:bg-white/[0.05] border-blue-300/70 dark:border-blue-300/25'
+        : ['bg-white dark:bg-white/[0.05] hover:-translate-y-1', accent.cardBorder],
+    ]"
+    :title="isBuildLocked ? 'Imagi is building your app — this card unlocks the moment the build finishes' : tool.name"
+    :aria-disabled="isBuildLocked ? 'true' : undefined"
   >
     <!-- Soft accent glow on hover -->
     <div
+      v-if="!isBuildLocked"
       class="pointer-events-none absolute -top-px inset-x-0 mx-auto w-40 h-40 rounded-full blur-3xl opacity-0 group-hover:opacity-100 bg-gradient-to-b to-transparent transition-opacity duration-500"
       :class="accent.glow"
     ></div>
 
-    <!-- Status -->
-    <span
-      v-if="isBuilding"
-      class="absolute top-3 right-3 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-[11px] font-semibold uppercase tracking-[0.14em] transition-colors duration-300"
-      :class="accent.badge"
-    >
-      <span class="w-3 h-3 rounded-full border-2 border-current border-t-transparent animate-spin"></span>
-      AI building
-    </span>
+    <!-- Moving sheen while building -->
+    <div v-if="isBuildLocked" class="building-sheen pointer-events-none absolute inset-0 rounded-2xl overflow-hidden"></div>
 
-    <!-- Icon -->
-    <div
-      class="relative w-14 h-14 rounded-2xl flex items-center justify-center border mb-5 transition-transform duration-300 group-hover:scale-105"
-      :class="[accent.iconWrap]"
-    >
-      <i :class="['fas', tool.icon, accent.iconText]" class="text-xl"></i>
-    </div>
+    <!-- ==================== BUILDING STATE ==================== -->
+    <template v-if="isBuildLocked">
+      <span
+        class="absolute top-3 right-3 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-blue-300/70 dark:border-blue-300/30 bg-blue-50/90 dark:bg-blue-400/10 text-[11px] font-semibold uppercase tracking-[0.14em] text-blue-700 dark:text-blue-200"
+      >
+        <span class="relative flex w-2 h-2">
+          <span class="absolute inline-flex w-full h-full rounded-full bg-blue-500 dark:bg-blue-300 opacity-60 animate-ping"></span>
+          <span class="relative inline-flex w-2 h-2 rounded-full bg-blue-600 dark:bg-blue-300"></span>
+        </span>
+        Building
+      </span>
 
-    <!-- Name + tagline -->
-    <div class="relative flex-1">
-      <h3 class="text-lg font-semibold text-blue-950 dark:text-white mb-1.5 tracking-tight transition-colors duration-300">
-        {{ tool.name }}
-      </h3>
-      <p class="text-sm text-blue-950/70 dark:text-blue-100/70 leading-relaxed transition-colors duration-300">
-        {{ isBuilding ? 'Imagi is building the first version of your app from your business description…' : tool.tagline }}
-      </p>
-    </div>
+      <!-- Animated build icon: concentric pulsing rings behind a spinner ring -->
+      <div class="relative w-16 h-16 flex items-center justify-center mb-5">
+        <span class="absolute inset-0 rounded-2xl bg-blue-400/15 dark:bg-blue-300/10 animate-ping" style="animation-duration: 1.8s;"></span>
+        <span class="absolute inset-1.5 rounded-2xl bg-blue-400/20 dark:bg-blue-300/15 animate-ping" style="animation-duration: 1.8s; animation-delay: .3s;"></span>
+        <div class="relative w-14 h-14 rounded-2xl flex items-center justify-center border border-blue-300/70 dark:border-blue-300/25 bg-gradient-to-br from-blue-50 to-blue-100/60 dark:from-blue-400/10 dark:to-blue-500/10">
+          <span class="absolute inset-0 rounded-2xl border-2 border-blue-500/70 dark:border-blue-300/60 border-t-transparent animate-spin" style="animation-duration: 1s;"></span>
+          <i class="fas fa-wand-magic-sparkles text-lg text-blue-600 dark:text-blue-200"></i>
+        </div>
+      </div>
 
-    <!-- CTA -->
-    <div
-      class="relative flex items-center justify-center gap-1.5 w-full text-sm font-medium mt-6 pt-4 border-t border-blue-200/60 dark:border-white/[0.1] transition-colors duration-300"
-      :class="accent.link"
-    >
-      <span>{{ tool.status === 'available' ? 'Open workspace' : 'Preview' }}</span>
-      <i class="fas fa-arrow-right text-xs group-hover:translate-x-1 transition-transform duration-200"></i>
-    </div>
-  </router-link>
+      <div class="relative flex-1">
+        <h3 class="text-lg font-semibold text-blue-950 dark:text-white mb-1.5 tracking-tight">
+          Building your app
+        </h3>
+        <p class="text-sm text-blue-950/70 dark:text-blue-100/70 leading-relaxed">
+          Imagi is turning your business description into a tailored first version. This usually takes a moment.
+        </p>
+        <!-- Indeterminate progress track -->
+        <div class="mt-4 h-1 w-full rounded-full bg-blue-100 dark:bg-white/[0.08] overflow-hidden">
+          <div class="building-bar h-full w-1/3 rounded-full bg-gradient-to-r from-blue-400 via-blue-500 to-blue-400 dark:from-blue-300 dark:via-blue-400 dark:to-blue-300"></div>
+        </div>
+      </div>
+
+      <div class="relative flex items-center justify-center gap-2 w-full text-sm font-medium mt-6 pt-4 border-t border-blue-200/60 dark:border-white/[0.1] text-blue-700/90 dark:text-blue-200/80">
+        <i class="fas fa-lock text-[11px]"></i>
+        <span>Unlocks when the build finishes</span>
+      </div>
+    </template>
+
+    <!-- ==================== DEFAULT STATE ==================== -->
+    <template v-else>
+      <!-- Failed build hint -->
+      <span
+        v-if="buildFailed"
+        class="absolute top-3 right-3 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-amber-300/70 dark:border-amber-300/30 bg-amber-50/90 dark:bg-amber-400/10 text-[11px] font-semibold uppercase tracking-[0.14em] text-amber-700 dark:text-amber-200"
+        title="The initial build didn't finish — open the workspace to continue building"
+      >
+        <i class="fas fa-triangle-exclamation text-[10px]"></i>
+        Ready to build
+      </span>
+
+      <!-- Icon -->
+      <div
+        class="relative w-14 h-14 rounded-2xl flex items-center justify-center border mb-5 transition-transform duration-300 group-hover:scale-105"
+        :class="[accent.iconWrap]"
+      >
+        <i :class="['fas', tool.icon, accent.iconText]" class="text-xl"></i>
+      </div>
+
+      <!-- Name + tagline -->
+      <div class="relative flex-1">
+        <h3 class="text-lg font-semibold text-blue-950 dark:text-white mb-1.5 tracking-tight transition-colors duration-300">
+          {{ tool.name }}
+        </h3>
+        <p class="text-sm text-blue-950/70 dark:text-blue-100/70 leading-relaxed transition-colors duration-300">
+          {{ tool.tagline }}
+        </p>
+      </div>
+
+      <!-- CTA -->
+      <div
+        class="relative flex items-center justify-center gap-1.5 w-full text-sm font-medium mt-6 pt-4 border-t border-blue-200/60 dark:border-white/[0.1] transition-colors duration-300"
+        :class="accent.link"
+      >
+        <span>{{ tool.status === 'available' ? 'Open workspace' : 'Preview' }}</span>
+        <i class="fas fa-arrow-right text-xs group-hover:translate-x-1 transition-transform duration-200"></i>
+      </div>
+    </template>
+  </component>
 </template>
 
 <script setup lang="ts">
@@ -70,7 +124,22 @@ const props = defineProps<{
 
 const accent = computed(() => accentClasses[props.tool.accent])
 
-const isBuilding = computed(() => props.tool.id === 'build' && props.buildStatus === 'generating')
+/**
+ * The initial AI build is still running. While it is, the Build card is locked:
+ * it shows a dedicated building state and cannot navigate into the workspace,
+ * so users never enter a half-built project. Only the Build tool is gated.
+ *
+ * We lock strictly on 'generating' — the status the backend sets synchronously
+ * the moment a build starts, before the create response returns. 'pending' is
+ * deliberately excluded: it's the transient/legacy default, and locking on it
+ * would trap older projects whose build never ran out of their own workspace.
+ */
+const isBuildLocked = computed(
+  () => props.tool.id === 'build' && props.buildStatus === 'generating'
+)
+
+/** The initial build failed — the workspace is still usable, just not seeded. */
+const buildFailed = computed(() => props.tool.id === 'build' && props.buildStatus === 'failed')
 
 const target = computed<RouteLocationRaw>(() => {
   // "Build" points at the real workspace; everything else uses the generic
@@ -117,5 +186,76 @@ const target = computed<RouteLocationRaw>(() => {
     0 2px 4px rgba(0, 0, 0, 0.55),
     0 8px 18px -4px rgba(0, 0, 0, 0.5),
     0 20px 40px -12px rgba(0, 0, 0, 0.6);
+}
+
+/* ---- Building state ---- */
+/* A soft, breathing ring around the card so "AI building" reads as active work. */
+.building-card {
+  animation: building-glow 2.4s ease-in-out infinite;
+}
+
+@keyframes building-glow {
+  0%, 100% {
+    box-shadow:
+      0 0 0 1px rgba(59, 130, 246, 0.18),
+      0 1px 2px rgba(15, 23, 42, 0.06),
+      0 8px 22px -8px rgba(59, 130, 246, 0.28);
+  }
+  50% {
+    box-shadow:
+      0 0 0 1px rgba(59, 130, 246, 0.32),
+      0 1px 2px rgba(15, 23, 42, 0.06),
+      0 12px 34px -8px rgba(59, 130, 246, 0.45);
+  }
+}
+
+/* Diagonal sheen sweeping across the card. */
+.building-sheen::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -60%;
+  width: 45%;
+  height: 100%;
+  background: linear-gradient(
+    100deg,
+    transparent,
+    rgba(255, 255, 255, 0.55),
+    transparent
+  );
+  transform: skewX(-18deg);
+  animation: building-sweep 2.6s ease-in-out infinite;
+}
+
+:global(.dark) .building-sheen::before {
+  background: linear-gradient(
+    100deg,
+    transparent,
+    rgba(147, 197, 253, 0.14),
+    transparent
+  );
+}
+
+@keyframes building-sweep {
+  0% { left: -60%; }
+  60%, 100% { left: 120%; }
+}
+
+/* Indeterminate progress bar that slides back and forth. */
+.building-bar {
+  animation: building-bar 1.6s ease-in-out infinite;
+}
+
+@keyframes building-bar {
+  0% { transform: translateX(-110%); }
+  100% { transform: translateX(320%); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .building-card,
+  .building-sheen::before,
+  .building-bar {
+    animation: none;
+  }
 }
 </style>


### PR DESCRIPTION
## Summary

This addresses three requests around project creation and the initial AI build:

1. **Faster project creation**
2. **Users can't enter the build workspace until the initial build completes**
3. **A better-designed "AI building" message in the project workspace**

## Performance

- **In-process Django scaffolding.** `_create_django_backend` previously ran `python -m django startproject` as a subprocess, which cold-started a second Python interpreter and re-imported Django on every project create — the single biggest chunk of creation latency. It now calls `call_command('startproject', ...)` in-process (Django is already loaded in the worker), falling back to the subprocess form only if that fails. Verified the in-process call produces the same `manage.py` / `settings.py` / `urls.py` scaffold and preserves the pre-existing `apps/` dir, in ~0.28s.
- **Batched disk→DB file sync.** `import_project_from_disk` did one auto-committed `update_or_create` per file — hundreds of individual commits (one fsync each) for a freshly scaffolded project, especially painful on SQLite. The whole sweep is now wrapped in a single `transaction.atomic()`, so it commits once.

## Gate the build workspace until the initial build completes

- The project hub's **Build card no longer navigates** while the initial AI build is running (`generation_status === 'generating'`); it renders a dedicated building state instead.
- **`Workspace.vue` checks the authoritative build status on load** and redirects back to the project hub if a build is still in progress. This is the backstop for direct URLs and refreshes; the card gating handles the common in-app path.
- Gating keys strictly on `generating` (set synchronously the moment a build starts), never on `pending`, so older/legacy projects are never trapped out of their own workspace.

## Redesigned "AI building" message

Replaced the small spinner badge on the Build card with a polished building state:
- Pulsing status dot, animated build icon (concentric pulse rings + spinner ring), a breathing card glow, a sweeping sheen, and an indeterminate progress bar.
- Clearer copy ("Building your app" + explanation) and a locked footer ("Unlocks when the build finishes").
- Honors `prefers-reduced-motion`.
- Adds a subtle "Ready to build" hint when the initial build failed, so the workspace stays reachable.

## Testing

- Backend: `apps.Imagi.ProjectManager` (38) and `apps.Imagi.Build` (77) test suites pass.
- Verified in-process `startproject` output and directory preservation directly.
- Frontend: `npm run type-check` passes; `vitest run` — 55 tests pass (7 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMxmPTWrMPvdMU7mGHJmjh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMxmPTWrMPvdMU7mGHJmjh)_