### PR TITLE
Fix project create-button feedback and make delete notifications visible

### DIFF
--- a/frontend/vuejs/src/App.vue
+++ b/frontend/vuejs/src/App.vue
@@ -5,11 +5,15 @@
         <component :is="Component" />
       </transition>
     </router-view>
+
+    <!-- Global toast notifications (create/delete feedback, auth prompts, etc.) -->
+    <NotificationToast />
   </div>
 </template>
 
 <script setup lang="ts">
 import { useThemeStore } from '@/shared/stores/theme'
+import { NotificationToast } from '@/shared/components/atoms'
 
 const themeStore = useThemeStore()
 

--- a/frontend/vuejs/src/apps/imagi/project-manager/views/Projects.vue
+++ b/frontend/vuejs/src/apps/imagi/project-manager/views/Projects.vue
@@ -112,6 +112,14 @@
 
                   <!-- Create Button -->
                   <div class="flex-shrink-0 pt-1">
+                    <!-- Why the button is disabled -->
+                    <p
+                      v-if="createHint && !isCreating"
+                      class="flex items-center gap-1.5 mb-2 text-xs text-amber-600 dark:text-amber-300 transition-colors duration-300"
+                    >
+                      <i class="fas fa-circle-info text-[11px]"></i>
+                      <span>{{ createHint }}</span>
+                    </p>
                     <button
                       @click="createProject"
                       :disabled="!canCreate || isCreating"
@@ -167,33 +175,6 @@
                     >
                   </div>
                 </div>
-
-                <!-- Inline Delete Success Notification -->
-                <Transition
-                  enter-active-class="transition-all duration-300 ease-out"
-                  enter-from-class="opacity-0 -translate-y-2"
-                  enter-to-class="opacity-100 translate-y-0"
-                  leave-active-class="transition-all duration-200 ease-in"
-                  leave-from-class="opacity-100 translate-y-0"
-                  leave-to-class="opacity-0 -translate-y-2"
-                >
-                  <div
-                    v-if="deletedProjectMessage"
-                    class="mb-4 p-3 rounded-xl bg-red-50 dark:bg-red-500/10 border border-red-200 dark:border-red-400/30 flex items-center gap-3 flex-shrink-0"
-                  >
-                    <div class="w-8 h-8 rounded-lg bg-red-100 dark:bg-red-500/20 border border-red-200 dark:border-red-400/30 flex items-center justify-center flex-shrink-0">
-                      <i class="fas fa-trash-alt text-red-600 dark:text-red-300 text-sm"></i>
-                    </div>
-                    <p class="flex-1 text-sm font-medium text-blue-950 dark:text-red-100">{{ deletedProjectMessage }}</p>
-                    <button
-                      @click="clearDeletedProjectMessage"
-                      class="w-6 h-6 rounded-lg flex items-center justify-center text-red-400 dark:text-red-300/70 hover:text-red-600 dark:hover:text-red-200 hover:bg-red-100 dark:hover:bg-red-500/20 transition-all duration-200"
-                      aria-label="Dismiss"
-                    >
-                      <i class="fas fa-times text-xs"></i>
-                    </button>
-                  </div>
-                </Transition>
 
                 <!-- Content Section -->
                 <div class="flex-1 flex flex-col min-h-0">
@@ -297,31 +278,28 @@ const canCreate = computed(() =>
   Boolean(newProjectName.value.trim()) &&
   newProjectDescription.value.trim().length >= MIN_DESCRIPTION_LENGTH
 )
+
+// Explain why the Create button is disabled so users aren't left guessing.
+// Empty while the form is valid (canCreate === true).
+const createHint = computed(() => {
+  if (!newProjectName.value.trim()) {
+    return 'Enter a business name to continue.'
+  }
+  const remaining = MIN_DESCRIPTION_LENGTH - newProjectDescription.value.trim().length
+  if (remaining > 0) {
+    return `Add ${remaining} more character${remaining === 1 ? '' : 's'} to the business description to continue.`
+  }
+  return ''
+})
 const isInitializing = ref(true)
-const deletedProjectMessage = ref('')
-let deleteMessageTimeout: ReturnType<typeof setTimeout> | null = null
 
-// Clear the inline delete success message
-const clearDeletedProjectMessage = () => {
-  deletedProjectMessage.value = ''
-  if (deleteMessageTimeout) {
-    clearTimeout(deleteMessageTimeout)
-    deleteMessageTimeout = null
-  }
-}
-
-// Show inline delete success message with auto-clear
+// Show a global toast confirming a project was deleted.
 const showDeleteSuccess = (projectName: string) => {
-  // Clear any existing timeout
-  if (deleteMessageTimeout) {
-    clearTimeout(deleteMessageTimeout)
-  }
-  deletedProjectMessage.value = `"${projectName}" deleted successfully`
-  // Auto-clear after 4 seconds
-  deleteMessageTimeout = setTimeout(() => {
-    deletedProjectMessage.value = ''
-    deleteMessageTimeout = null
-  }, 4000)
+  showNotification({
+    type: 'delete',
+    message: `"${projectName}" deleted successfully`,
+    duration: 4000
+  })
 }
 
 // Computed
@@ -648,12 +626,6 @@ onBeforeUnmount(() => {
   // Clear dashboard-specific notifications when leaving
   const notificationStore = useNotificationStore()
   notificationStore.clear()
-  
-  // Clear delete message timeout
-  if (deleteMessageTimeout) {
-    clearTimeout(deleteMessageTimeout)
-    deleteMessageTimeout = null
-  }
 })
 
 // Watch auth store authentication status


### PR DESCRIPTION
## Summary

Two fixes to the project-manager workspace (`Projects.vue`) around creating and deleting projects.

### 1. Create button couldn't be clicked
The **Create Project** button is gated on `canCreate`, which requires the business description to be at least 20 characters — but nothing on screen explained that, so the button silently stayed disabled and users had no idea why. Added a live hint above the button that says exactly what's missing ("Enter a business name…" / "Add N more characters to the business description…"). The hint disappears the moment the form is valid.

### 2. Delete notifications weren't visible
The global `NotificationToast` component was exported from the atoms barrel but **never mounted anywhere**, so every `showNotification()` toast — create errors, delete feedback, "please log in" prompts — was invisible app-wide.

- Mounted `NotificationToast` once in `App.vue`.
- Routed the delete-success message through the now-visible global toast (`type: 'delete'`), and removed the redundant bespoke inline banner and its timer/state.

The delete flow itself (confirm modal → `projectStore.deleteProject` → list refresh, including the 404-as-success path) was already correct; it just lacked a visible confirmation.

## Testing
- `npm run type-check` — passes
- `npm run build-only` — succeeds (pre-existing chunk-size warning only)

## Files changed
- `frontend/vuejs/src/App.vue` — mount global toast
- `frontend/vuejs/src/apps/imagi/project-manager/views/Projects.vue` — create-button hint + toast-based delete notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjtEuwrRb7yvTFiuUzqMAm)_