### PR TITLE
Convert legacy gradient buttons to navy ink pill system

### DIFF
--- a/frontend/vuejs/src/apps/auth/components/atoms/buttons/GradientButton.vue
+++ b/frontend/vuejs/src/apps/auth/components/atoms/buttons/GradientButton.vue
@@ -2,26 +2,25 @@
   <button
     :type="type"
     :disabled="disabled || loading"
-    class="btn-3d btn-accent group relative w-full inline-flex items-center justify-center gap-2 px-8 py-4
-           text-blue-950
+    class="group relative w-full inline-flex items-center justify-center gap-2 px-8 py-4
            rounded-full
            font-medium
-           border border-white/60 dark:border-white/30
+           bg-blue-950 text-[#fdf9f2] hover:bg-blue-900
+           dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white
+           shadow-[0_1px_2px_rgba(23,37,84,0.25),0_8px_20px_-6px_rgba(23,37,84,0.35),inset_0_1px_0_rgba(255,255,255,0.12)]
+           hover:shadow-[0_2px_3px_rgba(23,37,84,0.22),0_14px_28px_-8px_rgba(23,37,84,0.4),inset_0_1px_0_rgba(255,255,255,0.12)]
+           dark:shadow-[0_1px_2px_rgba(0,0,0,0.5),0_10px_24px_-8px_rgba(0,0,0,0.55)]
+           dark:hover:shadow-[0_2px_3px_rgba(0,0,0,0.5),0_14px_30px_-8px_rgba(0,0,0,0.6)]
            focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]
-           transition-all duration-300
-           disabled:opacity-50 disabled:cursor-not-allowed
-           overflow-hidden"
+           transition-all duration-200 hover:-translate-y-0.5 active:translate-y-0
+           disabled:opacity-50 disabled:cursor-not-allowed"
   >
-    <!-- Top edge highlight for 3D effect -->
-    <span class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/70 to-transparent"></span>
-    <!-- Bottom edge shadow for depth -->
-    <span class="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-blue-900/15 to-transparent"></span>
     <!-- Content -->
-    <span v-if="loading" class="relative z-10 flex items-center justify-center">
+    <span v-if="loading" class="flex items-center justify-center">
       <i class="fas fa-circle-notch fa-spin mr-2"></i>
       <span class="font-medium">{{ loadingText }}</span>
     </span>
-    <span v-else class="relative z-10 flex items-center justify-center gap-2">
+    <span v-else class="flex items-center justify-center gap-2">
       <span class="font-medium"><slot></slot></span>
       <i class="fas fa-arrow-right text-sm transition-transform duration-300 group-hover:translate-x-1"></i>
     </span>
@@ -48,41 +47,3 @@ defineProps({
   }
 })
 </script>
-
-<style scoped>
-/* Soft 3D button effect - tight, layered, crisp. Blue-tinted shadows to suit the light baby-blue fill. */
-.btn-3d {
-  transform: translateY(0) translateZ(0);
-  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
-  box-shadow:
-    0 1px 2px rgba(30, 58, 138, 0.14),
-    0 4px 10px -2px rgba(30, 58, 138, 0.16),
-    0 10px 20px -6px rgba(30, 58, 138, 0.18),
-    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
-    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.12);
-}
-
-.btn-3d:active {
-  transform: translateY(0) translateZ(0);
-  transition-duration: 0.1s;
-}
-
-/* Soft baby-blue gradient fill */
-.btn-accent {
-  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
-}
-
-.dark .btn-accent {
-  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
-}
-
-/* On dark, ground the light button with deep neutral shadows; keep the inner sheen */
-.dark .btn-3d {
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.5),
-    0 4px 10px -2px rgba(0, 0, 0, 0.45),
-    0 10px 20px -6px rgba(0, 0, 0, 0.5),
-    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
-    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.18);
-}
-</style>

--- a/frontend/vuejs/src/apps/docs/views/DocsQuickStart.vue
+++ b/frontend/vuejs/src/apps/docs/views/DocsQuickStart.vue
@@ -15,13 +15,11 @@
         <div class="w-full h-px bg-blue-200/70 dark:bg-blue-300/[0.16] mb-6"></div>
         <router-link
           to="/imagi/projects"
-          class="btn-3d btn-accent group relative inline-flex items-center justify-center gap-3 px-8 py-4 text-blue-950 rounded-full font-medium text-lg transition-all duration-300 overflow-hidden border border-white/60 dark:border-white/30"
+          class="group inline-flex items-center justify-center gap-3 px-8 py-4 rounded-full font-medium text-lg bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white transition-all duration-200 hover:-translate-y-0.5 active:translate-y-0 shadow-[0_1px_2px_rgba(23,37,84,0.25),0_8px_20px_-6px_rgba(23,37,84,0.35),inset_0_1px_0_rgba(255,255,255,0.12)] hover:shadow-[0_2px_3px_rgba(23,37,84,0.22),0_14px_28px_-8px_rgba(23,37,84,0.4),inset_0_1px_0_rgba(255,255,255,0.12)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.5),0_10px_24px_-8px_rgba(0,0,0,0.55)] dark:hover:shadow-[0_2px_3px_rgba(0,0,0,0.5),0_14px_30px_-8px_rgba(0,0,0,0.6)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
         >
-          <span class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/70 to-transparent"></span>
-          <span class="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-blue-900/15 to-transparent"></span>
-          <span class="relative">Create New Project</span>
+          <span>Create New Project</span>
           <svg
-            class="relative w-5 h-5 ml-1 transition-transform duration-300 group-hover:translate-x-1"
+            class="w-5 h-5 ml-1 transition-transform duration-300 group-hover:translate-x-1"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -128,32 +126,3 @@
 import DocsLayout from '../layouts/DocsLayout.vue';
 import { DocsPageHeader, DocsStepCard, DocsNavigationCard } from '../components';
 </script>
-
-<style scoped>
-/* Soft 3D button effect - tight, layered, crisp. Blue-tinted shadows to suit the baby-blue fill. */
-.btn-3d {
-  transform: translateZ(0);
-  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
-  box-shadow:
-    0 1px 2px rgba(30, 58, 138, 0.14),
-    0 4px 10px -2px rgba(30, 58, 138, 0.16),
-    0 10px 20px -6px rgba(30, 58, 138, 0.18),
-    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
-    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.12);
-}
-
-/* Soft baby-blue gradient fill */
-.btn-accent {
-  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
-}
-
-/* On dark, ground the light button with deep neutral shadows; keep the inner sheen */
-.dark .btn-3d {
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.5),
-    0 4px 10px -2px rgba(0, 0, 0, 0.45),
-    0 10px 20px -6px rgba(0, 0, 0, 0.5),
-    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
-    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.18);
-}
-</style>

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspaceError.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspaceError.vue
@@ -19,12 +19,10 @@
             <div class="flex flex-col sm:flex-row gap-4 justify-center">
               <router-link
                 to="/imagi/projects"
-                class="btn-3d btn-accent group relative inline-flex items-center justify-center px-6 py-3 rounded-full text-blue-950 border border-white/60 dark:border-white/30 font-semibold overflow-hidden"
+                class="group inline-flex items-center justify-center px-6 py-3 rounded-full font-medium bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white transition-colors duration-200 shadow-[0_1px_2px_rgba(23,37,84,0.2),0_3px_8px_-2px_rgba(23,37,84,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
               >
-                <span class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/70 to-transparent"></span>
-                <span class="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-blue-900/15 to-transparent"></span>
-                <i class="fas fa-arrow-left mr-2 relative"></i>
-                <span class="relative">Go to Dashboard</span>
+                <i class="fas fa-arrow-left mr-2"></i>
+                <span>Go to Dashboard</span>
               </router-link>
               <button
                 @click="$emit('retry')"
@@ -63,32 +61,4 @@ const props = defineProps<{ error: string | null | undefined }>()
     0 12px 28px -10px rgba(0, 0, 0, 0.55);
 }
 
-/* Soft 3D button matching the site's primary "Start Building" button */
-.btn-3d {
-  transform: translateY(0) translateZ(0);
-  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
-  box-shadow:
-    0 1px 2px rgba(30, 58, 138, 0.14),
-    0 4px 10px -2px rgba(30, 58, 138, 0.16),
-    0 10px 20px -6px rgba(30, 58, 138, 0.18),
-    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
-    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.12);
-}
-
-.btn-3d:active {
-  transition-duration: 0.1s;
-}
-
-.btn-accent {
-  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
-}
-
-.dark .btn-3d {
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.5),
-    0 4px 10px -2px rgba(0, 0, 0, 0.45),
-    0 10px 20px -6px rgba(0, 0, 0, 0.5),
-    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
-    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.18);
-}
 </style>

--- a/frontend/vuejs/src/apps/imagi/project-manager/views/Projects.vue
+++ b/frontend/vuejs/src/apps/imagi/project-manager/views/Projects.vue
@@ -52,12 +52,10 @@
               <p class="text-blue-950/70 dark:text-blue-100/70 mb-8 max-w-md mx-auto transition-colors duration-300">Please log in to view and manage your projects.</p>
               <router-link
                 to="/auth/signin"
-                class="btn-3d btn-accent group relative inline-flex items-center justify-center gap-3 px-8 py-4 text-blue-950 rounded-full font-medium text-lg overflow-hidden border border-white/60 dark:border-white/30"
+                class="group inline-flex items-center justify-center gap-3 px-8 py-4 rounded-full font-medium text-lg bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white transition-all duration-200 hover:-translate-y-0.5 active:translate-y-0 shadow-[0_1px_2px_rgba(23,37,84,0.25),0_8px_20px_-6px_rgba(23,37,84,0.35),inset_0_1px_0_rgba(255,255,255,0.12)] hover:shadow-[0_2px_3px_rgba(23,37,84,0.22),0_14px_28px_-8px_rgba(23,37,84,0.4),inset_0_1px_0_rgba(255,255,255,0.12)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.5),0_10px_24px_-8px_rgba(0,0,0,0.55)] dark:hover:shadow-[0_2px_3px_rgba(0,0,0,0.5),0_14px_30px_-8px_rgba(0,0,0,0.6)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#16120e]"
               >
-                <span class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/70 to-transparent"></span>
-                <span class="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-blue-900/15 to-transparent"></span>
-                <i class="fas fa-sign-in-alt relative"></i>
-                <span class="relative">Log In</span>
+                <i class="fas fa-sign-in-alt"></i>
+                <span>Log In</span>
               </router-link>
             </div>
           </div>
@@ -115,17 +113,15 @@
                     <button
                       @click="createProject"
                       :disabled="!canCreate || isCreating"
-                      class="btn-3d btn-accent group relative w-full inline-flex items-center justify-center gap-3 px-8 py-3.5 text-blue-950 rounded-full font-medium text-base overflow-hidden border border-white/60 dark:border-white/30 disabled:opacity-50 disabled:cursor-not-allowed"
+                      class="group w-full inline-flex items-center justify-center gap-3 px-8 py-3.5 rounded-full font-medium text-base bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white transition-all duration-200 hover:-translate-y-0.5 active:translate-y-0 shadow-[0_1px_2px_rgba(23,37,84,0.25),0_8px_20px_-6px_rgba(23,37,84,0.35),inset_0_1px_0_rgba(255,255,255,0.12)] hover:shadow-[0_2px_3px_rgba(23,37,84,0.22),0_14px_28px_-8px_rgba(23,37,84,0.4),inset_0_1px_0_rgba(255,255,255,0.12)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.5),0_10px_24px_-8px_rgba(0,0,0,0.55)] dark:hover:shadow-[0_2px_3px_rgba(0,0,0,0.5),0_14px_30px_-8px_rgba(0,0,0,0.6)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#16120e] disabled:opacity-50 disabled:cursor-not-allowed"
                     >
-                      <span class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/70 to-transparent"></span>
-                      <span class="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-blue-900/15 to-transparent"></span>
                       <template v-if="isCreating">
-                        <div class="relative w-5 h-5 border-2 border-blue-950/30 border-t-blue-950 rounded-full animate-spin"></div>
-                        <span class="relative">Creating...</span>
+                        <div class="w-5 h-5 border-2 border-[#fdf9f2]/30 border-t-[#fdf9f2] dark:border-blue-950/30 dark:border-t-blue-950 rounded-full animate-spin"></div>
+                        <span>Creating...</span>
                       </template>
                       <template v-else>
-                        <span class="relative">Create Project</span>
-                        <svg class="relative w-5 h-5 transition-transform duration-300 group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <span>Create Project</span>
+                        <svg class="w-5 h-5 transition-transform duration-300 group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
                         </svg>
                       </template>
@@ -626,39 +622,4 @@ input:focus, textarea:focus {
     0 12px 28px -10px rgba(0, 0, 0, 0.55);
 }
 
-/* Soft 3D button effect matching the hero "Start Building" button - blue-tinted shadows for the baby-blue fill. */
-.btn-3d {
-  transform: translateY(0) translateZ(0);
-  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
-  box-shadow:
-    0 1px 2px rgba(30, 58, 138, 0.14),
-    0 4px 10px -2px rgba(30, 58, 138, 0.16),
-    0 10px 20px -6px rgba(30, 58, 138, 0.18),
-    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
-    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.12);
-}
-
-.btn-3d:active {
-  transform: translateY(0) translateZ(0);
-  transition-duration: 0.1s;
-}
-
-/* Soft baby-blue gradient fill */
-.btn-accent {
-  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
-}
-
-.dark .btn-accent {
-  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
-}
-
-/* On dark, ground the light button with deep neutral shadows; keep the inner sheen */
-.dark .btn-3d {
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.5),
-    0 4px 10px -2px rgba(0, 0, 0, 0.45),
-    0 10px 20px -6px rgba(0, 0, 0, 0.5),
-    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
-    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.18);
-}
 </style>

--- a/frontend/vuejs/src/apps/imagi/project-manager/views/ToolCategory.vue
+++ b/frontend/vuejs/src/apps/imagi/project-manager/views/ToolCategory.vue
@@ -92,12 +92,10 @@
                 </p>
                 <router-link
                   :to="{ name: 'builder-workspace', params: { projectName } }"
-                  class="btn-3d btn-accent group relative inline-flex items-center justify-center gap-3 px-7 py-3 text-blue-950 rounded-full font-medium text-base overflow-hidden border border-white/60 dark:border-white/30"
+                  class="group inline-flex items-center justify-center gap-3 px-7 py-3 rounded-full font-medium text-base bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white transition-colors duration-200 shadow-[0_1px_2px_rgba(23,37,84,0.2),0_3px_8px_-2px_rgba(23,37,84,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#16120e]"
                 >
-                  <span class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/70 to-transparent"></span>
-                  <span class="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-blue-900/15 to-transparent"></span>
-                  <i class="fas fa-wand-magic-sparkles relative"></i>
-                  <span class="relative">Open the app builder</span>
+                  <i class="fas fa-wand-magic-sparkles"></i>
+                  <span>Open the app builder</span>
                 </router-link>
               </div>
             </section>
@@ -140,36 +138,4 @@ const accent = computed(() => accentClasses[tool.value?.accent ?? 'blue'])
     0 12px 28px -10px rgba(0, 0, 0, 0.55);
 }
 
-.btn-3d {
-  transform: translateY(0) translateZ(0);
-  transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
-  box-shadow:
-    0 1px 2px rgba(30, 58, 138, 0.14),
-    0 4px 10px -2px rgba(30, 58, 138, 0.16),
-    0 10px 20px -6px rgba(30, 58, 138, 0.18),
-    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
-    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.12);
-}
-
-.btn-3d:active {
-  transform: translateY(0) translateZ(0);
-  transition-duration: 0.1s;
-}
-
-.btn-accent {
-  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
-}
-
-:global(.dark) .btn-accent {
-  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
-}
-
-:global(.dark) .btn-3d {
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.5),
-    0 4px 10px -2px rgba(0, 0, 0, 0.45),
-    0 10px 20px -6px rgba(0, 0, 0, 0.5),
-    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
-    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.18);
-}
 </style>

--- a/frontend/vuejs/src/shared/components/atoms/buttons/GradientButton.vue
+++ b/frontend/vuejs/src/shared/components/atoms/buttons/GradientButton.vue
@@ -3,7 +3,7 @@
     :is="componentTag"
     :to="to"
     :disabled="disabled"
-    class="inline-flex items-center justify-center rounded-xl font-medium transition-all duration-300 shadow-lg focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-violet-400/40"
+    class="inline-flex items-center justify-center rounded-full font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#16120e]"
     :class="[
       sizeClass,
       disabled
@@ -51,16 +51,9 @@ const sizeClass = computed(() => ({
   lg: 'px-5 py-3 text-base'
 }[props.size]))
 
+// Both variants share the navy ink pill from the home page button system
 const variantClass = computed(() => {
-  // Default (primary) matches existing gradient to avoid breaking styles elsewhere
-  if (props.variant === 'primary') {
-    return 'bg-gradient-to-r from-indigo-500 via-violet-500 to-fuchsia-500 hover:from-indigo-400 hover:via-violet-400 hover:to-fuchsia-400 text-white shadow-indigo-500/25 hover:shadow-indigo-500/35'
-  }
-  // Imagi variant: tuned to Imagi site palette with primary + violet/indigo accents
-  if (props.variant === 'imagi') {
-    return 'bg-gradient-to-r from-primary-500 via-violet-500 to-indigo-500 hover:from-primary-400 hover:via-violet-400 hover:to-indigo-400 text-white shadow-violet-500/20 hover:shadow-violet-500/30'
-  }
-  return 'bg-gradient-to-r from-indigo-500 via-violet-500 to-fuchsia-500 hover:from-indigo-400 hover:via-violet-400 hover:to-fuchsia-400 text-white shadow-indigo-500/25 hover:shadow-indigo-500/35'
+  return 'bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white shadow-[0_1px_2px_rgba(23,37,84,0.2),0_3px_8px_-2px_rgba(23,37,84,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)]'
 })
 
 function onClick(ev: MouseEvent) {


### PR DESCRIPTION
## What changed

Restyles the last legacy-gradient buttons on pages one click from the redesigned home page to the unified navy ink pill system (solid `bg-blue-950` with warm cream `#fdf9f2` text in light mode, inverting to cream `#f3ede2` with navy text in dark mode, `rounded-full`, home-page shadow recipes):

- `apps/auth/.../GradientButton.vue` — the submit button used by Login (`/auth/signin`) and Register; was the baby-blue `btn-3d`/`btn-accent` 3D gradient.
- `shared/.../GradientButton.vue` — was an indigo/violet/fuchsia gradient (used by ProjectList's retry state); both variants now render the navy pill and its `focus:ring-violet-400/40` became the standard focus-visible ring.
- `docs/views/DocsQuickStart.vue` — "Create New Project" CTA.
- `project-manager/views/Projects.vue` — "Log In" and "Create Project" buttons; the create-button spinner now inverts with the fill.
- `project-manager/views/ToolCategory.vue` — "Open the app builder" CTA.
- `build/.../WorkspaceError.vue` — "Go to Dashboard" button.

All scoped `btn-3d`/`btn-accent` CSS blocks and the edge-highlight overlay spans were removed (net −180 lines).

## Why

The home page redesign introduced the navy ink button system, but adjacent pages — especially `/auth/signin`, reachable directly from the navbar — still showed the retired baby-blue 3D gradient, breaking the brand language one click in.

## Notes for reviewers

- The home app components (HeroSection, CTASection, HomeNavbar) are intentionally untouched: the home redesign itself lives on a separate in-progress branch (`claude/home-page-design-polish-81332f`), and this PR only aligns the surrounding pages to avoid conflicting with it.
- Focus-visible rings were preserved where present and added where missing, with ring-offset colors matched to each page background (`white`/`#0a0a0a` for auth/docs, `white`/`#16120e` for projects pages).
- Verified with `npm run type-check` and visually via the Vite dev server: `/auth/signin`, `/docs/quickstart`, and `/imagi/projects` in both light and dark mode. ToolCategory/WorkspaceError sit behind auth+project state and use the identical class recipe.
- Remaining baby-blue accents deeper in the build workspace (chat send button, agent panel chips, empty-state icon) are being handled in a separate follow-up session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)