### PR TITLE
Fix project deletion leaving Projects panel stuck spinning

### DIFF
--- a/frontend/vuejs/src/apps/imagi/build/stores/__tests__/projectStore.spec.ts
+++ b/frontend/vuejs/src/apps/imagi/build/stores/__tests__/projectStore.spec.ts
@@ -122,7 +122,7 @@ describe('project store', () => {
       await expect(store.deleteProject('1')).rejects.toThrow('You must be logged in')
     })
 
-    it('optimistically removes the project and records the deletion', async () => {
+    it('optimistically removes the project, leaving the rest', async () => {
       projectService.deleteProject.mockResolvedValue(undefined)
       const store = useProjectStore()
       store.setAuthenticated(true)
@@ -135,9 +135,25 @@ describe('project store', () => {
 
       expect(store.getProjectById('2')).toBeUndefined()
       expect(store.projects.map((p) => p.name)).toEqual(['Keep'])
-      const deleted = JSON.parse(localStorage.getItem('deletedProjects') || '[]')
-      expect(deleted).toContain('2')
       expect(projectService.deleteProject).toHaveBeenCalledWith('2')
+    })
+
+    it('restores the project when the server rejects a real error', async () => {
+      const err: any = new Error('server exploded')
+      err.response = { status: 500 }
+      projectService.deleteProject.mockRejectedValue(err)
+      const store = useProjectStore()
+      store.setAuthenticated(true)
+      store.updateProjects([
+        { id: 1, name: 'Keep' },
+        { id: 2, name: 'Remove' },
+      ])
+
+      await expect(store.deleteProject('2')).rejects.toThrow('server exploded')
+
+      // The optimistic removal is rolled back so the list stays truthful.
+      expect(store.getProjectById('2')?.name).toBe('Remove')
+      expect(store.projects.map((p) => p.name)).toEqual(['Keep', 'Remove'])
     })
 
     it('does not raise the list loading flag while deleting', async () => {

--- a/frontend/vuejs/src/apps/imagi/build/stores/__tests__/projectStore.spec.ts
+++ b/frontend/vuejs/src/apps/imagi/build/stores/__tests__/projectStore.spec.ts
@@ -140,6 +140,25 @@ describe('project store', () => {
       expect(projectService.deleteProject).toHaveBeenCalledWith('2')
     })
 
+    it('does not raise the list loading flag while deleting', async () => {
+      // Deletion is optimistic, so it must not flip `loading` — otherwise the
+      // Project Library panel flashes (or hangs on) its full-page spinner.
+      const store = useProjectStore()
+      let loadingDuringServerCall = false
+      projectService.deleteProject.mockImplementation(async () => {
+        loadingDuringServerCall = store.loading
+      })
+      store.setAuthenticated(true)
+      store.updateProjects([{ id: 1, name: 'Only' }])
+
+      await store.deleteProject('1')
+
+      expect(loadingDuringServerCall).toBe(false)
+      expect(store.loading).toBe(false)
+      // The last project is gone, so the view renders its empty state.
+      expect(store.projects).toHaveLength(0)
+    })
+
     it('treats a 404 from the server as success', async () => {
       const err: any = new Error('not found')
       err.response = { status: 404 }

--- a/frontend/vuejs/src/apps/imagi/build/stores/projectStore.ts
+++ b/frontend/vuejs/src/apps/imagi/build/stores/projectStore.ts
@@ -55,11 +55,6 @@ export const useProjectStore = defineStore('builder', () => {
     () => globalAuthStore.isAuthenticated,
     (newValue) => {
       setAuthenticated(newValue)
-      
-      // Clean up old deleted projects when auth state changes
-      if (newValue) {
-        cleanupDeletedProjects()
-      }
     },
     { immediate: true }
   )
@@ -249,71 +244,14 @@ export const useProjectStore = defineStore('builder', () => {
         }
         
         console.debug(`Fetched ${projectsData.length} projects from API`)
-        
-        // Get list of recently deleted project IDs
-        let deletedProjectIds: string[] = []
-        try {
-          deletedProjectIds = JSON.parse(localStorage.getItem('deletedProjects') || '[]')
-        } catch (e) {
-          console.warn('Failed to parse deleted projects from localStorage:', e)
-        }
-        
-        // Filter out recently deleted projects from the fetched data
-        const filteredProjects = projectsData.filter(project => {
-          // Skip projects that are in the deleted list
-          if (project && project.id && deletedProjectIds.includes(String(project.id))) {
-            console.debug(`Filtering out deleted project: ${project.id}`)
-            return false
-          }
-          return true
-        })
-        
-        console.debug(`After filtering deleted projects: ${filteredProjects.length} projects remaining`)
-        
-        // Update projects in store
-        updateProjects(filteredProjects)
+
+        // The server is the source of truth: a deleted project is gone from
+        // this response, so the list can be stored as-is.
+        updateProjects(projectsData)
         initialized.value = true
         lastFetch.value = new Date()
-        
-        // Clean up old deleted project IDs (older than 1 hour)
-        try {
-          const ONE_HOUR = 60 * 60 * 1000
-          const now = Date.now()
-          const deletedProjectsWithTimestamp = JSON.parse(localStorage.getItem('deletedProjectsTimestamp') || '{}')
-          
-          // Keep track of which projects to remove from the deleted list
-          const projectsToRemove: string[] = []
-          
-          for (const projectId of deletedProjectIds) {
-            const timestamp = deletedProjectsWithTimestamp[projectId]
-            if (timestamp && (now - timestamp) > ONE_HOUR) {
-              projectsToRemove.push(projectId)
-            } else if (!timestamp) {
-              // Add timestamp for projects that don't have one yet
-              deletedProjectsWithTimestamp[projectId] = now
-            }
-          }
-          
-          // Remove expired deleted projects
-          if (projectsToRemove.length > 0) {
-            const updatedDeletedProjects = deletedProjectIds.filter(id => !projectsToRemove.includes(id))
-            localStorage.setItem('deletedProjects', JSON.stringify(updatedDeletedProjects))
-            
-            // Also update the timestamps
-            for (const projectId of projectsToRemove) {
-              delete deletedProjectsWithTimestamp[projectId]
-            }
-            
-            localStorage.setItem('deletedProjectsTimestamp', JSON.stringify(deletedProjectsWithTimestamp))
-          } else {
-            // Just update the timestamps
-            localStorage.setItem('deletedProjectsTimestamp', JSON.stringify(deletedProjectsWithTimestamp))
-          }
-        } catch (e) {
-          console.warn('Failed to clean up old deleted project IDs:', e)
-        }
-        
-        return filteredProjects
+
+        return projectsData
       } catch (err: any) {
         handleError(err, 'Failed to fetch projects')
         return []
@@ -529,58 +467,38 @@ export const useProjectStore = defineStore('builder', () => {
     // into its "Loading your projects..." state during every delete.
     error.value = null
 
-    try {
-      console.debug('Deleting project:', {
-        projectId,
-        existingProject: projectsMap.value.get(String(projectId))
-      })
+    const deletedProjectId = String(projectId)
 
-      const deletedProjectId = String(projectId)
-      
-      // Store deleted project IDs in localStorage FIRST to prevent any race conditions
-      // This ensures no other part of the app tries to fetch this project during deletion
-      try {
-        const deletedProjects = JSON.parse(localStorage.getItem('deletedProjects') || '[]')
-        if (!deletedProjects.includes(deletedProjectId)) {
-          deletedProjects.push(deletedProjectId)
-          localStorage.setItem('deletedProjects', JSON.stringify(deletedProjects))
-          
-          // Also store timestamp for cleanup purposes
-          const deletedProjectsTimestamp = JSON.parse(localStorage.getItem('deletedProjectsTimestamp') || '{}')
-          deletedProjectsTimestamp[deletedProjectId] = Date.now()
-          localStorage.setItem('deletedProjectsTimestamp', JSON.stringify(deletedProjectsTimestamp))
-        }
-      } catch (e) {
-        console.error('Failed to store deleted project ID in localStorage:', e)
-      }
-      
-      // Remove from local state IMMEDIATELY to update the UI
+    // Snapshot the project and its position so we can restore it if the server
+    // rejects the delete.
+    const removedIndex = projects.value.findIndex(p => String(p.id) === deletedProjectId)
+    const removedProject = removedIndex >= 0 ? projects.value[removedIndex] : null
+
+    try {
+      console.debug('Deleting project:', { projectId, existingProject: removedProject })
+
+      // Remove from local state IMMEDIATELY to update the UI (optimistic delete).
       projects.value = projects.value.filter(p => String(p.id) !== deletedProjectId)
       projectsMap.value.delete(deletedProjectId)
-      
+
       // Clear current project if it's the one being deleted
       if (currentProject.value && String(currentProject.value.id) === deletedProjectId) {
         currentProject.value = null
       }
-      
+
       // Clear any cached fetch promises for this project
       projectFetchPromises.value.delete(deletedProjectId)
       lastProjectFetch.value.delete(deletedProjectId)
-      
+
       console.debug('Project removed from local state:', {
         remainingProjects: projects.value.length,
         deletedId: deletedProjectId
       })
-      
-      // Now delete the project on the server (this will also clear the cache)
+
+      // Delete on the server (this also clears the cached project list).
       await ProjectService.deleteProject(projectId)
-      
+
       console.debug('Project deleted from server successfully')
-      
-      // Do NOT immediately refresh projects to avoid race conditions
-      // Let the calling component decide when to refresh if needed
-      // This prevents 404 errors during the deletion process
-      
     } catch (err: any) {
       console.error('Project deletion error in store:', {
         error: err,
@@ -589,38 +507,22 @@ export const useProjectStore = defineStore('builder', () => {
         data: err.response?.data,
         projectId
       })
-      
-      // If we get a 404, the project was already deleted - treat as success
+
+      // A 404 means the project is already gone on the server — exactly the end
+      // state we wanted, so treat it as success and keep the optimistic removal.
       if (err.response?.status === 404) {
         console.debug('Project already deleted (404), treating as success')
-        
-        // Local state cleanup was already done above, so just return success
-        // Don't throw error for 404 - project is gone which is what we wanted
         return
       }
-      
-      // For other errors, restore the project to local state since deletion failed
-      // and remove it from the deleted projects list
-      const deletedProjectId = String(projectId)
-      
-      try {
-        // Remove from deleted projects list since deletion failed
-        const deletedProjects = JSON.parse(localStorage.getItem('deletedProjects') || '[]')
-        const updatedDeletedProjects = deletedProjects.filter((id: string) => id !== deletedProjectId)
-        localStorage.setItem('deletedProjects', JSON.stringify(updatedDeletedProjects))
-        
-        // Also remove timestamp
-        const deletedProjectsTimestamp = JSON.parse(localStorage.getItem('deletedProjectsTimestamp') || '{}')
-        delete deletedProjectsTimestamp[deletedProjectId]
-        localStorage.setItem('deletedProjectsTimestamp', JSON.stringify(deletedProjectsTimestamp))
-        
-        console.debug('Removed project from deleted list due to deletion failure')
-      } catch (e) {
-        console.warn('Failed to remove project from deleted list after error:', e)
+
+      // A real failure: restore the project to local state so the UI stays
+      // truthful about what still exists.
+      if (removedProject && !projectsMap.value.has(deletedProjectId)) {
+        const restored = [...projects.value]
+        restored.splice(removedIndex >= 0 ? removedIndex : restored.length, 0, removedProject)
+        projects.value = restored
+        projectsMap.value.set(deletedProjectId, removedProject)
       }
-      
-      // We don't need to restore to projects array since we need to refresh from API anyway
-      // The calling component will handle refreshing the project list
 
       handleError(err, 'Failed to delete project')
       throw err
@@ -638,22 +540,7 @@ export const useProjectStore = defineStore('builder', () => {
     if (!projectId) {
       return null
     }
-    
-    // Check if project is in the deleted projects list - fail fast
-    try {
-      const deletedProjects = JSON.parse(localStorage.getItem('deletedProjects') || '[]')
-      if (deletedProjects.includes(String(projectId))) {
-        console.debug(`ProjectStore: Project ${projectId} is in deleted list, not fetching`)
-        error.value = 'Project not found'
-        throw new Error('Project not found')
-      }
-    } catch (parseError) {
-      if (parseError instanceof Error && parseError.message === 'Project not found') {
-        throw parseError
-      }
-      // Handle JSON parsing errors silently and continue
-    }
-    
+
     // Check if there's an existing in-progress fetch for this project
     if (projectFetchPromises.value.has(projectId)) {
       console.debug(`ProjectStore: Reusing existing fetch promise for project ${projectId}`)
@@ -736,21 +623,7 @@ export const useProjectStore = defineStore('builder', () => {
         }
       } catch (err: any) {
         console.error('ProjectStore: Error fetching project', err)
-        
-        // If project not found (404), add it to deleted projects list to prevent future attempts
-        if (err.response?.status === 404 || err.message?.includes('Project not found')) {
-          console.debug(`ProjectStore: Project ${projectId} not found, adding to deleted list`)
-          try {
-            const deletedProjects = JSON.parse(localStorage.getItem('deletedProjects') || '[]')
-            if (!deletedProjects.includes(String(projectId))) {
-              deletedProjects.push(String(projectId))
-              localStorage.setItem('deletedProjects', JSON.stringify(deletedProjects))
-            }
-          } catch (e) {
-            // Handle localStorage errors silently
-          }
-        }
-        
+
         error = err
         throw err
       } finally {
@@ -790,40 +663,6 @@ export const useProjectStore = defineStore('builder', () => {
   function setLoading(isLoadingState: boolean) {
     loading.value = isLoadingState
     isLoading.value = isLoadingState // Update both for compatibility
-  }
-
-  // Utility function to clean up old deleted project IDs
-  function cleanupDeletedProjects() {
-    try {
-      const deletedProjects = JSON.parse(localStorage.getItem('deletedProjects') || '[]')
-      const deletedProjectsTimestamp = JSON.parse(localStorage.getItem('deletedProjectsTimestamp') || '{}')
-      const now = Date.now()
-      const maxAge = 24 * 60 * 60 * 1000 // 24 hours
-      
-      // Remove projects that were deleted more than 24 hours ago
-      const recentlyDeleted = deletedProjects.filter((projectId: string) => {
-        const deleteTime = deletedProjectsTimestamp[projectId]
-        return deleteTime && (now - deleteTime) < maxAge
-      })
-      
-      // Update localStorage if there were changes
-      if (recentlyDeleted.length !== deletedProjects.length) {
-        localStorage.setItem('deletedProjects', JSON.stringify(recentlyDeleted))
-        
-        // Also clean up timestamps
-        const cleanedTimestamps: Record<string, number> = {}
-        recentlyDeleted.forEach((projectId: string) => {
-          if (deletedProjectsTimestamp[projectId]) {
-            cleanedTimestamps[projectId] = deletedProjectsTimestamp[projectId]
-          }
-        })
-        localStorage.setItem('deletedProjectsTimestamp', JSON.stringify(cleanedTimestamps))
-        
-        console.debug(`Cleaned up ${deletedProjects.length - recentlyDeleted.length} old deleted project IDs`)
-      }
-    } catch (e) {
-      console.debug('Error cleaning up deleted projects:', e)
-    }
   }
 
   /**

--- a/frontend/vuejs/src/apps/imagi/build/stores/projectStore.ts
+++ b/frontend/vuejs/src/apps/imagi/build/stores/projectStore.ts
@@ -523,9 +523,12 @@ export const useProjectStore = defineStore('builder', () => {
       throw new Error('Project ID is required')
     }
 
-    loading.value = true
+    // Note: deletion is optimistic (the project is removed from the list below
+    // before the server round-trip), so we deliberately do NOT toggle the shared
+    // `loading` flag here. Doing so would flash the whole Project Library panel
+    // into its "Loading your projects..." state during every delete.
     error.value = null
-    
+
     try {
       console.debug('Deleting project:', {
         projectId,
@@ -618,11 +621,9 @@ export const useProjectStore = defineStore('builder', () => {
       
       // We don't need to restore to projects array since we need to refresh from API anyway
       // The calling component will handle refreshing the project list
-      
+
       handleError(err, 'Failed to delete project')
       throw err
-    } finally {
-      loading.value = false
     }
   }
 

--- a/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
+++ b/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
@@ -750,28 +750,6 @@ onMounted(async () => {
     
     // Set the project ID from the found project
     projectId.value = String(foundProject.id);
-    
-    // IMPORTANT: Check if project is in deleted list BEFORE doing anything else
-    // This prevents any API calls or initialization for deleted projects
-    try {
-      const deletedProjects = JSON.parse(localStorage.getItem('deletedProjects') || '[]')
-      if (deletedProjects.includes(projectId.value)) {
-        // Show notification and redirect immediately
-        const { showNotification } = useNotification();
-        showNotification({
-          type: 'error',
-          message: `Project "${foundProject.name}" has been deleted.`,
-          duration: 3000
-        });
-        
-        // Immediate redirect without waiting
-        router.replace({ name: 'projects' });
-        return; // Exit early to prevent any further initialization
-      }
-    } catch (e) {
-      // Handle localStorage errors silently and continue
-      console.warn('Error checking deleted projects list:', e)
-    }
 
     // Gate: the workspace must not open while the initial AI build is still
     // running, or the user would land in a half-built project. Check the
@@ -843,25 +821,10 @@ onMounted(async () => {
       console.error('Error loading project:', projectError);
       
       // Handle specific cases for missing projects
-      if (projectError.message?.includes('Project not found') || 
+      if (projectError.message?.includes('Project not found') ||
           projectError.response?.status === 404) {
         console.log('Project not found - redirecting to dashboard');
-        
-        // Add project to deleted list if it resulted in 404
-        try {
-          const deletedProjects = JSON.parse(localStorage.getItem('deletedProjects') || '[]')
-          if (!deletedProjects.includes(projectId.value)) {
-            deletedProjects.push(projectId.value)
-            localStorage.setItem('deletedProjects', JSON.stringify(deletedProjects))
-            
-            const deletedProjectsTimestamp = JSON.parse(localStorage.getItem('deletedProjectsTimestamp') || '{}')
-            deletedProjectsTimestamp[projectId.value] = Date.now()
-            localStorage.setItem('deletedProjectsTimestamp', JSON.stringify(deletedProjectsTimestamp))
-          }
-        } catch (e) {
-          console.warn('Failed to add project to deleted list:', e)
-        }
-        
+
         // Show a notification but redirect to dashboard to prevent further errors
         const { showNotification } = useNotification();
         showNotification({
@@ -927,28 +890,8 @@ watch(
       }
       
       const newProjectId = String(foundProject.id);
-      
-      // Check if the new project is in the deleted list
-      try {
-        const deletedProjects = JSON.parse(localStorage.getItem('deletedProjects') || '[]')
-        if (deletedProjects.includes(newProjectId)) {
-          // Show notification and redirect immediately
-          const { showNotification } = useNotification();
-          showNotification({
-            type: 'error',
-            message: `Project "${foundProject.name}" has been deleted.`,
-            duration: 3000
-          });
-          
-          // Immediate redirect without waiting
-          router.replace({ name: 'projects' });
-          return;
-        }
-      } catch (e) {
-        console.warn('Error checking deleted projects list during route change:', e)
-      }
-      
-      // If not deleted, update the project ID and reload
+
+      // Update the project ID and reload
       projectId.value = newProjectId
       // Could add logic here to reload the project if needed
     }

--- a/frontend/vuejs/src/apps/imagi/project-manager/views/Projects.vue
+++ b/frontend/vuejs/src/apps/imagi/project-manager/views/Projects.vue
@@ -203,7 +203,12 @@
                   </div>
 
                   <!-- Empty State -->
-                  <div v-else-if="!projects.length" class="flex-1 flex flex-col items-center justify-center">
+                  <!--
+                    Keyed off displayedProjects (what's actually shown) rather than
+                    the raw store list, so deleting the last project immediately
+                    surfaces this "No projects yet" state instead of a blank panel.
+                  -->
+                  <div v-else-if="!displayedProjects.length" class="flex-1 flex flex-col items-center justify-center">
                     <div class="w-12 h-12 rounded-xl bg-orange-100 dark:bg-orange-400/[0.14] ring-1 ring-orange-900/[0.08] dark:ring-orange-300/[0.18] flex items-center justify-center mb-4">
                       <i class="fas fa-folder-open text-orange-600 dark:text-orange-300 text-lg"></i>
                     </div>
@@ -212,7 +217,7 @@
                   </div>
 
                   <!-- Scrollable Project List -->
-                  <div v-else-if="displayedProjects.length > 0" class="flex-1 overflow-y-auto pr-2 pl-0.5 pt-1 pb-2 space-y-3 custom-scrollbar min-h-0">
+                  <div v-else class="flex-1 overflow-y-auto pr-2 pl-0.5 pt-1 pb-2 space-y-3 custom-scrollbar min-h-0">
                     <ProjectCard
                       v-for="(project, index) in displayedProjects"
                       :key="project.id"
@@ -464,99 +469,43 @@ const confirmDelete = async (project: Project) => {
   
   // Capture the project name before deletion to ensure we have it for the notification
   const projectName = project.name || `Project ${project.id}` || 'Unknown Project'
-  
+
   // Check if user is currently in the workspace for this project
-  const isCurrentlyInWorkspace = router.currentRoute.value.name === 'builder-workspace' && 
+  const isCurrentlyInWorkspace = router.currentRoute.value.name === 'builder-workspace' &&
                                  router.currentRoute.value.params.projectName === toSlug(project.name)
-  
+
   try {
-    // First clear the cache to ensure fresh data
-    projectStore.clearProjectsCache()
-    
-    // Mark project as deleted BEFORE making the API call to prevent race conditions
-    const deletedProjectId = String(project.id)
-    
-    // Add to deleted projects list immediately to prevent any fetching attempts
-    try {
-      const deletedProjects = JSON.parse(localStorage.getItem('deletedProjects') || '[]')
-      if (!deletedProjects.includes(deletedProjectId)) {
-        deletedProjects.push(deletedProjectId)
-        localStorage.setItem('deletedProjects', JSON.stringify(deletedProjects))
-        
-        // Also store timestamp for cleanup purposes
-        const deletedProjectsTimestamp = JSON.parse(localStorage.getItem('deletedProjectsTimestamp') || '{}')
-        deletedProjectsTimestamp[deletedProjectId] = Date.now()
-        localStorage.setItem('deletedProjectsTimestamp', JSON.stringify(deletedProjectsTimestamp))
-      }
-    } catch (e) {
-      console.error('Failed to store deleted project ID in localStorage:', e)
-    }
-    
+    // The store owns the delete: it optimistically removes the project from the
+    // list, records the deletion tombstone, clears the cache, and treats a 404
+    // from the server as success. Because the list updates optimistically, the
+    // UI reflects the deletion the moment this resolves — the remaining projects
+    // (or the "No projects yet" empty state) render immediately without waiting
+    // on a forced refetch that could hang or race and leave the panel spinning.
     await projectStore.deleteProject(String(project.id))
-    
-    // If user was in the workspace for this project, navigate away from it
-    if (isCurrentlyInWorkspace) {
-      console.log('User was in workspace for deleted project, redirecting to dashboard')
-      await router.push({ name: 'projects' })
-    }
-    
-    // Immediately refresh the projects list to show updated state
-    try {
-      await fetchProjects(true) // Force refresh to get latest state from API
-    } catch (refreshError) {
-      console.warn('Failed to refresh projects after deletion:', refreshError)
-    }
-    
-    // Show inline deletion success message in the Project Library section
+
+    // Confirm the deletion right away, independent of any background refresh.
     showDeleteSuccess(projectName)
 
+    // If the user was in the workspace for this project, navigate away from it.
+    if (isCurrentlyInWorkspace) {
+      await router.push({ name: 'projects' })
+    }
   } catch (error: any) {
     console.error('Error deleting project:', error)
-    
-    // Check if the error is actually a success (project was deleted but API returned unexpected response)
-    if (error.response?.status === 404) {
-      // Project is gone, which means deletion was successful
-      // Clear cache and refresh
-      projectStore.clearProjectsCache()
-      
 
-      
-      // If user was in the workspace for this project, navigate away from it
-      if (isCurrentlyInWorkspace) {
-        console.log('Project was deleted (404), redirecting from workspace to dashboard')
-        await router.push({ name: 'projects' })
-      }
-      
-            // Still refresh the projects list to ensure clean state
-      try {
-        await fetchProjects(true)
-      } catch (refreshError) {
-        console.warn('Failed to refresh projects after deletion:', refreshError)
-      }
-      
-      // Show inline deletion success message in the Project Library section
-      showDeleteSuccess(projectName)
-    } else {
-      // Actual error occurred - remove the project from deleted list if it was added
-      try {
-        const deletedProjects = JSON.parse(localStorage.getItem('deletedProjects') || '[]')
-        const updatedDeletedProjects = deletedProjects.filter((id: string) => id !== String(project.id))
-        localStorage.setItem('deletedProjects', JSON.stringify(updatedDeletedProjects))
-        
-        // Also remove timestamp
-        const deletedProjectsTimestamp = JSON.parse(localStorage.getItem('deletedProjectsTimestamp') || '{}')
-        delete deletedProjectsTimestamp[String(project.id)]
-        localStorage.setItem('deletedProjectsTimestamp', JSON.stringify(deletedProjectsTimestamp))
-      } catch (e) {
-        console.warn('Failed to remove project from deleted list after error:', e)
-      }
-      
-              // Show actual error with captured project name
-        showNotification({
-          message: error?.message || `Failed to delete "${projectName}"`,
-          type: 'error',
-          duration: 5000
-        })
+    // A real failure (the store already treats 404 as success). The optimistic
+    // removal leaves the project missing from the list, so reconcile with the
+    // server to bring it back, then report the error.
+    showNotification({
+      message: error?.message || `Failed to delete "${projectName}"`,
+      type: 'error',
+      duration: 5000
+    })
+
+    try {
+      await fetchProjects(true)
+    } catch (refreshError) {
+      console.warn('Failed to refresh projects after failed deletion:', refreshError)
     }
   }
 }

--- a/frontend/vuejs/src/apps/imagi/project-manager/views/Projects.vue
+++ b/frontend/vuejs/src/apps/imagi/project-manager/views/Projects.vue
@@ -303,37 +303,26 @@ const { searchQuery, filteredProjects } = useProjectSearch(normalizedProjects, {
 
 // Compute displayed projects
 const displayedProjects = computed<Project[]>(() => {
-  let deletedProjects: string[] = [];
-  try {
-    deletedProjects = JSON.parse(localStorage.getItem('deletedProjects') || '[]');
-  } catch (e) {
-    // Handle localStorage errors silently
-  }
-  
   const hasSearchQuery = searchQuery.value?.trim().length > 0;
-  let baseProjects: Project[] = [];
-  
+
   if (hasSearchQuery) {
-    baseProjects = filteredProjects.value || [];
-  } else {
-    if (!normalizedProjects.value?.length) {
-      return [];
-    }
-    
-    baseProjects = [...normalizedProjects.value]
-      .sort((a, b) => {
-        if (!a.updated_at) return 1;
-        if (!b.updated_at) return -1;
-        
-        const dateA = new Date(a.updated_at).getTime()
-        const dateB = new Date(b.updated_at).getTime()
-        return dateB - dateA
-      })
+    return (filteredProjects.value || []).filter(project => project && project.id);
   }
-  
-  return baseProjects.filter(project => 
-    project && project.id && !deletedProjects.includes(String(project.id))
-  );
+
+  if (!normalizedProjects.value?.length) {
+    return [];
+  }
+
+  return [...normalizedProjects.value]
+    .filter(project => project && project.id)
+    .sort((a, b) => {
+      if (!a.updated_at) return 1;
+      if (!b.updated_at) return -1;
+
+      const dateA = new Date(a.updated_at).getTime()
+      const dateB = new Date(b.updated_at).getTime()
+      return dateB - dateA
+    });
 });
 
 /**


### PR DESCRIPTION
## Summary

Fixes the project deletion flow and then removes the machinery that made it fragile in the first place. Two commits:

1. **Fix the stuck spinner / missing confirmation** on delete.
2. **Remove the localStorage tombstone system** so the deletion path is simple and server-authoritative.

### Behavior after this PR

- **On delete** → the confirmation toast (`"<name>" deleted successfully`) shows immediately.
- **No projects left** → the "No projects yet" empty state renders right away.
- **Other projects remain** → the remaining projects render in place.
- **Real server failure** → the project is restored to the list and an error toast is shown.

## Commit 1 — Fix the stuck panel

Root causes:
- `confirmDelete` gated both the confirmation toast **and** the post-delete UI update behind an awaited forced `fetchProjects(true)`. That refetch re-raised the full-page loader — if it hung or raced, the spinner stayed up and the toast never fired.
- The empty state keyed off the raw store list (`!projects.length`) while the list keyed off the filtered `displayedProjects`, creating a dead zone where neither branch rendered.
- The store's `deleteProject` toggled the shared `loading` flag, flashing the whole panel into its loading state on every delete.

Fixes: rely on the store's optimistic removal, show the confirmation immediately, key the empty state off `displayedProjects`, and stop `deleteProject` from raising the list loader. The blocking refetch now runs only on the error path.

## Commit 2 — Remove the tombstone system

The `deletedProjects` / `deletedProjectsTimestamp` localStorage tombstones were a defensive workaround against a deleted project reappearing from a stale frontend cache. They're unnecessary — the backend delete is synchronous (204 only after the project is actually gone), the store removes the project optimistically and clears the cached list, and the next fetch reads the server as the source of truth. The tombstones added a lot of cross-file bookkeeping and the very dead zone fixed above.

Removed across `projectStore.ts`, `Projects.vue`, and `Workspace.vue`: the fetch-time filtering, the delete-time writes + restore bookkeeping, the workspace fail-fast checks and 404 writes, and the `cleanupDeletedProjects` helper. `deleteProject` now rolls back its optimistic removal **in memory** on a real (non-404) error, keeping the list truthful without touching localStorage. Net **−213 lines**.

## Testing

- `vitest` project store suite: 13 passed (added rollback + no-loading-flag tests; dropped the tombstone assertion)
- Full `vitest` run: 57 passed (the 15 reported errors are a pre-existing jsdom `scrollTo` limitation in `ChatConversation.spec.ts`, unrelated to this PR)
- `vue-tsc` type-check: clean
- `eslint`: no new warnings or errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxvPu9YWVbct2fZmjP1m3C