### PR TITLE
Fix homepage copy claiming Imagi has no subscriptions

### DIFF
--- a/frontend/vuejs/src/apps/home/components/organisms/sections/FAQSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/FAQSection.vue
@@ -192,7 +192,7 @@ export default defineComponent({
       {
         icon: 'fas fa-dollar-sign',
         question: 'How does pricing work?',
-        answer: 'Imagi uses a credit-based system. You purchase credits and spend them on AI requests. Building a complete app typically costs $5-15 in credits depending on complexity. There are no monthly fees — you only pay for what you build.',
+        answer: 'Imagi offers monthly subscription plans: Hobby ($10/month), Pro ($50/month), and Max ($100/month). Each plan includes a monthly allowance of AI usage and project deployments, with higher tiers unlocking more deployments, usage, and support. You can cancel anytime.',
         link: { text: 'View pricing details', to: '/payments/pricing' }
       },
       {

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/StatsSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/StatsSection.vue
@@ -77,9 +77,9 @@ export default defineComponent({
       type: Array,
       default: () => [
         {
-          value: '$10-20',
-          unit: '',
-          label: 'Typical App Cost'
+          value: '$10',
+          unit: '/mo',
+          label: 'Plans Starting At'
         },
         {
           value: '30',

--- a/frontend/vuejs/src/apps/home/views/Home.vue
+++ b/frontend/vuejs/src/apps/home/views/Home.vue
@@ -27,7 +27,7 @@
           primaryButtonText="Get Started"
           primaryButtonTo="/imagi/projects"
           :showSecondaryButton="false"
-          footnote="No subscriptions. Pay only for what you build."
+          footnote="Plans start at $10/month. Cancel anytime."
         />
       </main>
     </div>


### PR DESCRIPTION
## Summary
Imagi sells monthly subscription plans (Hobby $10, Pro $50, Max $100 — see the pricing page), but several pieces of homepage copy claimed the opposite. This PR updates all of them:

- **CTA footnote** (`frontend/vuejs/src/apps/home/views/Home.vue`): "No subscriptions. Pay only for what you build." → "Plans start at $10/month. Cancel anytime."
- **Stats section** (`StatsSection.vue`): the "$10-20 Typical App Cost" card (with caption "no subscriptions, no surprises") → "Plans Starting At $10/mo" with a caption noting plans include AI usage and deployments.
- **FAQ pricing answer** (`FAQSection.vue`): replaced the credit-based / "no monthly fees" description with the actual three subscription tiers. (FAQSection isn't currently rendered on the homepage, but the copy is now accurate for when it is.)

Latest main (including the #84 homepage redesign) is merged in; the redesign's new footnote/caption copy was the source of the "no subscriptions" claims.

## Verification
Verified in the Vite dev preview: the stat card and CTA footnote render the new copy, and no "no subscriptions" / "pay only for what you build" / "$10-20" text remains anywhere on the page. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)