### PR TITLE
Restyle build workspace controls to the navy ink button system

### DIFF
--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/chat/ChatConversation.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/chat/ChatConversation.vue
@@ -497,21 +497,22 @@ const copyToClipboard = (code: string) => {
   }
 }
 
-/* Empty state icon: soft baby-blue tile matching the site's primary button */
+/* Empty state icon: navy ink tile matching the site's primary button */
 .empty-icon {
-  color: theme('colors.blue.900');
-  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
+  color: #fdf9f2;
+  background: theme('colors.blue.950');
   box-shadow:
-    0 1px 2px rgba(30, 58, 138, 0.12),
-    0 6px 14px -4px rgba(30, 58, 138, 0.18),
-    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75);
+    0 1px 2px rgba(23, 37, 84, 0.2),
+    0 6px 14px -4px rgba(23, 37, 84, 0.25),
+    inset 0 1px 0 rgba(255, 255, 255, 0.12);
 }
 
 .dark .empty-icon {
+  color: theme('colors.blue.950');
+  background: #f3ede2;
   box-shadow:
     0 1px 2px rgba(0, 0, 0, 0.4),
-    0 6px 14px -4px rgba(0, 0, 0, 0.45),
-    inset 0 1px 1px 0 rgba(255, 255, 255, 0.6);
+    0 6px 14px -4px rgba(0, 0, 0, 0.45);
 }
 
 /* Prose styling for dark mode */

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/AgentManagerPanel.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/AgentManagerPanel.vue
@@ -27,7 +27,7 @@
       <!-- Panel title -->
       <div class="flex-1 min-w-0 flex items-center gap-2 pl-0.5">
         <div class="agents-icon-chip flex items-center justify-center w-5 h-5 rounded-md shrink-0">
-          <i class="fas fa-layer-group text-[9px] text-blue-700 dark:text-blue-300"></i>
+          <i class="fas fa-layer-group text-[9px] text-blue-950/80 dark:text-[#f3ede2]/90"></i>
         </div>
         <span class="text-xs font-semibold text-blue-950/80 dark:text-white/80 truncate">Agents</span>
       </div>
@@ -55,7 +55,7 @@
       <!-- New agent instance -->
       <div class="relative group">
         <button
-          class="btn-new flex items-center justify-center w-7 h-7 rounded-md text-blue-950 border border-white/60 dark:border-white/30 transition-all duration-200"
+          class="btn-new flex items-center justify-center w-7 h-7 rounded-md text-[#fdf9f2] dark:text-blue-950 transition-all duration-200"
           @click="handleCreate"
         >
           <i class="fas fa-plus text-xs"></i>
@@ -257,44 +257,46 @@ async function handleRename(id: string, title: string) {
 </script>
 
 <style scoped>
-/* Panel title chip - baby-blue accent matching the site's primary buttons */
+/* Panel title chip - subtle navy ink tint (a solid pill would compete with the + button) */
 .agents-icon-chip {
-  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
-  box-shadow:
-    0 1px 2px rgba(30, 58, 138, 0.1),
-    inset 0 1px 1px 0 rgba(255, 255, 255, 0.7);
+  background: rgba(23, 37, 84, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(23, 37, 84, 0.06);
 }
 
 .dark .agents-icon-chip {
-  background: rgba(96, 165, 250, 0.12);
+  background: rgba(243, 237, 226, 0.12);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
-/* Baby-blue "new agent" button - matching the chat's send button */
+/* Navy ink "new agent" button - matching the chat's send button */
 .btn-new {
-  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
+  background: theme('colors.blue.950');
   box-shadow:
-    0 1px 2px rgba(30, 58, 138, 0.14),
-    0 3px 8px -2px rgba(30, 58, 138, 0.16),
-    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
-    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.12);
+    0 1px 2px rgba(23, 37, 84, 0.2),
+    0 3px 8px -2px rgba(23, 37, 84, 0.25),
+    inset 0 1px 0 rgba(255, 255, 255, 0.12);
 }
 
 .btn-new:hover {
-  filter: brightness(1.04);
+  background: theme('colors.blue.900');
   box-shadow:
-    0 1px 2px rgba(30, 58, 138, 0.16),
-    0 5px 12px -2px rgba(30, 58, 138, 0.22),
-    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
-    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.12);
+    0 2px 3px rgba(23, 37, 84, 0.22),
+    0 5px 12px -2px rgba(23, 37, 84, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.12);
 }
 
 .dark .btn-new {
+  background: #f3ede2;
   box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.5),
-    0 3px 8px -2px rgba(0, 0, 0, 0.45),
-    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
-    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.18);
+    0 1px 2px rgba(0, 0, 0, 0.4),
+    0 3px 8px -2px rgba(0, 0, 0, 0.45);
+}
+
+.dark .btn-new:hover {
+  background: #ffffff;
+  box-shadow:
+    0 2px 3px rgba(0, 0, 0, 0.4),
+    0 5px 12px -2px rgba(0, 0, 0, 0.5);
 }
 
 /* Search field focus ring - matching the chat input shell */

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
@@ -113,7 +113,7 @@
               aria-label="Send message"
               class="btn-send flex shrink-0 items-center justify-center w-9 h-9 rounded-full transition-all duration-300"
               :class="prompt.trim() && activeInstance && !activeInstance.isProcessing
-                ? 'btn-send--active text-blue-950 border border-white/60 dark:border-white/30 shadow-lg hover:shadow-xl'
+                ? 'btn-send--active text-[#fdf9f2] dark:text-blue-950'
                 : 'bg-blue-100/60 dark:bg-white/[0.05] text-blue-950/40 dark:text-white/40 cursor-not-allowed border border-blue-200/70 dark:border-white/[0.12] shadow-sm'"
             >
               <i v-if="activeInstance?.isProcessing" class="fas fa-circle-notch fa-spin text-sm"></i>
@@ -401,28 +401,39 @@ textarea:active {
   transition: none !important;
 }
 
-/* Baby-blue send button - matching the site's primary "Start Building" button */
+/* Navy ink send button - matching the site's primary "Start Building" button */
 .btn-send {
   transform: translateY(0) translateZ(0);
 }
 
 .btn-send--active {
-  background: linear-gradient(155deg, #dbeeff 0%, #b7ddf7 55%, #9ecdf3 100%);
+  background: theme('colors.blue.950');
   box-shadow:
-    0 1px 2px rgba(30, 58, 138, 0.14),
-    0 4px 10px -2px rgba(30, 58, 138, 0.16),
-    0 10px 20px -6px rgba(30, 58, 138, 0.18),
-    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
-    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.12);
+    0 1px 2px rgba(23, 37, 84, 0.2),
+    0 3px 8px -2px rgba(23, 37, 84, 0.25),
+    inset 0 1px 0 rgba(255, 255, 255, 0.12);
+}
+
+.btn-send--active:hover {
+  background: theme('colors.blue.900');
+  box-shadow:
+    0 2px 3px rgba(23, 37, 84, 0.22),
+    0 5px 12px -2px rgba(23, 37, 84, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.12);
 }
 
 .dark .btn-send--active {
+  background: #f3ede2;
   box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.5),
-    0 4px 10px -2px rgba(0, 0, 0, 0.45),
-    0 10px 20px -6px rgba(0, 0, 0, 0.5),
-    inset 0 1px 1px 0 rgba(255, 255, 255, 0.75),
-    inset 0 -2px 4px -1px rgba(30, 58, 138, 0.18);
+    0 1px 2px rgba(0, 0, 0, 0.4),
+    0 3px 8px -2px rgba(0, 0, 0, 0.45);
+}
+
+.dark .btn-send--active:hover {
+  background: #ffffff;
+  box-shadow:
+    0 2px 3px rgba(0, 0, 0, 0.4),
+    0 5px 12px -2px rgba(0, 0, 0, 0.5);
 }
 
 /* Refined minimal scrollbar - matching homepage */


### PR DESCRIPTION
## What changed

Converts the last baby-blue gradient (`linear-gradient(155deg, #dbeeff, #b7ddf7, #9ecdf3)`) instances in the build workspace to the navy ink button system introduced with the home-page redesign (#84): `bg-blue-950` fill with warm cream (`#fdf9f2`) text in light mode, warm cream (`#f3ede2`) fill with navy text in dark mode.

- **ChatConversation** — the empty-state wand tile is now a solid navy tile with a cream icon (cream tile / navy icon in dark mode), using the system's shadow recipe instead of the gradient inset sheen.
- **BuilderSidebarChat** — the active send button is a navy pill that hovers to `blue-900` (cream hovering to white in dark mode), with the small-shadow recipe moved into scoped CSS alongside the fill. The old white border and Tailwind `shadow-lg`/`hover:shadow-xl` on the active branch were dropped in favor of the recipe; the disabled state is untouched.
- **AgentManagerPanel** — the "+ new agent" button gets the same solid navy/cream treatment (its `brightness()` hover replaced by the system's background swap). The tiny 20px "Agents" title chip intentionally uses a subtle navy tint (`rgba(23,37,84,0.08)` light / cream-tinted dark) rather than a solid fill, so the decorative chip doesn't compete with the adjacent + action button.

## Why

The baby-blue gradient was retired in favor of the navy ink system; auth, docs, project-manager, and workspace-error conversions are underway separately, and these build-workspace spots were the remaining stragglers in that surface.

## Notes for review

- Verified visually in the running Vite dev server in both light and dark themes, covering the send button's active, hover, and disabled states (disabled styling is unchanged from before).
- Border radii were deliberately left as-is (`rounded-md` header controls, `rounded-2xl` tile, `rounded-full` send button) — this PR only converts fills, text colors, and shadows.
- Heads-up: the auth/docs/project-manager/workspace-error conversions referenced above are not yet on `main` — that work currently sits uncommitted in the `exciting-rosalind-6ab022` worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)