### PR TITLE
Redesign home page with warm porcelain editorial style

### DIFF
--- a/frontend/vuejs/index.html
+++ b/frontend/vuejs/index.html
@@ -6,6 +6,9 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="/favicon.ico">
     <title>Imagi - Build and Run Your Business</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT,WONK@0,9..144,400..700,0..100,0..1;1,9..144,400..700,0..100,0..1&family=Instrument+Sans:ital,wght@0,400..700;1,400..700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" />
     <script>
       // Apply the saved theme before first paint to avoid a flash of the wrong theme.

--- a/frontend/vuejs/src/apps/home/components/organisms/navigation/HomeNavbar.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/navigation/HomeNavbar.vue
@@ -1,11 +1,6 @@
 <!-- Home navigation component -->
 <template>
   <BaseNavbar fluid>
-    <!-- Logo override -->
-    <template #logo>
-      <span class="text-xl font-bold text-blue-950 dark:text-white tracking-tight transition-colors duration-300">Imagi</span>
-    </template>
-
     <!-- Center menu -->
     <template #center>
       <div class="flex items-center space-x-4">
@@ -17,7 +12,7 @@
           text-style
         >
           Product
-          
+
           <template #menu>
             <router-link
               :to="{ name: 'builder' }"
@@ -52,28 +47,22 @@
       <!-- Auth Buttons -->
       <div class="flex items-center space-x-3">
         <template v-if="isAuthenticated">
+          <!-- Sign Out: quiet hairline pill — a non-promoted action -->
           <button
             type="button"
             @click="handleLogout"
-            class="btn-3d btn-accent group relative inline-flex items-center justify-center min-w-[100px] px-6 py-2.5 text-blue-950 rounded-full font-medium text-sm overflow-hidden border border-white/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
+            class="inline-flex items-center justify-center px-5 py-2 rounded-full font-medium text-sm border border-blue-950/[0.14] text-blue-950/80 hover:text-blue-950 hover:border-blue-950/30 hover:bg-blue-950/[0.03] dark:border-white/[0.16] dark:text-blue-100/80 dark:hover:text-white dark:hover:border-white/30 dark:hover:bg-white/[0.06] transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
           >
-            <!-- Top edge highlight for 3D effect -->
-            <span class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/70 to-transparent"></span>
-            <!-- Bottom edge shadow for depth -->
-            <span class="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-blue-900/15 to-transparent"></span>
-            <span class="relative">Sign Out</span>
+            Sign Out
           </button>
         </template>
         <template v-else>
+          <!-- Sign In: small navy ink pill — the one conversion action in the bar -->
           <router-link
             to="/auth/signin"
-            class="btn-3d btn-accent group relative inline-flex items-center justify-center min-w-[100px] px-6 py-2.5 text-blue-950 rounded-full font-medium text-sm overflow-hidden border border-white/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
+            class="inline-flex items-center justify-center px-5 py-2 rounded-full font-medium text-sm bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white transition-colors duration-200 shadow-[0_1px_2px_rgba(23,37,84,0.2),0_3px_8px_-2px_rgba(23,37,84,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
           >
-            <!-- Top edge highlight for 3D effect -->
-            <span class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/70 to-transparent"></span>
-            <!-- Bottom edge shadow for depth -->
-            <span class="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-blue-900/15 to-transparent"></span>
-            <span class="relative">Sign In</span>
+            Sign In
           </router-link>
         </template>
       </div>
@@ -151,41 +140,5 @@ export default defineComponent({
 /* Add transition for dropdown chevron */
 .fa-chevron-down {
   transition: transform 0.2s ease-in-out;
-}
-
-/* Soft 3D button effect matching the hero "Start Building" button - blue-tinted shadows for the baby-blue fill. */
-.btn-3d {
-  transform: translateY(0) translateZ(0);
-  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
-  box-shadow:
-    0 1px 2px rgba(30, 58, 138, 0.14),
-    0 4px 10px -2px rgba(30, 58, 138, 0.16),
-    0 10px 20px -6px rgba(30, 58, 138, 0.18),
-    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
-    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.12);
-}
-
-.btn-3d:active {
-  transform: translateY(0) translateZ(0);
-  transition-duration: 0.1s;
-}
-
-/* Soft baby-blue gradient fill */
-.btn-accent {
-  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
-}
-
-.dark .btn-accent {
-  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
-}
-
-/* On dark, ground the light button with deep neutral shadows; keep the inner sheen */
-.dark .btn-3d {
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.5),
-    0 4px 10px -2px rgba(0, 0, 0, 0.45),
-    0 10px 20px -6px rgba(0, 0, 0, 0.5),
-    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
-    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.18);
 }
 </style>

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/CTASection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/CTASection.vue
@@ -1,41 +1,55 @@
-<!-- CTA Section - Clean Apple/Cursor-inspired design -->
+<!-- CTA Section - full-canvas editorial finale that bookends the hero -->
 <template>
-  <section class="relative py-24 sm:py-32 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-[#16120e] border-t border-orange-200/60 dark:border-orange-400/[0.14] transition-colors duration-500 overflow-hidden">
+  <section class="relative py-28 sm:py-36 px-6 sm:px-8 lg:px-12 transition-colors duration-500">
 
-    <div class="relative max-w-4xl mx-auto text-center">
+    <!-- One warm wash behind the headline, echoing the hero's apricot glow -->
+    <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
+      <div class="cta-glow-warm absolute top-8 left-1/2 -translate-x-1/2 w-[760px] h-[440px]"></div>
+    </div>
 
-      <!-- Content -->
-      <h2 class="text-4xl sm:text-5xl md:text-6xl font-semibold text-blue-950 dark:text-white mb-6 tracking-tight text-balance transition-colors duration-300">
-        {{ title }}
-      </h2>
+    <div class="relative max-w-6xl mx-auto">
 
-      <p class="text-xl text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty mb-10 max-w-2xl mx-auto transition-colors duration-300">
-        {{ description }}
-      </p>
-      
-      <!-- Buttons with 3D printed styling -->
-      <div class="flex flex-col sm:flex-row gap-4 justify-center">
-        <router-link
-          :to="getAuthenticatedRedirect"
-          class="btn-3d btn-accent group relative inline-flex items-center justify-center gap-3 px-8 py-4 text-blue-950 rounded-full font-medium text-lg overflow-hidden border border-white/60 dark:border-white/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#16120e]"
-        >
-          <!-- Top edge highlight for 3D effect -->
-          <span class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/70 to-transparent"></span>
-          <!-- Bottom edge shadow for depth -->
-          <span class="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-blue-900/15 to-transparent"></span>
-          <span class="relative">{{ primaryButtonText }}</span>
-          <svg class="relative w-5 h-5 transition-transform duration-300 group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
-          </svg>
-        </router-link>
-        
-        <router-link 
-          v-if="showSecondaryButton"
-          :to="secondaryButtonTo"
-          class="group relative inline-flex items-center justify-center gap-2 px-8 py-4 bg-transparent text-orange-700 dark:text-orange-300 rounded-full font-medium text-lg overflow-hidden border-2 border-orange-500/60 dark:border-orange-400/50 hover:bg-orange-50 dark:hover:bg-orange-500/10 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500/40 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#16120e]"
-        >
-          <span class="relative">{{ secondaryButtonText }}</span>
-        </router-link>
+      <!-- Hairline divider -->
+      <div class="section-divider mb-20 md:mb-24" aria-hidden="true"></div>
+
+      <div v-reveal class="max-w-3xl mx-auto text-center">
+
+        <!-- Headline: the largest type after the hero, closing on the same voice -->
+        <h2 class="font-display text-5xl sm:text-6xl md:text-[4.5rem] font-semibold text-blue-950 dark:text-white mb-7 tracking-[-0.02em] leading-[1.05] text-balance transition-colors duration-300">
+          {{ titleLead }} <em class="cta-accent not-italic">{{ titleAccent }}</em>
+        </h2>
+
+        <p class="text-lg sm:text-xl text-blue-950/65 dark:text-blue-100/65 leading-relaxed text-pretty mb-11 max-w-xl mx-auto transition-colors duration-300">
+          {{ description }}
+        </p>
+
+        <!-- Buttons -->
+        <div class="flex flex-col sm:flex-row gap-4 justify-center">
+          <router-link
+            :to="getAuthenticatedRedirect"
+            class="group inline-flex items-center justify-center gap-3 px-8 py-4 rounded-full font-medium text-lg bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white transition-all duration-200 hover:-translate-y-0.5 active:translate-y-0 shadow-[0_1px_2px_rgba(23,37,84,0.25),0_8px_20px_-6px_rgba(23,37,84,0.35),inset_0_1px_0_rgba(255,255,255,0.12)] hover:shadow-[0_2px_3px_rgba(23,37,84,0.22),0_14px_28px_-8px_rgba(23,37,84,0.4),inset_0_1px_0_rgba(255,255,255,0.12)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.5),0_10px_24px_-8px_rgba(0,0,0,0.55)] dark:hover:shadow-[0_2px_3px_rgba(0,0,0,0.5),0_14px_30px_-8px_rgba(0,0,0,0.6)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
+          >
+            <span>{{ primaryButtonText }}</span>
+            <svg class="w-5 h-5 transition-transform duration-300 group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+            </svg>
+          </router-link>
+
+          <router-link
+            v-if="showSecondaryButton"
+            :to="secondaryButtonTo"
+            class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-full font-medium text-lg border border-blue-950/[0.14] text-blue-950/80 hover:text-blue-950 hover:border-blue-950/30 hover:bg-blue-950/[0.03] dark:border-white/[0.16] dark:text-blue-100/80 dark:hover:text-white dark:hover:border-white/30 dark:hover:bg-white/[0.06] transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
+          >
+            <span>{{ secondaryButtonText }}</span>
+          </router-link>
+        </div>
+
+        <!-- Footnote set as a folio line: serif italic between hairlines -->
+        <p v-if="footnote" class="mt-10 flex items-center justify-center gap-4 text-sm">
+          <span aria-hidden="true" class="h-px w-10 bg-blue-950/20 dark:bg-white/20"></span>
+          <span class="font-display italic text-blue-950/70 dark:text-blue-100/55">{{ footnote }}</span>
+          <span aria-hidden="true" class="h-px w-10 bg-blue-950/20 dark:bg-white/20"></span>
+        </p>
       </div>
     </div>
   </section>
@@ -44,9 +58,11 @@
 <script>
 import { defineComponent, computed } from 'vue'
 import { useAuthStore } from '@/shared/stores/auth'
+import reveal from '@/apps/home/directives/reveal'
 
 export default defineComponent({
   name: 'CTASection',
+  directives: { reveal },
   props: {
     title: {
       type: String,
@@ -75,60 +91,72 @@ export default defineComponent({
     secondaryButtonTo: {
       type: [String, Object],
       default: '/docs'
+    },
+    footnote: {
+      type: String,
+      default: ''
     }
   },
   setup(props) {
     const authStore = useAuthStore()
     const isAuthenticated = computed(() => authStore.isAuthenticated)
-    
+
     const getAuthenticatedRedirect = computed(() => {
-      return isAuthenticated.value 
+      return isAuthenticated.value
         ? (typeof props.primaryButtonTo === 'string' ? props.primaryButtonTo : '/imagi/projects')
         : '/auth/signin'
     })
-    
+
+    // Split the title so its final word carries the italic gradient accent
+    const titleLead = computed(() => props.title.split(' ').slice(0, -1).join(' '))
+    const titleAccent = computed(() => props.title.split(' ').slice(-1)[0])
+
     return {
       isAuthenticated,
-      getAuthenticatedRedirect
+      getAuthenticatedRedirect,
+      titleLead,
+      titleAccent
     }
   }
 })
 </script>
 
 <style scoped>
-/* Soft 3D button effect - tight, layered, crisp. Blue-tinted shadows to suit the light baby-blue fill. */
-.btn-3d {
-  transform: translateY(0) translateZ(0);
-  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
-  box-shadow:
-    0 1px 2px rgba(30, 58, 138, 0.14),
-    0 4px 10px -2px rgba(30, 58, 138, 0.16),
-    0 10px 20px -6px rgba(30, 58, 138, 0.18),
-    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
-    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.12);
+/* Hairline gradient divider that fades at the edges */
+.section-divider {
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(23, 37, 84, 0.12), transparent);
 }
 
-.btn-3d:active {
-  transform: translateY(0) translateZ(0);
-  transition-duration: 0.1s;
+.dark .section-divider {
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.1), transparent);
 }
 
-/* Soft baby-blue gradient fill */
-.btn-accent {
-  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
+/* Soft warm wash mirroring the hero's apricot glow at half strength */
+.cta-glow-warm {
+  background: radial-gradient(closest-side, rgba(251, 146, 60, 0.11), rgba(251, 146, 60, 0.03) 55%, transparent 75%);
+  filter: blur(48px);
 }
 
-.dark .btn-accent {
-  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
+.dark .cta-glow-warm {
+  background: radial-gradient(closest-side, rgba(251, 146, 60, 0.06), rgba(251, 146, 60, 0.02) 55%, transparent 75%);
 }
 
-/* On dark, ground the light button with deep neutral shadows; keep the inner sheen */
-.dark .btn-3d {
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.5),
-    0 4px 10px -2px rgba(0, 0, 0, 0.45),
-    0 10px 20px -6px rgba(0, 0, 0, 0.5),
-    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
-    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.18);
+/* Italic serif accent with the hero's warm gradient ink */
+.cta-accent {
+  font-style: italic;
+  font-variation-settings: 'SOFT' 30, 'WONK' 1;
+  background: linear-gradient(115deg, #c2410c 5%, #ea580c 55%, #b45309 95%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  padding-right: 0.06em;
+}
+
+.dark .cta-accent {
+  background: linear-gradient(115deg, #fb923c 5%, #fcd34d 60%, #f59e0b 95%);
+  -webkit-background-clip: text;
+  background-clip: text;
 }
 </style>

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/FeaturesSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/FeaturesSection.vue
@@ -1,55 +1,74 @@
-<!-- Features Section - Clean Apple/Cursor-inspired design -->
+<!-- Features Section (Step 1 - Build) - warm porcelain editorial design -->
 <template>
-  <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-[#16120e] border-t border-orange-200/60 dark:border-orange-400/[0.14] transition-colors duration-500 overflow-hidden">
+  <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 transition-colors duration-500">
+
+    <!-- Warm apricot wash behind the section -->
+    <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
+      <div class="section-wash-warm absolute -top-24 left-[-15%] w-[760px] h-[560px]"></div>
+    </div>
 
     <div class="relative max-w-6xl mx-auto">
 
-      <!-- Section header -->
-      <div class="text-center mb-16 md:mb-20">
-        <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-blue-200/70 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 text-xs font-semibold text-blue-700 dark:text-blue-300 uppercase tracking-[0.18em] mb-5 transition-colors duration-300">Step 1 · Build</p>
-        <h2 class="text-4xl sm:text-5xl md:text-6xl font-semibold text-blue-950 dark:text-white mb-6 tracking-tight text-balance transition-colors duration-300">
-          Build your web app
-        </h2>
-        <p class="text-xl text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty max-w-2xl mx-auto transition-colors duration-300">
-          Every business starts with a product. Design visually, chat with AI, and launch your web application—the foundation of your business.
+      <!-- Hairline divider -->
+      <div class="section-divider mb-20 md:mb-24" aria-hidden="true"></div>
+
+      <!-- Editorial header: headline left, supporting copy right -->
+      <div v-reveal class="md:flex md:items-end md:justify-between gap-12 mb-14 md:mb-16">
+        <div class="max-w-xl">
+          <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-blue-200/70 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 text-xs font-semibold text-blue-700 dark:text-blue-300 uppercase tracking-[0.18em] mb-6 transition-colors duration-300">Step 1 &middot; Build</p>
+          <h2 class="font-display text-4xl sm:text-5xl md:text-[3.4rem] font-semibold text-blue-950 dark:text-white tracking-[-0.015em] leading-[1.08] text-balance transition-colors duration-300">
+            Build your <em class="section-accent not-italic">web app</em>
+          </h2>
+        </div>
+        <p class="mt-6 md:mt-0 md:max-w-sm md:pb-2 text-lg text-blue-950/65 dark:text-blue-100/65 leading-relaxed text-pretty transition-colors duration-300">
+          Every business starts with a product. Design visually, chat with AI, and launch your web application&mdash;the foundation of your business.
         </p>
       </div>
 
-      <!-- Features grid with enhanced cards -->
+      <!-- Features grid -->
       <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-
         <div
           v-for="(feature, index) in features"
           :key="index"
-          class="relative"
+          v-reveal="{ delay: 90 + index * 90 }"
+          class="lift-card group relative h-full p-8 rounded-2xl bg-white/85 dark:bg-white/[0.045] border backdrop-blur-sm transition-all duration-300"
+          :class="index % 2 === 1 ? 'border-orange-200/70 dark:border-orange-300/[0.14]' : 'border-blue-200/70 dark:border-blue-300/[0.14]'"
         >
-          <!-- Card with tinted background matching its accent color -->
+          <!-- Icon -->
           <div
-            class="relative h-full p-8 rounded-2xl border crisp-card transition-colors duration-300"
-            :class="index % 2 === 1 ? 'bg-white dark:bg-white/[0.05] border-orange-200/70 dark:border-orange-300/[0.16]' : 'bg-white dark:bg-white/[0.05] border-blue-200/70 dark:border-blue-300/[0.16]'"
+            class="icon-tile relative flex items-center justify-center w-12 h-12 rounded-xl mb-6 ring-1 transition-all duration-300"
+            :class="index % 2 === 1 ? 'bg-orange-100 dark:bg-orange-400/[0.14] ring-orange-900/[0.08] dark:ring-orange-300/[0.18]' : 'bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] dark:from-blue-400/[0.18] dark:to-blue-500/[0.22] ring-blue-900/[0.08] dark:ring-blue-300/[0.18]'"
           >
-
-            <!-- Icon -->
-            <div
-              class="relative flex items-center justify-center w-12 h-12 rounded-xl mx-auto mb-5 ring-1 transition-colors duration-300"
-              :class="index % 2 === 1 ? 'bg-orange-100 dark:bg-orange-400/[0.14] ring-orange-900/[0.08] dark:ring-orange-300/[0.18]' : 'bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] dark:from-blue-400/[0.18] dark:to-blue-500/[0.22] ring-blue-900/[0.08] dark:ring-blue-300/[0.18]'"
-            >
-              <i :class="[feature.icon, 'text-lg', index % 2 === 1 ? 'text-orange-600 dark:text-orange-300' : 'text-blue-600 dark:text-blue-300']"></i>
-            </div>
-
-            <!-- Title -->
-            <h3 class="relative text-xl font-semibold tracking-tight text-blue-950 dark:text-white transition-colors duration-300 mb-4 text-center">
-              {{ feature.title }}
-            </h3>
-
-            <!-- Description -->
-            <p class="relative text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty transition-colors duration-300 text-center">
-              {{ feature.description }}
-            </p>
-
+            <i :class="[feature.icon, 'text-lg', index % 2 === 1 ? 'text-orange-600 dark:text-orange-300' : 'text-blue-600 dark:text-blue-300']"></i>
           </div>
-        </div>
 
+          <!-- Title -->
+          <h3 class="relative text-xl font-semibold tracking-tight text-blue-950 dark:text-white transition-colors duration-300 mb-3">
+            {{ feature.title }}
+          </h3>
+
+          <!-- Description -->
+          <p class="relative text-blue-950/65 dark:text-blue-100/65 leading-relaxed text-pretty transition-colors duration-300 mb-6">
+            {{ feature.description }}
+          </p>
+
+          <!-- Highlights checklist -->
+          <ul class="relative space-y-2.5 pt-5 border-t border-blue-950/[0.06] dark:border-white/[0.07]">
+            <li
+              v-for="(highlight, hIndex) in feature.highlights"
+              :key="hIndex"
+              class="flex items-center gap-2.5"
+            >
+              <span
+                class="flex-shrink-0 w-[18px] h-[18px] rounded-full ring-1 flex items-center justify-center transition-all duration-300"
+                :class="index % 2 === 1 ? 'bg-orange-100 dark:bg-orange-400/[0.14] ring-orange-200/80 dark:ring-orange-300/[0.18]' : 'bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] dark:from-blue-400/[0.18] dark:to-blue-500/[0.22] ring-blue-200/80 dark:ring-blue-300/[0.18]'"
+              >
+                <i class="fas fa-check text-[9px]" :class="index % 2 === 1 ? 'text-orange-600 dark:text-orange-300' : 'text-blue-600 dark:text-blue-300'"></i>
+              </span>
+              <span class="text-sm text-blue-950/70 dark:text-blue-100/70 leading-relaxed transition-colors duration-300">{{ highlight }}</span>
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
   </section>
@@ -57,9 +76,11 @@
 
 <script>
 import { defineComponent } from 'vue'
+import reveal from '@/apps/home/directives/reveal'
 
 export default defineComponent({
   name: 'FeaturesSection',
+  directives: { reveal },
   props: {
     features: {
       type: Array,
@@ -101,8 +122,46 @@ export default defineComponent({
 </script>
 
 <style scoped>
-/* Crisp, sharply-defined cards: hairline edge + tight layered shadow */
-.crisp-card {
+/* Hairline gradient divider that fades at the edges */
+.section-divider {
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(23, 37, 84, 0.12), transparent);
+}
+
+.dark .section-divider {
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.1), transparent);
+}
+
+/* Soft warm wash */
+.section-wash-warm {
+  background: radial-gradient(closest-side, rgba(251, 146, 60, 0.13), rgba(251, 146, 60, 0.04) 55%, transparent 75%);
+  filter: blur(48px);
+}
+
+.dark .section-wash-warm {
+  background: radial-gradient(closest-side, rgba(251, 146, 60, 0.07), rgba(251, 146, 60, 0.02) 55%, transparent 75%);
+}
+
+/* Italic serif accent in blue ink */
+.section-accent {
+  font-style: italic;
+  font-variation-settings: 'SOFT' 30, 'WONK' 1;
+  background: linear-gradient(115deg, #1d4ed8 5%, #2563eb 55%, #0284c7 95%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  padding-right: 0.05em;
+}
+
+.dark .section-accent {
+  background: linear-gradient(115deg, #93c5fd 5%, #60a5fa 60%, #7dd3fc 95%);
+  -webkit-background-clip: text;
+  background-clip: text;
+}
+
+/* Cards that lift gently on hover */
+.lift-card {
   box-shadow:
     0 0 0 1px rgba(15, 23, 42, 0.03),
     0 1px 2px rgba(15, 23, 42, 0.06),
@@ -110,11 +169,34 @@ export default defineComponent({
     0 12px 28px -10px rgba(15, 23, 42, 0.10);
 }
 
-.dark .crisp-card {
+.lift-card:hover {
+  transform: translateY(-4px);
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.04),
+    0 2px 4px rgba(15, 23, 42, 0.06),
+    0 10px 20px -4px rgba(15, 23, 42, 0.1),
+    0 24px 44px -12px rgba(15, 23, 42, 0.14);
+}
+
+.dark .lift-card {
   box-shadow:
     0 0 0 1px rgba(255, 255, 255, 0.04),
     0 1px 2px rgba(0, 0, 0, 0.5),
     0 4px 10px -2px rgba(0, 0, 0, 0.45),
     0 12px 28px -10px rgba(0, 0, 0, 0.55);
+}
+
+.dark .lift-card:hover {
+  transform: translateY(-4px);
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.06),
+    0 2px 4px rgba(0, 0, 0, 0.5),
+    0 12px 24px -4px rgba(0, 0, 0, 0.5),
+    0 28px 48px -12px rgba(0, 0, 0, 0.6);
+}
+
+/* Icon tile nudge on card hover */
+.lift-card:hover .icon-tile {
+  transform: scale(1.06) rotate(-3deg);
 }
 </style>

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/HeroSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/HeroSection.vue
@@ -1,47 +1,75 @@
-<!-- Hero Section - Clean Apple/Cursor-inspired design -->
+<!-- Hero Section - warm porcelain editorial design -->
 <template>
-  <section class="relative py-32 sm:py-40 md:py-48 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-[#16120e] transition-colors duration-500 overflow-hidden">
+  <section class="relative pt-36 pb-28 sm:pt-44 sm:pb-36 md:pt-52 md:pb-44 px-6 sm:px-8 lg:px-12 transition-colors duration-500">
+
+    <!-- Atmosphere: soft apricot + baby-blue washes over the porcelain canvas -->
+    <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
+      <div class="hero-glow-warm absolute -top-40 left-1/2 -translate-x-1/3 w-[900px] h-[560px]"></div>
+      <div class="hero-glow-cool absolute -top-24 -left-40 w-[700px] h-[520px]"></div>
+      <!-- Hairline halo ring behind the headline -->
+      <div class="hero-ring absolute left-1/2 top-[46%] -translate-x-1/2 -translate-y-1/2 w-[54rem] h-[54rem] rounded-full"></div>
+    </div>
 
     <div class="relative max-w-4xl mx-auto text-center">
 
+      <!-- Editorial kicker: tracked small caps flanked by fading hairline rules -->
+      <div class="hero-item flex items-center justify-center gap-4 mb-8" style="animation-delay: 0ms">
+        <span aria-hidden="true" class="hidden sm:block h-px w-12 md:w-16 bg-gradient-to-l from-blue-950/25 to-transparent dark:from-white/25"></span>
+        <span class="flex items-center gap-3">
+          <span aria-hidden="true" class="w-1 h-1 rotate-45 bg-orange-500/80 dark:bg-orange-400/80"></span>
+          <span class="text-[10px] sm:text-[11px] font-semibold uppercase tracking-[0.25em] sm:tracking-[0.3em] leading-none text-blue-950/70 dark:text-blue-100/55 whitespace-nowrap">The all-in-one business platform</span>
+          <span aria-hidden="true" class="w-1 h-1 rotate-45 bg-orange-500/80 dark:bg-orange-400/80"></span>
+        </span>
+        <span aria-hidden="true" class="hidden sm:block h-px w-12 md:w-16 bg-gradient-to-r from-blue-950/25 to-transparent dark:from-white/25"></span>
+      </div>
+
       <!-- Hero title -->
-      <h1 class="text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-semibold mb-6 tracking-[-0.025em] leading-[1.08] text-balance text-blue-950 dark:text-white">
-        Build and run your business
+      <h1 class="hero-item font-display font-semibold text-[2.9rem] sm:text-6xl md:text-7xl lg:text-[5.4rem] mb-7 tracking-[-0.02em] leading-[1.04] text-balance text-blue-950 dark:text-white" style="animation-delay: 90ms">
+        Build and run
+        <br class="hidden sm:block" />
+        <em class="hero-accent not-italic">your business</em>
       </h1>
 
       <!-- Subtitle -->
-      <p class="text-lg sm:text-xl text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty mb-10 max-w-3xl mx-auto transition-colors duration-300">
-        Imagi is the all-in-one platform to launch and grow a business. Build your web application with AI tools, then run everything—marketing, sales, and finance—in one place. Fast, affordable, and approachable.
+      <p class="hero-item text-lg sm:text-xl text-blue-950/65 dark:text-blue-100/65 leading-relaxed text-pretty mb-11 max-w-2xl mx-auto transition-colors duration-300" style="animation-delay: 180ms">
+        Imagi is the all-in-one platform to launch and grow a business. Build your web application with AI, then run everything&mdash;marketing, sales, and finance&mdash;in one place.
       </p>
 
       <!-- CTA buttons -->
-      <div class="flex flex-col sm:flex-row gap-4 justify-center mb-12">
+      <div class="hero-item flex flex-col sm:flex-row items-center gap-4 justify-center mb-14" style="animation-delay: 270ms">
         <router-link
           :to="startBuildingRoute"
-          class="btn-3d btn-accent group relative inline-flex items-center justify-center gap-3 px-8 py-4 text-blue-950 rounded-full font-medium text-lg overflow-hidden border border-white/60 dark:border-white/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#16120e]"
+          class="group inline-flex items-center justify-center gap-3 px-8 py-4 rounded-full font-medium text-lg bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white transition-all duration-200 hover:-translate-y-0.5 active:translate-y-0 shadow-[0_1px_2px_rgba(23,37,84,0.25),0_8px_20px_-6px_rgba(23,37,84,0.35),inset_0_1px_0_rgba(255,255,255,0.12)] hover:shadow-[0_2px_3px_rgba(23,37,84,0.22),0_14px_28px_-8px_rgba(23,37,84,0.4),inset_0_1px_0_rgba(255,255,255,0.12)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.5),0_10px_24px_-8px_rgba(0,0,0,0.55)] dark:hover:shadow-[0_2px_3px_rgba(0,0,0,0.5),0_14px_30px_-8px_rgba(0,0,0,0.6)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
         >
-          <!-- Top edge highlight for 3D effect -->
-          <span class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/70 to-transparent"></span>
-          <!-- Bottom edge shadow for depth -->
-          <span class="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-blue-900/15 to-transparent"></span>
-          <span class="relative">Start Building</span>
-          <svg class="relative w-5 h-5 transition-transform duration-300 group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <span>Start Building</span>
+          <svg class="w-5 h-5 transition-transform duration-300 group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
           </svg>
         </router-link>
+
+        <button
+          type="button"
+          @click="scrollToWhy"
+          class="group inline-flex items-center gap-2.5 px-6 py-4 rounded-full font-medium text-lg text-blue-950/75 dark:text-blue-100/75 hover:text-blue-950 dark:hover:text-white transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
+        >
+          <span class="border-b border-blue-950/20 dark:border-blue-100/25 group-hover:border-blue-950/50 dark:group-hover:border-blue-100/60 transition-colors duration-200 pb-0.5">See how it works</span>
+          <svg class="w-4 h-4 transition-transform duration-300 group-hover:translate-y-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 14l-7 7m0 0l-7-7m7 7V3" />
+          </svg>
+        </button>
       </div>
 
       <!-- Value props - centered and minimal -->
-      <div class="flex flex-wrap items-center justify-center gap-3 text-xs transition-colors duration-300">
+      <div class="hero-item flex flex-wrap items-center justify-center gap-3 text-xs transition-colors duration-300" style="animation-delay: 360ms">
         <span
           v-for="(prop, index) in valueProps"
           :key="index"
-          class="value-pill flex items-center gap-2 px-3.5 py-2 rounded-full bg-white dark:bg-white/[0.07] border border-gray-200/90 dark:border-white/[0.14] transition-all duration-300 whitespace-nowrap"
+          class="value-pill flex items-center gap-2 px-3.5 py-2 rounded-full bg-white/85 dark:bg-white/[0.07] border border-blue-950/[0.08] dark:border-white/[0.14] transition-all duration-300 whitespace-nowrap"
         >
           <span class="w-4 h-4 rounded-full bg-orange-100 dark:bg-orange-400/[0.16] ring-1 ring-orange-200/80 dark:ring-orange-400/30 flex items-center justify-center transition-all duration-300">
             <i class="fas fa-check text-[9px] text-orange-600 dark:text-orange-300"></i>
           </span>
-          <span class="text-gray-800 dark:text-blue-100/85 font-medium">{{ prop }}</span>
+          <span class="text-blue-950/80 dark:text-blue-100/85 font-medium">{{ prop }}</span>
         </span>
       </div>
 
@@ -70,46 +98,85 @@ export default defineComponent({
       'No coding experience required'
     ]
 
-    return { startBuildingRoute, valueProps }
+    const scrollToWhy = () => {
+      const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      document.getElementById('why-imagi')?.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth', block: 'start' })
+    }
+
+    return { startBuildingRoute, valueProps, scrollToWhy }
   }
 })
 </script>
 
 <style scoped>
-/* Soft 3D button effect - tight, layered, crisp. Blue-tinted shadows to suit the light baby-blue fill. */
-.btn-3d {
-  transform: translateY(0) translateZ(0);
-  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
-  box-shadow:
-    0 1px 2px rgba(30, 58, 138, 0.14),
-    0 4px 10px -2px rgba(30, 58, 138, 0.16),
-    0 10px 20px -6px rgba(30, 58, 138, 0.18),
-    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
-    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.12);
+/* Staggered entrance: each .hero-item rises in sequence on page load */
+.hero-item {
+  animation: hero-rise 0.9s cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
-.btn-3d:active {
-  transform: translateY(0) translateZ(0);
-  transition-duration: 0.1s;
+@keyframes hero-rise {
+  from {
+    opacity: 0;
+    transform: translateY(22px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
-/* Soft baby-blue gradient fill */
-.btn-accent {
-  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
+@media (prefers-reduced-motion: reduce) {
+  .hero-item {
+    animation: none;
+  }
 }
 
-.dark .btn-accent {
-  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
+/* Atmosphere washes */
+.hero-glow-warm {
+  background: radial-gradient(closest-side, rgba(251, 146, 60, 0.16), rgba(251, 146, 60, 0.05) 55%, transparent 75%);
+  filter: blur(40px);
 }
 
-/* On dark, ground the light button with deep neutral shadows; keep the inner sheen */
-.dark .btn-3d {
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.5),
-    0 4px 10px -2px rgba(0, 0, 0, 0.45),
-    0 10px 20px -6px rgba(0, 0, 0, 0.5),
-    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
-    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.18);
+.hero-glow-cool {
+  background: radial-gradient(closest-side, rgba(158, 205, 243, 0.28), rgba(158, 205, 243, 0.08) 55%, transparent 75%);
+  filter: blur(44px);
+}
+
+.dark .hero-glow-warm {
+  background: radial-gradient(closest-side, rgba(251, 146, 60, 0.09), rgba(251, 146, 60, 0.025) 55%, transparent 75%);
+}
+
+.dark .hero-glow-cool {
+  background: radial-gradient(closest-side, rgba(96, 165, 250, 0.11), rgba(96, 165, 250, 0.03) 55%, transparent 75%);
+}
+
+/* Hairline halo ring for quiet depth behind the headline */
+.hero-ring {
+  border: 1px solid rgba(23, 37, 84, 0.05);
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.9), transparent 70%);
+  -webkit-mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.9), transparent 70%);
+}
+
+.dark .hero-ring {
+  border-color: rgba(255, 255, 255, 0.06);
+}
+
+/* Italic serif accent with a warm gradient ink */
+.hero-accent {
+  font-style: italic;
+  font-variation-settings: 'SOFT' 30, 'WONK' 1;
+  background: linear-gradient(115deg, #c2410c 5%, #ea580c 55%, #b45309 95%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  padding-right: 0.06em; /* keep the italic terminal from clipping */
+}
+
+.dark .hero-accent {
+  background: linear-gradient(115deg, #fb923c 5%, #fcd34d 60%, #f59e0b 95%);
+  -webkit-background-clip: text;
+  background-clip: text;
 }
 
 /* Hairline-edged pills with a whisper of depth */
@@ -119,9 +186,24 @@ export default defineComponent({
     0 2px 6px -2px rgba(15, 23, 42, 0.06);
 }
 
+.value-pill:hover {
+  transform: translateY(-2px);
+  border-color: rgba(234, 88, 12, 0.28);
+  box-shadow:
+    0 2px 4px rgba(15, 23, 42, 0.06),
+    0 6px 14px -4px rgba(15, 23, 42, 0.1);
+}
+
 .dark .value-pill {
   box-shadow:
     0 1px 2px rgba(0, 0, 0, 0.4),
     0 2px 6px -2px rgba(0, 0, 0, 0.35);
+}
+
+.dark .value-pill:hover {
+  border-color: rgba(251, 146, 60, 0.35);
+  box-shadow:
+    0 2px 4px rgba(0, 0, 0, 0.45),
+    0 6px 14px -4px rgba(0, 0, 0, 0.4);
 }
 </style>

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/KeyFeaturesSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/KeyFeaturesSection.vue
@@ -1,68 +1,74 @@
-<!-- Key Features Section - Clean Apple/Cursor-inspired design -->
+<!-- Key Features Section (Step 2 - Run) - warm porcelain editorial design -->
 <template>
-  <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-blue-50 dark:bg-[#0e141f] border-t border-blue-200/60 dark:border-blue-400/[0.14] transition-colors duration-500 overflow-hidden">
+  <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 transition-colors duration-500">
+
+    <!-- Cool baby-blue wash behind the section -->
+    <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
+      <div class="section-wash-cool absolute -top-24 right-[-15%] w-[760px] h-[560px]"></div>
+    </div>
 
     <div class="relative max-w-6xl mx-auto">
 
-      <!-- Section header -->
-      <div class="text-center mb-16 md:mb-20">
-        <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-orange-200/70 dark:border-orange-400/25 bg-orange-50/80 dark:bg-orange-400/10 text-xs font-semibold text-orange-700 dark:text-orange-300 uppercase tracking-[0.18em] mb-5 transition-colors duration-300">Step 2 · Run</p>
-        <h2 class="text-4xl sm:text-5xl md:text-6xl font-semibold text-blue-950 dark:text-white mb-6 tracking-tight text-balance transition-colors duration-300">
-          Run your business
-        </h2>
-        <p class="text-xl text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty max-w-2xl mx-auto transition-colors duration-300">
-          Once your app is live, grow it with built-in tools for marketing, sales, and finance—all in one place.
+      <!-- Hairline divider -->
+      <div class="section-divider mb-20 md:mb-24" aria-hidden="true"></div>
+
+      <!-- Editorial header: headline left, supporting copy right -->
+      <div v-reveal class="md:flex md:items-end md:justify-between gap-12 mb-14 md:mb-16">
+        <div class="max-w-xl">
+          <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-orange-200/70 dark:border-orange-400/25 bg-orange-50/80 dark:bg-orange-400/10 text-xs font-semibold text-orange-700 dark:text-orange-300 uppercase tracking-[0.18em] mb-6 transition-colors duration-300">Step 2 &middot; Run</p>
+          <h2 class="font-display text-4xl sm:text-5xl md:text-[3.4rem] font-semibold text-blue-950 dark:text-white tracking-[-0.015em] leading-[1.08] text-balance transition-colors duration-300">
+            Run your <em class="section-accent-warm not-italic">business</em>
+          </h2>
+        </div>
+        <p class="mt-6 md:mt-0 md:max-w-sm md:pb-2 text-lg text-blue-950/65 dark:text-blue-100/65 leading-relaxed text-pretty transition-colors duration-300">
+          Once your app is live, grow it with built-in tools for marketing, sales, and finance&mdash;all in one place.
         </p>
       </div>
 
-      <!-- Features grid with enhanced cards -->
+      <!-- Features grid -->
       <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-
         <div
           v-for="(feature, index) in features"
           :key="index"
-          class="relative"
+          v-reveal="{ delay: 90 + index * 90 }"
+          class="lift-card group relative h-full p-8 rounded-2xl bg-white/85 dark:bg-white/[0.045] border backdrop-blur-sm transition-all duration-300"
+          :class="index % 2 === 1 ? 'border-blue-200/70 dark:border-blue-300/[0.14]' : 'border-orange-200/70 dark:border-orange-300/[0.14]'"
         >
-          <!-- Card with tinted background alternating blue / orange -->
+          <!-- Icon -->
           <div
-            class="relative h-full p-8 rounded-2xl border crisp-card transition-colors duration-300"
-            :class="index % 2 === 1 ? 'bg-white dark:bg-white/[0.05] border-blue-200/70 dark:border-blue-300/[0.16]' : 'bg-white dark:bg-white/[0.05] border-orange-200/70 dark:border-orange-300/[0.16]'"
+            class="icon-tile relative flex items-center justify-center w-12 h-12 rounded-xl mb-6 ring-1 transition-all duration-300"
+            :class="index % 2 === 1 ? 'bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] dark:from-blue-400/[0.18] dark:to-blue-500/[0.22] ring-blue-900/[0.08] dark:ring-blue-300/[0.18]' : 'bg-orange-100 dark:bg-orange-400/[0.14] ring-orange-900/[0.08] dark:ring-orange-300/[0.18]'"
           >
-
-            <!-- Title -->
-            <h3 class="relative text-xl font-semibold tracking-tight text-blue-950 dark:text-white transition-colors duration-300 mb-4 text-center">
-              {{ feature.title }}
-            </h3>
-
-            <!-- Description -->
-            <p class="relative text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty mb-6 transition-colors duration-300 text-center">
-              {{ feature.description }}
-            </p>
-
-            <!-- Feature highlights with accent-colored checkmarks -->
-            <div class="relative flex justify-center">
-              <ul class="space-y-3 inline-flex flex-col">
-                <li
-                  v-for="(highlight, hIndex) in feature.highlights"
-                  :key="hIndex"
-                  class="flex items-start gap-3"
-                >
-                  <div class="flex-shrink-0 mt-0.5">
-                    <div
-                      class="w-5 h-5 rounded-full ring-1 flex items-center justify-center transition-all duration-300"
-                      :class="index % 2 === 1 ? 'bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] dark:from-blue-400/[0.18] dark:to-blue-500/[0.22] ring-blue-200/80 dark:ring-blue-300/[0.18]' : 'bg-orange-100 dark:bg-orange-400/[0.14] ring-orange-200/80 dark:ring-orange-300/[0.18]'"
-                    >
-                      <i class="fas fa-check text-[10px]" :class="index % 2 === 1 ? 'text-blue-600 dark:text-blue-300' : 'text-orange-600 dark:text-orange-300'"></i>
-                    </div>
-                  </div>
-                  <span class="text-blue-950/70 dark:text-blue-100/70 text-sm leading-relaxed transition-colors duration-300">{{ highlight }}</span>
-                </li>
-              </ul>
-            </div>
-
+            <i :class="[feature.icon, 'text-lg', index % 2 === 1 ? 'text-blue-600 dark:text-blue-300' : 'text-orange-600 dark:text-orange-300']"></i>
           </div>
-        </div>
 
+          <!-- Title -->
+          <h3 class="relative text-xl font-semibold tracking-tight text-blue-950 dark:text-white transition-colors duration-300 mb-3">
+            {{ feature.title }}
+          </h3>
+
+          <!-- Description -->
+          <p class="relative text-blue-950/65 dark:text-blue-100/65 leading-relaxed text-pretty transition-colors duration-300 mb-6">
+            {{ feature.description }}
+          </p>
+
+          <!-- Highlights checklist -->
+          <ul class="relative space-y-2.5 pt-5 border-t border-blue-950/[0.06] dark:border-white/[0.07]">
+            <li
+              v-for="(highlight, hIndex) in feature.highlights"
+              :key="hIndex"
+              class="flex items-center gap-2.5"
+            >
+              <span
+                class="flex-shrink-0 w-[18px] h-[18px] rounded-full ring-1 flex items-center justify-center transition-all duration-300"
+                :class="index % 2 === 1 ? 'bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] dark:from-blue-400/[0.18] dark:to-blue-500/[0.22] ring-blue-200/80 dark:ring-blue-300/[0.18]' : 'bg-orange-100 dark:bg-orange-400/[0.14] ring-orange-200/80 dark:ring-orange-300/[0.18]'"
+              >
+                <i class="fas fa-check text-[9px]" :class="index % 2 === 1 ? 'text-blue-600 dark:text-blue-300' : 'text-orange-600 dark:text-orange-300'"></i>
+              </span>
+              <span class="text-sm text-blue-950/70 dark:text-blue-100/70 leading-relaxed transition-colors duration-300">{{ highlight }}</span>
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
   </section>
@@ -70,9 +76,11 @@
 
 <script>
 import { defineComponent } from 'vue'
+import reveal from '@/apps/home/directives/reveal'
 
 export default defineComponent({
   name: 'KeyFeaturesSection',
+  directives: { reveal },
   props: {
     features: {
       type: Array,
@@ -114,8 +122,46 @@ export default defineComponent({
 </script>
 
 <style scoped>
-/* Crisp, sharply-defined cards: hairline edge + tight layered shadow */
-.crisp-card {
+/* Hairline gradient divider that fades at the edges */
+.section-divider {
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(23, 37, 84, 0.12), transparent);
+}
+
+.dark .section-divider {
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.1), transparent);
+}
+
+/* Soft cool wash */
+.section-wash-cool {
+  background: radial-gradient(closest-side, rgba(158, 205, 243, 0.2), rgba(158, 205, 243, 0.06) 55%, transparent 75%);
+  filter: blur(48px);
+}
+
+.dark .section-wash-cool {
+  background: radial-gradient(closest-side, rgba(96, 165, 250, 0.08), rgba(96, 165, 250, 0.02) 55%, transparent 75%);
+}
+
+/* Italic serif accent in warm ink */
+.section-accent-warm {
+  font-style: italic;
+  font-variation-settings: 'SOFT' 30, 'WONK' 1;
+  background: linear-gradient(115deg, #c2410c 5%, #ea580c 55%, #b45309 95%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  padding-right: 0.05em;
+}
+
+.dark .section-accent-warm {
+  background: linear-gradient(115deg, #fb923c 5%, #fcd34d 60%, #f59e0b 95%);
+  -webkit-background-clip: text;
+  background-clip: text;
+}
+
+/* Cards that lift gently on hover */
+.lift-card {
   box-shadow:
     0 0 0 1px rgba(15, 23, 42, 0.03),
     0 1px 2px rgba(15, 23, 42, 0.06),
@@ -123,11 +169,34 @@ export default defineComponent({
     0 12px 28px -10px rgba(15, 23, 42, 0.10);
 }
 
-.dark .crisp-card {
+.lift-card:hover {
+  transform: translateY(-4px);
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.04),
+    0 2px 4px rgba(15, 23, 42, 0.06),
+    0 10px 20px -4px rgba(15, 23, 42, 0.1),
+    0 24px 44px -12px rgba(15, 23, 42, 0.14);
+}
+
+.dark .lift-card {
   box-shadow:
     0 0 0 1px rgba(255, 255, 255, 0.04),
     0 1px 2px rgba(0, 0, 0, 0.5),
     0 4px 10px -2px rgba(0, 0, 0, 0.45),
     0 12px 28px -10px rgba(0, 0, 0, 0.55);
+}
+
+.dark .lift-card:hover {
+  transform: translateY(-4px);
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.06),
+    0 2px 4px rgba(0, 0, 0, 0.5),
+    0 12px 24px -4px rgba(0, 0, 0, 0.5),
+    0 28px 48px -12px rgba(0, 0, 0, 0.6);
+}
+
+/* Icon tile nudge on card hover */
+.lift-card:hover .icon-tile {
+  transform: scale(1.06) rotate(-3deg);
 }
 </style>

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/StatsSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/StatsSection.vue
@@ -1,67 +1,75 @@
-<!-- Stats Section - Clean Apple/Cursor-inspired design -->
+<!-- Stats Section - warm porcelain editorial design -->
 <template>
-  <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-blue-50 dark:bg-[#0e141f] border-t border-blue-200/60 dark:border-blue-400/[0.14] transition-colors duration-500">
-    <div class="max-w-6xl mx-auto">
+  <section id="why-imagi" class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 scroll-mt-14 transition-colors duration-500">
 
-      <!-- Section header -->
-      <div class="text-center mb-16">
-        <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-orange-200/70 dark:border-orange-400/25 bg-orange-50/80 dark:bg-orange-400/10 text-xs font-semibold text-orange-700 dark:text-orange-300 uppercase tracking-[0.18em] mb-5 transition-colors duration-300">Why Imagi</p>
-        <h2 class="text-4xl sm:text-5xl md:text-6xl font-semibold text-blue-950 dark:text-white mb-6 tracking-tight text-balance transition-colors duration-300">
-          Everything your business needs, in one place
-        </h2>
-        <p class="text-xl text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty max-w-2xl mx-auto transition-colors duration-300">
+    <!-- Cool baby-blue wash behind the section -->
+    <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
+      <div class="section-wash-cool absolute -top-20 right-[-15%] w-[760px] h-[560px]"></div>
+    </div>
+
+    <div class="relative max-w-6xl mx-auto">
+
+      <!-- Hairline divider -->
+      <div class="section-divider mb-20 md:mb-24" aria-hidden="true"></div>
+
+      <!-- Editorial header: headline left, supporting copy right -->
+      <div v-reveal class="md:flex md:items-end md:justify-between gap-12 mb-14 md:mb-16">
+        <div class="max-w-xl">
+          <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-orange-200/70 dark:border-orange-400/25 bg-orange-50/80 dark:bg-orange-400/10 text-xs font-semibold text-orange-700 dark:text-orange-300 uppercase tracking-[0.18em] mb-6 transition-colors duration-300">Why Imagi</p>
+          <h2 class="font-display text-4xl sm:text-5xl md:text-[3.4rem] font-semibold text-blue-950 dark:text-white tracking-[-0.015em] leading-[1.08] text-balance transition-colors duration-300">
+            Everything your business needs, <em class="section-accent not-italic">in one place</em>
+          </h2>
+        </div>
+        <p class="mt-6 md:mt-0 md:max-w-sm md:pb-2 text-lg text-blue-950/65 dark:text-blue-100/65 leading-relaxed text-pretty transition-colors duration-300">
           Your practical partner for building and running a business. We handle the technical complexity while you focus on your customers.
         </p>
       </div>
 
-      <!-- Stats grid -->
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-3xl mx-auto mb-16">
-        <div
-          v-for="(stat, index) in stats"
-          :key="index"
-          class="relative text-center p-10 rounded-2xl bg-white dark:bg-white/[0.05] border border-blue-200/70 dark:border-blue-300/[0.16] crisp-card transition-colors duration-300"
-        >
-          <p class="relative text-sm font-medium uppercase tracking-widest text-blue-700/70 dark:text-blue-300/70 mb-4 transition-colors duration-300">{{ stat.label }}</p>
-          <div class="relative text-5xl md:text-6xl font-semibold tracking-tight tabular-nums text-blue-950 dark:text-white transition-colors duration-300">
-            {{ stat.value }}<span v-if="stat.unit" class="text-3xl text-blue-950/70 dark:text-blue-100/70 ml-1.5 font-medium">{{ stat.unit }}</span>
+      <!-- Stat band: spec-sheet panel with hairline dividers -->
+      <div v-reveal="{ delay: 90 }" class="crisp-card relative rounded-2xl bg-white/85 dark:bg-white/[0.045] border border-blue-950/[0.08] dark:border-white/[0.1] backdrop-blur-sm mb-6 overflow-hidden">
+        <div class="grid grid-cols-1 sm:grid-cols-2">
+          <div
+            v-for="(stat, index) in stats"
+            :key="index"
+            class="relative px-8 py-10 md:px-12"
+            :class="index > 0 ? 'border-t sm:border-t-0 sm:border-l border-blue-950/[0.07] dark:border-white/[0.08]' : ''"
+          >
+            <p class="text-xs font-semibold uppercase tracking-[0.16em] text-blue-700 dark:text-blue-300/70 mb-3 transition-colors duration-300">{{ stat.label }}</p>
+            <div class="font-display text-5xl md:text-6xl font-semibold tracking-tight tabular-nums text-blue-950 dark:text-white transition-colors duration-300">
+              {{ stat.value }}<span v-if="stat.unit" class="text-3xl text-blue-950/60 dark:text-blue-100/60 ml-1.5 font-medium">{{ stat.unit }}</span>
+            </div>
+            <p v-if="stat.caption" class="mt-3 text-sm text-blue-950/70 dark:text-blue-100/55 transition-colors duration-300">{{ stat.caption }}</p>
           </div>
         </div>
       </div>
 
-      <!-- Use case cards -->
+      <!-- Audience cards -->
       <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-
         <div
           v-for="(metric, index) in metrics"
           :key="index"
-          class="relative"
+          v-reveal="{ delay: 140 + index * 90 }"
+          class="lift-card group relative h-full p-8 rounded-2xl bg-white/85 dark:bg-white/[0.045] border backdrop-blur-sm transition-all duration-300"
+          :class="index % 2 === 1 ? 'border-orange-200/70 dark:border-orange-300/[0.14]' : 'border-blue-200/70 dark:border-blue-300/[0.14]'"
         >
-          <!-- Card with tinted background matching its accent color -->
+          <!-- Icon -->
           <div
-            class="relative h-full p-8 rounded-2xl border crisp-card transition-colors duration-300"
-            :class="index % 2 === 1 ? 'bg-white dark:bg-white/[0.05] border-orange-200/70 dark:border-orange-300/[0.16]' : 'bg-white dark:bg-white/[0.05] border-blue-200/70 dark:border-blue-300/[0.16]'"
+            class="icon-tile relative flex items-center justify-center w-12 h-12 rounded-xl mb-6 ring-1 transition-all duration-300"
+            :class="index % 2 === 1 ? 'bg-orange-100 dark:bg-orange-400/[0.14] ring-orange-900/[0.08] dark:ring-orange-300/[0.18]' : 'bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] dark:from-blue-400/[0.18] dark:to-blue-500/[0.22] ring-blue-900/[0.08] dark:ring-blue-300/[0.18]'"
           >
-
-            <!-- Icon -->
-            <div
-              class="relative flex items-center justify-center w-12 h-12 rounded-xl mx-auto mb-5 ring-1 transition-colors duration-300"
-              :class="index % 2 === 1 ? 'bg-orange-100 dark:bg-orange-400/[0.14] ring-orange-900/[0.08] dark:ring-orange-300/[0.18]' : 'bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] dark:from-blue-400/[0.18] dark:to-blue-500/[0.22] ring-blue-900/[0.08] dark:ring-blue-300/[0.18]'"
-            >
-              <i :class="[metric.icon, 'text-lg', index % 2 === 1 ? 'text-orange-600 dark:text-orange-300' : 'text-blue-600 dark:text-blue-300']"></i>
-            </div>
-
-            <!-- Title -->
-            <h3 class="relative text-xl font-semibold tracking-tight text-blue-950 dark:text-white transition-colors duration-300 mb-4 text-center">
-              {{ metric.title }}
-            </h3>
-
-            <!-- Description -->
-            <p class="relative text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty transition-colors duration-300 text-center">
-              {{ metric.description }}
-            </p>
+            <i :class="[metric.icon, 'text-lg', index % 2 === 1 ? 'text-orange-600 dark:text-orange-300' : 'text-blue-600 dark:text-blue-300']"></i>
           </div>
-        </div>
 
+          <!-- Title -->
+          <h3 class="relative text-xl font-semibold tracking-tight text-blue-950 dark:text-white transition-colors duration-300 mb-3">
+            {{ metric.title }}
+          </h3>
+
+          <!-- Description -->
+          <p class="relative text-blue-950/65 dark:text-blue-100/65 leading-relaxed text-pretty transition-colors duration-300">
+            {{ metric.description }}
+          </p>
+        </div>
       </div>
     </div>
   </section>
@@ -69,9 +77,11 @@
 
 <script>
 import { defineComponent } from 'vue'
+import reveal from '@/apps/home/directives/reveal'
 
 export default defineComponent({
   name: 'StatsSection',
+  directives: { reveal },
   props: {
     stats: {
       type: Array,
@@ -79,12 +89,14 @@ export default defineComponent({
         {
           value: '$10-20',
           unit: '',
-          label: 'Typical App Cost'
+          label: 'Typical App Cost',
+          caption: 'Pay only for what you build—no subscriptions, no surprises.'
         },
         {
           value: '30',
           unit: 'min',
-          label: 'Typical Build Time'
+          label: 'Typical Build Time',
+          caption: 'From first prompt to a working app you can share.'
         }
       ]
     },
@@ -113,6 +125,44 @@ export default defineComponent({
 </script>
 
 <style scoped>
+/* Hairline gradient divider that fades at the edges */
+.section-divider {
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(23, 37, 84, 0.12), transparent);
+}
+
+.dark .section-divider {
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.1), transparent);
+}
+
+/* Soft cool wash */
+.section-wash-cool {
+  background: radial-gradient(closest-side, rgba(158, 205, 243, 0.2), rgba(158, 205, 243, 0.06) 55%, transparent 75%);
+  filter: blur(48px);
+}
+
+.dark .section-wash-cool {
+  background: radial-gradient(closest-side, rgba(96, 165, 250, 0.08), rgba(96, 165, 250, 0.02) 55%, transparent 75%);
+}
+
+/* Italic serif accent in blue ink */
+.section-accent {
+  font-style: italic;
+  font-variation-settings: 'SOFT' 30, 'WONK' 1;
+  background: linear-gradient(115deg, #1d4ed8 5%, #2563eb 55%, #0284c7 95%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  padding-right: 0.05em;
+}
+
+.dark .section-accent {
+  background: linear-gradient(115deg, #93c5fd 5%, #60a5fa 60%, #7dd3fc 95%);
+  -webkit-background-clip: text;
+  background-clip: text;
+}
+
 /* Crisp, sharply-defined cards: hairline edge + tight layered shadow */
 .crisp-card {
   box-shadow:
@@ -128,5 +178,45 @@ export default defineComponent({
     0 1px 2px rgba(0, 0, 0, 0.5),
     0 4px 10px -2px rgba(0, 0, 0, 0.45),
     0 12px 28px -10px rgba(0, 0, 0, 0.55);
+}
+
+/* Cards that lift gently on hover */
+.lift-card {
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.03),
+    0 1px 2px rgba(15, 23, 42, 0.06),
+    0 4px 10px -2px rgba(15, 23, 42, 0.07),
+    0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
+
+.lift-card:hover {
+  transform: translateY(-4px);
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.04),
+    0 2px 4px rgba(15, 23, 42, 0.06),
+    0 10px 20px -4px rgba(15, 23, 42, 0.1),
+    0 24px 44px -12px rgba(15, 23, 42, 0.14);
+}
+
+.dark .lift-card {
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 12px 28px -10px rgba(0, 0, 0, 0.55);
+}
+
+.dark .lift-card:hover {
+  transform: translateY(-4px);
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.06),
+    0 2px 4px rgba(0, 0, 0, 0.5),
+    0 12px 24px -4px rgba(0, 0, 0, 0.5),
+    0 28px 48px -12px rgba(0, 0, 0, 0.6);
+}
+
+/* Icon tile nudge on card hover */
+.lift-card:hover .icon-tile {
+  transform: scale(1.06) rotate(-3deg);
 }
 </style>

--- a/frontend/vuejs/src/apps/home/directives/reveal.ts
+++ b/frontend/vuejs/src/apps/home/directives/reveal.ts
@@ -1,0 +1,68 @@
+import type { Directive } from 'vue'
+
+/**
+ * v-reveal — fades and lifts an element into view the first time it enters
+ * the viewport. Usage: `v-reveal` or `v-reveal="{ delay: 120 }"` (ms).
+ * Respects prefers-reduced-motion by leaving the element fully visible.
+ * The transition styles live in Home.vue's unscoped style block
+ * (.reveal-init / .is-revealed).
+ */
+
+interface RevealOptions {
+  delay?: number
+}
+
+let observer: IntersectionObserver | null = null
+
+// Once the reveal transition has played, strip the transition override and
+// inline delay so later transitions (e.g. card hover lifts) aren't lagged
+// by the stagger delay.
+function finishReveal(el: HTMLElement) {
+  // transitionDelay is always set by this directive as "<n>ms"
+  const delay = parseFloat(el.style.transitionDelay) || 0
+  window.setTimeout(() => {
+    el.classList.remove('reveal-init', 'is-revealed')
+    el.style.transitionDelay = ''
+  }, delay + 850)
+}
+
+function getObserver(): IntersectionObserver {
+  if (!observer) {
+    observer = new IntersectionObserver(
+      entries => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('is-revealed')
+            finishReveal(entry.target as HTMLElement)
+            observer?.unobserve(entry.target)
+          }
+        }
+      },
+      { threshold: 0, rootMargin: '0px 0px -60px 0px' }
+    )
+  }
+  return observer
+}
+
+const reveal: Directive<HTMLElement, RevealOptions | undefined> = {
+  mounted(el, binding) {
+    if (
+      typeof window === 'undefined' ||
+      !('IntersectionObserver' in window) ||
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    ) {
+      return
+    }
+    el.classList.add('reveal-init')
+    const delay = binding.value?.delay
+    if (delay) {
+      el.style.transitionDelay = `${delay}ms`
+    }
+    getObserver().observe(el)
+  },
+  unmounted(el) {
+    observer?.unobserve(el)
+  }
+}
+
+export default reveal

--- a/frontend/vuejs/src/apps/home/views/Home.vue
+++ b/frontend/vuejs/src/apps/home/views/Home.vue
@@ -1,22 +1,25 @@
-<!-- Home landing page - Clean Apple/Cursor-inspired design -->
+<!-- Home landing page - warm porcelain editorial design -->
 <template>
   <DefaultLayout :isHomeNav="true">
-    <div class="home-page min-h-screen bg-white dark:bg-[#0a0a0a] relative overflow-hidden transition-colors duration-500">
+    <div class="home-page relative min-h-screen overflow-hidden font-body transition-colors duration-500">
+
+      <!-- Grain texture over the whole canvas -->
+      <div class="grain-overlay absolute inset-0 z-[1] pointer-events-none" aria-hidden="true"></div>
 
       <!-- Main Content -->
       <main class="relative z-10">
         <!-- Hero Section -->
         <HeroSection />
-        
+
         <!-- Stats Section -->
         <StatsSection />
-        
+
         <!-- Features Section -->
         <FeaturesSection />
-        
+
         <!-- Key Features Section -->
         <KeyFeaturesSection />
-        
+
         <!-- CTA Section -->
         <CTASection
           title="Start your business today"
@@ -24,6 +27,7 @@
           primaryButtonText="Get Started"
           primaryButtonTo="/imagi/projects"
           :showSecondaryButton="false"
+          footnote="No subscriptions. Pay only for what you build."
         />
       </main>
     </div>
@@ -66,11 +70,33 @@ export default defineComponent({
 </script>
 
 <style scoped>
-/* Crisp, sharp text rendering across the landing page */
+/* One continuous warm-porcelain canvas; sections paint soft washes on top.
+   The gradient ends on the footer's exact background so the page hands off
+   seamlessly (footer is bg-white / dark #0a0a0a). */
 .home-page {
+  background: linear-gradient(180deg, #fdf9f2 0%, #faf7f1 45%, #ffffff 100%);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
+}
+
+:root.dark .home-page,
+.dark .home-page {
+  background: linear-gradient(180deg, #0c0c0e 0%, #0a0b0f 50%, #0a0a0a 100%);
+}
+
+/* Fine film grain keeps large soft gradients from banding and adds texture */
+.grain-overlay {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)' opacity='0.5'/%3E%3C/svg%3E");
+  background-size: 160px 160px;
+  opacity: 0.035;
+  mix-blend-mode: multiply;
+}
+
+:root.dark .grain-overlay,
+.dark .grain-overlay {
+  opacity: 0.05;
+  mix-blend-mode: overlay;
 }
 
 .home-page :deep(h1),
@@ -111,5 +137,42 @@ export default defineComponent({
 /* Smooth scroll behavior */
 :deep(html) {
   scroll-behavior: smooth;
+}
+</style>
+
+<!-- Unscoped: shared motion + selection styles used across home sections -->
+<style>
+/* Scroll reveal (classes applied by the v-reveal directive) */
+.reveal-init {
+  opacity: 0;
+  transform: translateY(26px);
+  transition:
+    opacity 0.8s cubic-bezier(0.22, 1, 0.36, 1),
+    transform 0.8s cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: opacity, transform;
+}
+
+.reveal-init.is-revealed {
+  opacity: 1;
+  transform: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal-init {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+}
+
+/* Brand-tinted text selection on the landing page */
+.home-page ::selection {
+  background: rgba(158, 205, 243, 0.55);
+  color: #172554;
+}
+
+.dark .home-page ::selection {
+  background: rgba(96, 165, 250, 0.4);
+  color: #eff6ff;
 }
 </style>

--- a/frontend/vuejs/src/shared/components/molecules/branding/ImagiLogo.vue
+++ b/frontend/vuejs/src/shared/components/molecules/branding/ImagiLogo.vue
@@ -1,23 +1,24 @@
 <!--
   ImagiLogo.vue - Standardized logo component
-  
-  This component provides a consistent representation of the Imagi logo
-  across the application. It supports various sizes and customization options.
+
+  Serif wordmark set in the brand display face (Fraunces) with an orange
+  terminal period — "Imagi." — navy ink in light mode, white in dark.
+  Supports the same size variants as before.
 -->
 <template>
   <router-link :to="to" class="flex items-center" :class="[iconOnly ? '' : 'space-x-2']">
     <!-- Logo Text -->
-    <span 
-      class="font-bold text-black dark:text-white tracking-tight transition-colors duration-300"
+    <span
+      class="wordmark font-display font-semibold leading-none tracking-[-0.01em] text-blue-950 dark:text-white transition-colors duration-300"
       :class="[
-        size === 'sm' ? 'text-base' : 
-        size === 'md' ? 'text-xl' : 
-        size === 'lg' ? 'text-2xl' : 
-        size === 'xl' ? 'text-4xl' : 
-        'text-xl'
+        size === 'sm' ? 'text-lg' :
+        size === 'md' ? 'text-[1.35rem]' :
+        size === 'lg' ? 'text-2xl' :
+        size === 'xl' ? 'text-4xl' :
+        'text-[1.35rem]'
       ]"
     >
-      <slot>Imagi</slot>
+      <slot>Imagi</slot><span class="text-orange-600 dark:text-orange-400" aria-hidden="true">.</span>
     </span>
   </router-link>
 </template>
@@ -48,3 +49,12 @@ defineProps({
   }
 })
 </script>
+
+<style scoped>
+/* Warm cut of Fraunces; no WONK — the wordmark stays steady while
+   headline accent words carry the quirk */
+.wordmark {
+  font-variation-settings: 'SOFT' 30, 'WONK' 0;
+  font-optical-sizing: auto;
+}
+</style>

--- a/frontend/vuejs/tailwind.config.js
+++ b/frontend/vuejs/tailwind.config.js
@@ -44,6 +44,23 @@ export default {
           'Arial',
           'sans-serif',
         ],
+        display: [
+          'Fraunces',
+          'Georgia',
+          'Cambria',
+          'Times New Roman',
+          'serif',
+        ],
+        body: [
+          'Instrument Sans',
+          '-apple-system',
+          'BlinkMacSystemFont',
+          'Segoe UI',
+          'Roboto',
+          'Helvetica Neue',
+          'Arial',
+          'sans-serif',
+        ],
       },
       spacing: {
         'header': '64px',


### PR DESCRIPTION
## What changed

A full visual polish pass on the landing page, replacing the alternating orange/blue pastel stripes with a single warm-porcelain canvas and an editorial design language:

- **Typography**: Fraunces (variable display serif) + Instrument Sans now load via Google Fonts — previously the "Inter" in the font stack was never loaded, so everything rendered in system fonts. Headlines carry one italic gradient-ink accent word using Fraunces' SOFT/WONK axes (now actually requested in the font URL).
- **Hero**: staggered load-in animation, layered apricot/baby-blue radial glows with a hairline halo ring, an editorial kicker (tracked small caps between fading hairline rules with orange fleurons) replacing the old pill badge, and a "See how it works" smooth-scroll link.
- **Sections**: editorial two-column headers (headline left, copy right), hairline gradient dividers, hover-lift cards that now render the icon and highlight-checklist data they previously defined but never displayed, and a spec-sheet stat band with new captions.
- **CTA finale**: set directly on the canvas — large Fraunces headline with warm gradient accent, navy primary button, serif-italic folio footnote. The footnote is an opt-in prop so About/Privacy/Terms (which share `CTASection`) don't inherit pricing copy.
- **Buttons**: unified navy ink pill system matching the headline ink, inverting to warm paper in dark mode. Navbar Sign In is a small navy pill; Sign Out is a quiet hairline outline. The old glossy baby-blue 3D pattern is removed from the home page (remaining uses on auth/docs pages are tracked as a follow-up).
- **Wordmark**: shared `ImagiLogo` becomes "Imagi." — Fraunces semibold navy with an orange terminal period (also improves auth pages).
- **Motion**: new `v-reveal` IntersectionObserver directive with per-card stagger; the inline stagger delay is cleared after reveal so card hover transitions aren't lagged; `prefers-reduced-motion` is respected everywhere, including the smooth scroll.

## Why

The page previously used unloaded system fonts, flat centered layouts, hard full-bleed color stripes, and no motion. This pass gives it a distinctive, cohesive identity while keeping the existing brand palette (navy ink, orange spot accents, baby-blue tints) and both light/dark themes.

## Notes for reviewers

- A multi-agent review pass verified the diff; confirmed findings were fixed: light-mode gradient/muted-text contrast raised to WCAG AA (deepened gradient stops, higher opacities), the shared-component footnote leak, the missing font axes, the reveal-delay lag, and a footer background seam (the canvas now ends on the footer's exact colors).
- Verified in the browser at desktop and mobile widths, light and dark themes, including the auth page (inherits the new wordmark) and `/about` (shared CTA renders correctly, no footnote).
- `npm run type-check` and `npm run lint` pass (0 errors; 67 pre-existing warnings untouched).
- Backend health-check console errors on the home page are pre-existing (Django not running in dev preview) and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)