### PR TITLE
Reduce footer height for better proportions

### DIFF
--- a/frontend/vuejs/src/shared/components/organisms/navigation/BaseFooter.vue
+++ b/frontend/vuejs/src/shared/components/organisms/navigation/BaseFooter.vue
@@ -3,7 +3,7 @@
     <div class="relative max-w-7xl mx-auto px-6 sm:px-8 lg:px-12">
       
       <!-- Main footer content -->
-      <div class="py-16">
+      <div class="py-10">
         <div class="grid grid-cols-2 sm:grid-cols-4 gap-8 lg:gap-16">
           
           <!-- Product section -->
@@ -93,7 +93,7 @@
       </div>
 
       <!-- Bottom bar -->
-      <div class="py-6 border-t border-gray-200 dark:border-white/[0.12] transition-colors duration-300">
+      <div class="py-5 border-t border-gray-200 dark:border-white/[0.12] transition-colors duration-300">
         <div class="flex items-center justify-between">
           <p class="text-gray-500 dark:text-white/50 text-sm transition-colors duration-300">
             &copy; {{ currentYear }} Imagi. All rights reserved.


### PR DESCRIPTION
## Summary

Slightly decreases the height of the site footer so it sits more proportionally with the rest of the page sections across the Imagi website.

## Changes

- `BaseFooter.vue`: main footer content padding reduced from `py-16` (64px) → `py-10` (40px)
- `BaseFooter.vue`: bottom bar padding reduced from `py-6` (24px) → `py-5` (20px)

These are vertical-spacing-only tweaks — no layout, links, or content change. The footer keeps comfortable breathing room while taking up less vertical space, making it feel better balanced against the other sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAZdxykoB8Nh3JEkmS5QsW

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAZdxykoB8Nh3JEkmS5QsW)_