### PR TITLE
Fix project create/delete UX and remove "Ready to build" tag

### DIFF
--- a/frontend/vuejs/src/apps/imagi/project-manager/components/organisms/hub/ToolCategoryCard.vue
+++ b/frontend/vuejs/src/apps/imagi/project-manager/components/organisms/hub/ToolCategoryCard.vue
@@ -70,16 +70,6 @@
 
     <!-- ==================== DEFAULT STATE ==================== -->
     <template v-else>
-      <!-- Failed build hint -->
-      <span
-        v-if="buildFailed"
-        class="absolute top-3 right-3 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border border-amber-300/70 dark:border-amber-300/30 bg-amber-50/90 dark:bg-amber-400/10 text-[11px] font-semibold uppercase tracking-[0.14em] text-amber-700 dark:text-amber-200"
-        title="The initial build didn't finish — open the workspace to continue building"
-      >
-        <i class="fas fa-triangle-exclamation text-[10px]"></i>
-        Ready to build
-      </span>
-
       <!-- Icon -->
       <div
         class="relative w-14 h-14 rounded-2xl flex items-center justify-center border mb-5 transition-transform duration-300 group-hover:scale-105"
@@ -137,9 +127,6 @@ const accent = computed(() => accentClasses[props.tool.accent])
 const isBuildLocked = computed(
   () => props.tool.id === 'build' && props.buildStatus === 'generating'
 )
-
-/** The initial build failed — the workspace is still usable, just not seeded. */
-const buildFailed = computed(() => props.tool.id === 'build' && props.buildStatus === 'failed')
 
 const target = computed<RouteLocationRaw>(() => {
   // "Build" points at the real workspace; everything else uses the generic


### PR DESCRIPTION
## Summary

Fixes to the project-manager workspace, plus removal of the "Ready to build" tag.

### 1. Create button couldn't be clicked
The **Create Project** button is gated on `canCreate`, which requires the business description to be at least 20 characters — but nothing on screen explained that, so the button silently stayed disabled and users had no idea why. Added a live hint above the button that tells the user exactly what's missing ("Enter a business name…" / "Add N more characters to the business description…"). The hint clears the moment the form is valid.

### 2. Delete notifications weren't visible
The global `NotificationToast` component was exported from the atoms barrel but **never mounted anywhere**, so every `showNotification()` toast — create errors, delete feedback, "please log in" prompts — was invisible app-wide.

- Mounted `NotificationToast` once in `App.vue`.
- Routed the delete-success message through the now-visible global toast (`type: 'delete'`), and removed the redundant bespoke inline banner and its timer/state.

The delete flow itself (confirm modal → `projectStore.deleteProject` → list refresh, including the 404-as-success path) was already correct; it just lacked a visible confirmation.

### 3. Removed the "Ready to build" tag
Deleted the amber failed-build badge from the Build card on the project hub (`ToolCategoryCard.vue`), along with its now-unused `buildFailed` computed. The card's active "Building" state is untouched.

## Testing
- `npm run type-check` — passes
- `npm run build-only` — succeeds (pre-existing chunk-size warning only)

## Files changed
- `frontend/vuejs/src/App.vue` — mount global toast
- `frontend/vuejs/src/apps/imagi/project-manager/views/Projects.vue` — create hint + toast-based delete notification
- `frontend/vuejs/src/apps/imagi/project-manager/components/organisms/hub/ToolCategoryCard.vue` — remove "Ready to build" tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)