### PR TITLE
Remove "Use the form to get started" hint from projects empty state

### DIFF
--- a/frontend/vuejs/src/apps/imagi/project-manager/views/Projects.vue
+++ b/frontend/vuejs/src/apps/imagi/project-manager/views/Projects.vue
@@ -235,11 +235,7 @@
                       <i class="fas fa-folder-open text-orange-600 dark:text-orange-300 text-lg"></i>
                     </div>
                     <h3 class="text-lg font-medium text-blue-950 dark:text-white mb-1 transition-colors duration-300">No projects yet</h3>
-                    <p class="text-blue-950/70 dark:text-blue-100/70 text-center mb-4 text-sm transition-colors duration-300">Create your first project to start building</p>
-                    <div class="flex items-center text-blue-950/50 dark:text-blue-100/50 text-sm">
-                      <i class="fas fa-arrow-left mr-2 animate-pulse"></i>
-                      <span>Use the form to get started</span>
-                    </div>
+                    <p class="text-blue-950/70 dark:text-blue-100/70 text-center text-sm transition-colors duration-300">Create your first project to start building</p>
                   </div>
 
                   <!-- Scrollable Project List -->


### PR DESCRIPTION
## Summary

Removes the unnecessary "Use the form to get started" text (and its animated left-pointing arrow) from the empty state in the project library on the Projects page.

The empty state now shows just the "No projects yet" heading and the "Create your first project to start building" subtext. The now-redundant bottom margin (`mb-4`) on the subtext paragraph was also dropped since it no longer precedes another element.

## Changes

- `frontend/vuejs/src/apps/imagi/project-manager/views/Projects.vue`: removed the arrow + hint text div from the empty state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H8ni35dw2j4Hmcdy1kr4mX

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8ni35dw2j4Hmcdy1kr4mX)_