### PR TITLE
Extend warm porcelain editorial design to the rest of the site

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -12,9 +12,10 @@
     {
       "name": "backend-django",
       "runtimeExecutable": "bash",
-      "runtimeArgs": ["-c", "bash ../../.claude/hooks/dev-setup.sh backend; pipenv run uvicorn imagi.asgi:application --reload --port 8000"],
+      "runtimeArgs": ["-c", "bash ../../.claude/hooks/dev-setup.sh backend; pipenv run uvicorn imagi.asgi:application --reload --port ${PORT:-8000}"],
       "cwd": "backend/django",
-      "port": 8000
+      "port": 8000,
+      "autoPort": true
     }
   ]
 }

--- a/frontend/vuejs/src/apps/auth/components/atoms/buttons/GradientButton.vue
+++ b/frontend/vuejs/src/apps/auth/components/atoms/buttons/GradientButton.vue
@@ -2,16 +2,16 @@
   <button
     :type="type"
     :disabled="disabled || loading"
-    class="group relative w-full inline-flex items-center justify-center gap-2 px-8 py-4
+    class="group relative w-full inline-flex items-center justify-center gap-3 px-8 py-4
            rounded-full
-           font-medium
+           font-medium text-lg
            bg-blue-950 text-[#fdf9f2] hover:bg-blue-900
            dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white
            shadow-[0_1px_2px_rgba(23,37,84,0.25),0_8px_20px_-6px_rgba(23,37,84,0.35),inset_0_1px_0_rgba(255,255,255,0.12)]
            hover:shadow-[0_2px_3px_rgba(23,37,84,0.22),0_14px_28px_-8px_rgba(23,37,84,0.4),inset_0_1px_0_rgba(255,255,255,0.12)]
            dark:shadow-[0_1px_2px_rgba(0,0,0,0.5),0_10px_24px_-8px_rgba(0,0,0,0.55)]
            dark:hover:shadow-[0_2px_3px_rgba(0,0,0,0.5),0_14px_30px_-8px_rgba(0,0,0,0.6)]
-           focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]
+           focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]
            transition-all duration-200 hover:-translate-y-0.5 active:translate-y-0
            disabled:opacity-50 disabled:cursor-not-allowed"
   >

--- a/frontend/vuejs/src/apps/auth/components/atoms/inputs/PasswordInput.vue
+++ b/frontend/vuejs/src/apps/auth/components/atoms/inputs/PasswordInput.vue
@@ -19,23 +19,24 @@
         :disabled="disabled"
         class="w-full py-4 pl-12 pr-12 rounded-xl
                text-blue-950 dark:text-white
-               placeholder-blue-950/40 dark:placeholder-white/30
-               outline-none focus:outline-none
+               placeholder-blue-950/40 dark:placeholder-blue-100/35
                disabled:opacity-50 disabled:cursor-not-allowed
                transition-all duration-200
-               border bg-blue-50/50 dark:bg-white/[0.03] backdrop-blur-sm
-               focus:ring-0"
+               border bg-white/70 dark:bg-white/[0.04] backdrop-blur-sm
+               focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
         :class="{
-          'border-red-500/50 bg-red-50 dark:bg-red-500/5': hasError,
-          'border-blue-200/70 dark:border-white/[0.08]': !hasError
+          'border-red-500/50 dark:border-red-400/40 bg-red-50 dark:bg-red-500/5': hasError,
+          'border-blue-950/[0.12] dark:border-white/[0.14] hover:border-blue-950/25 dark:hover:border-white/25': !hasError
         }"
       >
       <button
         type="button"
         @click="togglePassword"
-        class="absolute inset-y-0 right-0 flex items-center pr-4
+        :aria-label="isVisible ? 'Hide password' : 'Show password'"
+        class="absolute inset-y-2 right-2 flex items-center justify-center w-9 my-auto rounded-lg
                text-blue-950/40 dark:text-blue-100/40
                hover:text-blue-950 dark:hover:text-white
+               focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]
                transition-colors duration-200 z-10"
       >
         <i :class="['fas', isVisible ? 'fa-eye-slash' : 'fa-eye']"></i>
@@ -98,53 +99,26 @@ defineEmits(['update:modelValue', 'blur', 'change'])
 </script>
 
 <style scoped>
-/* Completely remove all focus styles and outlines */
-input,
-input:focus,
-input:active,
-input:focus-within,
-input:focus-visible {
-  outline: none !important;
-  outline-width: 0 !important;
-  outline-style: none !important;
-  outline-color: transparent !important;
-  box-shadow: none !important;
-  -webkit-appearance: none !important;
-  -moz-appearance: none !important;
-  appearance: none !important;
-}
-
-/* Remove any ring effects */
+/* Remove browser default appearance; the canonical focus-visible ring takes over */
 input {
-  --tw-ring-shadow: 0 0 #0000 !important;
-  --tw-ring-offset-shadow: 0 0 #0000 !important;
-  --tw-ring-color: transparent !important;
-  --tw-ring-offset-color: transparent !important;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
 }
 
 /* Remove browser default focus ring */
 input::-moz-focus-inner {
-  border: 0 !important;
+  border: 0;
 }
 
-/* Ensure button doesn't show outline either */
-button,
-button:focus,
-button:active,
-button:focus-visible {
-  outline: none !important;
-  outline-width: 0 !important;
-  box-shadow: none !important;
-}
-
-/* Autofill styling for light mode */
+/* Autofill styling for light mode (warm porcelain, ink text) */
 input:-webkit-autofill,
 input:-webkit-autofill:hover,
 input:-webkit-autofill:focus {
   -webkit-text-fill-color: #172554;
-  -webkit-box-shadow: 0 0 0px 1000px rgba(239, 246, 255, 1) inset;
+  -webkit-box-shadow: 0 0 0px 1000px rgba(253, 249, 242, 1) inset;
   transition: background-color 5000s ease-in-out 0s;
-  border-color: rgb(191, 219, 254) !important;
+  border-color: rgba(23, 37, 84, 0.25) !important;
 }
 
 /* Autofill styling for dark mode */
@@ -152,8 +126,15 @@ input:-webkit-autofill:focus {
 :root.dark input:-webkit-autofill:hover,
 :root.dark input:-webkit-autofill:focus {
   -webkit-text-fill-color: white;
-  -webkit-box-shadow: 0 0 0px 1000px rgba(255, 255, 255, 0.03) inset;
+  -webkit-box-shadow: 0 0 0px 1000px rgba(28, 29, 33, 1) inset;
   transition: background-color 5000s ease-in-out 0s;
-  border-color: rgba(255, 255, 255, 0.08) !important;
+  border-color: rgba(255, 255, 255, 0.14) !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  input,
+  button {
+    transition: none;
+  }
 }
 </style>

--- a/frontend/vuejs/src/apps/auth/components/atoms/items/RequirementItem.vue
+++ b/frontend/vuejs/src/apps/auth/components/atoms/items/RequirementItem.vue
@@ -1,21 +1,21 @@
 <template>
   <div class="flex items-center gap-2.5">
-    <div 
+    <div
       class="w-5 h-5 rounded-md flex items-center justify-center transition-all duration-300"
       :class="checked
-        ? 'bg-emerald-500/20 border border-emerald-500/40'
-        : 'bg-blue-100/60 dark:bg-white/[0.03] border border-blue-200/70 dark:border-white/[0.08]'"
+        ? 'bg-orange-100 dark:bg-orange-400/[0.16] border border-orange-200/80 dark:border-orange-400/30'
+        : 'bg-white/70 dark:bg-white/[0.04] border border-blue-950/[0.1] dark:border-white/[0.12]'"
     >
       <i
         class="fas text-[10px] transition-all duration-300"
         :class="checked
-          ? 'fa-check text-emerald-500 dark:text-emerald-400'
-          : 'fa-circle text-blue-950/20 dark:text-white/20'"
+          ? 'fa-check text-orange-600 dark:text-orange-300'
+          : 'fa-circle text-blue-950/20 dark:text-blue-100/20'"
       ></i>
     </div>
     <span
       class="text-sm transition-colors duration-300"
-      :class="checked ? 'text-blue-950/80 dark:text-white/80' : 'text-blue-950/40 dark:text-white/40'"
+      :class="checked ? 'text-blue-950/80 dark:text-blue-100/85' : 'text-blue-950/40 dark:text-blue-100/40'"
     >
       {{ text }}
     </span>

--- a/frontend/vuejs/src/apps/auth/components/molecules/forms/FormCheckbox.vue
+++ b/frontend/vuejs/src/apps/auth/components/molecules/forms/FormCheckbox.vue
@@ -12,21 +12,22 @@
           v-bind="field"
           :disabled="disabled"
           class="w-4 h-4 rounded
-                 accent-blue-600
-                 border-blue-300 dark:border-white/20
-                 bg-blue-50 dark:bg-white/[0.05]
-                 text-blue-600 focus:ring-blue-500/40 focus:ring-offset-0 focus:ring-2
+                 accent-blue-950 dark:accent-blue-400
+                 border-blue-950/[0.25] dark:border-white/25
+                 bg-white/70 dark:bg-white/[0.05]
+                 text-blue-950 dark:text-blue-400
+                 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]
                  disabled:opacity-50 disabled:cursor-not-allowed
                  transition-all duration-300
-                 checked:bg-blue-600 checked:border-blue-600"
+                 checked:bg-blue-950 checked:border-blue-950 dark:checked:bg-blue-400 dark:checked:border-blue-400"
         >
       </Field>
     </div>
     <div class="ml-3">
-      <label class="text-sm text-blue-950/60 dark:text-white/60 leading-relaxed">
+      <label class="text-sm text-blue-950/65 dark:text-blue-100/65 leading-relaxed">
         <slot></slot>
       </label>
-      <ErrorMessage v-if="showError && false" :name="name" class="block mt-1 text-sm text-red-400" />
+      <ErrorMessage v-if="showError && false" :name="name" class="block mt-1 text-sm text-red-600 dark:text-red-400" />
     </div>
   </div>
 </template>

--- a/frontend/vuejs/src/apps/auth/components/molecules/forms/FormInput.vue
+++ b/frontend/vuejs/src/apps/auth/components/molecules/forms/FormInput.vue
@@ -17,19 +17,18 @@
         :placeholder="placeholder"
         class="w-full py-4 pl-12 pr-4 rounded-xl
                text-blue-950 dark:text-white
-               placeholder-blue-950/40 dark:placeholder-white/30
-               outline-none focus:outline-none
+               placeholder-blue-950/40 dark:placeholder-blue-100/35
                disabled:opacity-50 disabled:cursor-not-allowed
                transition-all duration-200
-               border bg-blue-50/50 dark:bg-white/[0.03] backdrop-blur-sm
-               focus:ring-0"
+               border bg-white/70 dark:bg-white/[0.04] backdrop-blur-sm
+               focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
         :class="{
-          'border-red-500/50 bg-red-50 dark:bg-red-500/5': hasError,
-          'border-blue-200/70 dark:border-white/[0.08]': !hasError
+          'border-red-500/50 dark:border-red-400/40 bg-red-50 dark:bg-red-500/5': hasError,
+          'border-blue-950/[0.12] dark:border-white/[0.14] hover:border-blue-950/25 dark:hover:border-white/25': !hasError
         }"
       >
     </label>
-    <ErrorMessage v-if="showError" :name="name" class="mt-2 text-sm text-red-400 flex items-center gap-2">
+    <ErrorMessage v-if="showError" :name="name" class="mt-2 text-sm text-red-600 dark:text-red-400 flex items-center gap-2">
       <i class="fas fa-exclamation-circle text-xs"></i>
     </ErrorMessage>
   </div>
@@ -90,43 +89,26 @@ const inputType = computed(() => {
 </script>
 
 <style scoped>
-/* Completely remove all focus styles and outlines */
-input,
-input:focus,
-input:active,
-input:focus-within,
-input:focus-visible {
-  outline: none !important;
-  outline-width: 0 !important;
-  outline-style: none !important;
-  outline-color: transparent !important;
-  box-shadow: none !important;
-  -webkit-appearance: none !important;
-  -moz-appearance: none !important;
-  appearance: none !important;
-}
-
-/* Remove any ring effects */
+/* Remove browser default appearance; the canonical focus-visible ring takes over */
 input {
-  --tw-ring-shadow: 0 0 #0000 !important;
-  --tw-ring-offset-shadow: 0 0 #0000 !important;
-  --tw-ring-color: transparent !important;
-  --tw-ring-offset-color: transparent !important;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
 }
 
 /* Remove browser default focus ring */
 input::-moz-focus-inner {
-  border: 0 !important;
+  border: 0;
 }
 
-/* Autofill styling for light mode */
+/* Autofill styling for light mode (warm porcelain, ink text) */
 input:-webkit-autofill,
 input:-webkit-autofill:hover,
 input:-webkit-autofill:focus {
   -webkit-text-fill-color: #172554;
-  -webkit-box-shadow: 0 0 0px 1000px rgba(239, 246, 255, 1) inset;
+  -webkit-box-shadow: 0 0 0px 1000px rgba(253, 249, 242, 1) inset;
   transition: background-color 5000s ease-in-out 0s;
-  border-color: rgb(191, 219, 254) !important;
+  border-color: rgba(23, 37, 84, 0.25) !important;
 }
 
 /* Autofill styling for dark mode */
@@ -134,8 +116,14 @@ input:-webkit-autofill:focus {
 :root.dark input:-webkit-autofill:hover,
 :root.dark input:-webkit-autofill:focus {
   -webkit-text-fill-color: white;
-  -webkit-box-shadow: 0 0 0px 1000px rgba(255, 255, 255, 0.03) inset;
+  -webkit-box-shadow: 0 0 0px 1000px rgba(28, 29, 33, 1) inset;
   transition: background-color 5000s ease-in-out 0s;
-  border-color: rgba(255, 255, 255, 0.08) !important;
+  border-color: rgba(255, 255, 255, 0.14) !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  input {
+    transition: none;
+  }
 }
 </style>

--- a/frontend/vuejs/src/apps/auth/components/molecules/links/AuthLinks.vue
+++ b/frontend/vuejs/src/apps/auth/components/molecules/links/AuthLinks.vue
@@ -3,12 +3,12 @@
     <!-- Enhanced Links Section -->
     <div class="text-center">
       <!-- Alternate Auth Action -->
-      <p class="text-blue-950/70 dark:text-blue-100/70 text-sm transition-colors duration-300">
+      <p class="text-blue-950/65 dark:text-blue-100/65 text-sm transition-colors duration-300">
         <template v-if="isLoginPage">
           New to Imagi?
           <router-link
             to="/auth/register"
-            class="text-blue-700 dark:text-blue-300 hover:text-blue-800 dark:hover:text-blue-200 font-medium transition-colors duration-200 ml-1"
+            class="font-medium text-blue-950 dark:text-blue-100 border-b border-blue-950/25 dark:border-blue-100/30 hover:border-blue-950/60 dark:hover:border-blue-100/70 pb-0.5 transition-colors duration-200 ml-1 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
           >
             Create an account
           </router-link>
@@ -17,7 +17,7 @@
           Already have an account?
           <router-link
             to="/auth/signin"
-            class="text-blue-700 dark:text-blue-300 hover:text-blue-800 dark:hover:text-blue-200 font-medium transition-colors duration-200 ml-1"
+            class="font-medium text-blue-950 dark:text-blue-100 border-b border-blue-950/25 dark:border-blue-100/30 hover:border-blue-950/60 dark:hover:border-blue-100/70 pb-0.5 transition-colors duration-200 ml-1 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
           >
             Sign in here
           </router-link>

--- a/frontend/vuejs/src/apps/auth/components/molecules/messages/SessionTimeoutWarning.vue
+++ b/frontend/vuejs/src/apps/auth/components/molecules/messages/SessionTimeoutWarning.vue
@@ -1,12 +1,12 @@
 <template>
   <div
     v-if="showWarning"
-    class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+    class="fixed inset-0 bg-blue-950/40 dark:bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 transition-colors duration-300"
   >
-    <div class="bg-dark-800 p-6 rounded-lg max-w-md w-full mx-4">
+    <div class="session-warning-card bg-white/95 dark:bg-[#131418] border border-blue-950/[0.08] dark:border-white/[0.14] backdrop-blur-sm p-6 rounded-2xl max-w-md w-full mx-4 transition-colors duration-300">
       <div class="text-center">
         <svg
-          class="w-12 h-12 text-yellow-500 mx-auto mb-4"
+          class="w-12 h-12 text-orange-500 dark:text-orange-400 mx-auto mb-4 transition-colors duration-300"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -18,26 +18,26 @@
             d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
           />
         </svg>
-        
-        <h2 class="text-xl font-semibold text-white mb-2">
+
+        <h2 class="text-xl font-semibold tracking-tight text-blue-950 dark:text-white mb-2 transition-colors duration-300">
           Session Timeout Warning
         </h2>
-        
-        <p class="text-gray-400 mb-4">
+
+        <p class="text-blue-950/65 dark:text-blue-100/65 mb-4 transition-colors duration-300">
           Your session will expire in {{ timeLeft }} minutes. Would you like to stay signed in?
         </p>
 
         <div class="flex justify-center space-x-4">
           <button
             @click="extendSession"
-            class="px-4 py-2 bg-primary-500 hover:bg-primary-600 text-white rounded-lg transition-colors"
+            class="inline-flex items-center justify-center px-5 py-2.5 rounded-full font-medium bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white transition-colors duration-200 shadow-[0_1px_2px_rgba(23,37,84,0.2),0_3px_8px_-2px_rgba(23,37,84,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#131418]"
           >
             Stay Signed In
           </button>
-          
+
           <button
             @click="logout"
-            class="px-4 py-2 bg-dark-700 hover:bg-dark-600 text-gray-300 rounded-lg transition-colors"
+            class="inline-flex items-center justify-center px-5 py-2.5 rounded-full font-medium border border-blue-950/[0.14] text-blue-950/80 hover:text-blue-950 hover:border-blue-950/30 hover:bg-blue-950/[0.03] dark:border-white/[0.16] dark:text-blue-100/80 dark:hover:text-white dark:hover:border-white/30 dark:hover:bg-white/[0.06] transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#131418]"
           >
             Logout
           </button>
@@ -116,4 +116,24 @@ onMounted(() => {
 onUnmounted(() => {
   resetTimers()
 })
-</script> 
+</script>
+
+<style scoped>
+/* Crisp card shadow recipe (matches marketing pages) */
+.session-warning-card {
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.03),
+    0 1px 2px rgba(15, 23, 42, 0.06),
+    0 4px 10px -2px rgba(15, 23, 42, 0.07),
+    0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
+
+:root.dark .session-warning-card,
+.dark .session-warning-card {
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 12px 28px -10px rgba(0, 0, 0, 0.55);
+}
+</style>

--- a/frontend/vuejs/src/apps/auth/components/organisms/headers/AuthHeader.vue
+++ b/frontend/vuejs/src/apps/auth/components/organisms/headers/AuthHeader.vue
@@ -1,13 +1,13 @@
 <template>
   <div class="text-center mb-8">
     <div class="brand-header mb-6">
-      <div class="logo-container inline-flex items-center justify-center p-3 rounded-2xl bg-gradient-to-br from-primary-500/10 to-violet-500/10 border border-primary-500/20 mb-6">
-        <h1 class="text-3xl font-bold bg-gradient-to-r from-primary-400 to-violet-400 bg-clip-text text-transparent">
+      <div class="logo-container inline-flex items-center justify-center p-3 rounded-2xl bg-white/85 dark:bg-white/[0.045] border border-blue-200/70 dark:border-blue-300/[0.14] backdrop-blur-sm mb-6 transition-colors duration-300">
+        <h1 class="font-display text-3xl font-semibold tracking-[-0.02em] text-blue-950 dark:text-white transition-colors duration-300">
           Imagi
         </h1>
       </div>
-      <h2 class="text-2xl font-bold text-white mb-2">{{ title }}</h2>
-      <p class="text-gray-400">{{ subtitle }}</p>
+      <h2 class="font-display text-2xl font-semibold tracking-[-0.02em] text-blue-950 dark:text-white mb-2 transition-colors duration-300">{{ title }}</h2>
+      <p class="text-blue-950/65 dark:text-blue-100/65 transition-colors duration-300">{{ subtitle }}</p>
     </div>
   </div>
 </template>

--- a/frontend/vuejs/src/apps/auth/layouts/AuthLayout.vue
+++ b/frontend/vuejs/src/apps/auth/layouts/AuthLayout.vue
@@ -1,26 +1,25 @@
-<!-- Auth Layout - Clean minimal design matching Home page -->
+<!-- Auth Layout - warm porcelain editorial design matching Home page -->
 <template>
   <DefaultLayout>
-    <!-- Clean full-screen layout matching Home page design -->
-    <div class="min-h-screen bg-white dark:bg-[#0a0a0a] relative overflow-hidden transition-colors duration-500">
-      <!-- Minimal background with subtle baby-blue wash - matching Home/About/Docs -->
-      <div class="fixed inset-0 pointer-events-none">
-        <!-- Soft baby-blue gradient fade from the top -->
-        <div class="absolute inset-x-0 top-0 h-[480px] bg-gradient-to-b from-blue-50/70 via-white to-white dark:from-blue-400/[0.06] dark:via-[#0a0a0a] dark:to-[#0a0a0a] transition-colors duration-500"></div>
-        
-        <!-- Very subtle grid pattern for texture (dark mode only) -->
-        <div class="absolute inset-0 opacity-[0.015] dark:opacity-[0.02]" 
-             style="background-image: linear-gradient(rgba(128,128,128,0.1) 1px, transparent 1px), linear-gradient(90deg, rgba(128,128,128,0.1) 1px, transparent 1px); background-size: 64px 64px;"></div>
+    <!-- Warm porcelain canvas that hands off to the white footer -->
+    <div class="auth-page min-h-screen relative overflow-hidden font-body transition-colors duration-500">
+      <!-- Grain texture over the whole canvas -->
+      <div class="grain-overlay absolute inset-0 z-[1] pointer-events-none" aria-hidden="true"></div>
+
+      <!-- Atmosphere: soft apricot + baby-blue washes behind the card -->
+      <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
+        <div class="auth-glow-warm absolute -top-32 left-1/2 -translate-x-1/3 w-[820px] h-[520px]"></div>
+        <div class="auth-glow-cool absolute top-16 -left-48 w-[640px] h-[480px]"></div>
       </div>
 
       <!-- Content wrapper with proper spacing -->
       <div class="flex min-h-screen w-full relative z-10">
         <div class="w-full flex items-center justify-center px-4 sm:px-6 py-16 pt-28 sm:pt-32">
-          <!-- Clean Auth Container -->
+          <!-- Auth Container -->
           <div class="w-full max-w-[520px] mx-auto">
-            <!-- Clean card with subtle shadow -->
-            <div class="relative animate-fade-in">
-              <div class="relative rounded-2xl border border-blue-200/70 dark:border-blue-300/[0.16] bg-white dark:bg-white/[0.05] crisp-card backdrop-blur-xl overflow-hidden transition-all duration-300">
+            <!-- Porcelain crisp card: hairline border + layered soft shadow -->
+            <div class="relative auth-card-rise">
+              <div class="crisp-card relative rounded-2xl border border-blue-200/70 dark:border-blue-300/[0.14] bg-white/85 dark:bg-white/[0.045] backdrop-blur-sm overflow-hidden transition-colors duration-300">
                 <!-- Card content -->
                 <div class="relative z-10 p-8 sm:p-10">
                   <!-- Logo and Title Section -->
@@ -28,12 +27,12 @@
                     <div class="inline-flex items-center justify-center mb-8">
                       <ImagiLogo size="xl" to="/" />
                     </div>
-                    
+
                     <!-- Title -->
-                    <h2 class="text-xl sm:text-2xl font-semibold tracking-tight mb-3 leading-[1.2] text-blue-950 dark:text-white transition-colors duration-300">
+                    <h2 class="font-display text-3xl sm:text-4xl font-semibold tracking-[-0.02em] mb-3 leading-[1.05] text-balance text-blue-950 dark:text-white transition-colors duration-300">
                       {{ route.meta.title }}
                     </h2>
-                    <p class="text-base text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty transition-colors duration-300">
+                    <p class="text-base text-blue-950/65 dark:text-blue-100/65 leading-relaxed text-pretty transition-colors duration-300">
                       {{ route.meta.subtitle }}
                     </p>
                   </div>
@@ -63,6 +62,53 @@ const route = useRoute()
 </script>
 
 <style scoped>
+/* Warm porcelain canvas fading to white so it hands off seamlessly
+   to the footer (footer is bg-white / dark #0a0a0a) */
+.auth-page {
+  background: linear-gradient(180deg, #fdf9f2 0%, #faf7f1 45%, #ffffff 100%);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+:root.dark .auth-page,
+.dark .auth-page {
+  background: linear-gradient(180deg, #0c0c0e 0%, #0a0b0f 50%, #0a0a0a 100%);
+}
+
+/* Fine film grain keeps the soft gradients from banding and adds texture */
+.grain-overlay {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)' opacity='0.5'/%3E%3C/svg%3E");
+  background-size: 160px 160px;
+  opacity: 0.035;
+  mix-blend-mode: multiply;
+}
+
+:root.dark .grain-overlay,
+.dark .grain-overlay {
+  opacity: 0.05;
+  mix-blend-mode: overlay;
+}
+
+/* Atmosphere washes behind the card */
+.auth-glow-warm {
+  background: radial-gradient(closest-side, rgba(251, 146, 60, 0.16), rgba(251, 146, 60, 0.05) 55%, transparent 75%);
+  filter: blur(40px);
+}
+
+.auth-glow-cool {
+  background: radial-gradient(closest-side, rgba(158, 205, 243, 0.28), rgba(158, 205, 243, 0.08) 55%, transparent 75%);
+  filter: blur(44px);
+}
+
+.dark .auth-glow-warm {
+  background: radial-gradient(closest-side, rgba(251, 146, 60, 0.09), rgba(251, 146, 60, 0.025) 55%, transparent 75%);
+}
+
+.dark .auth-glow-cool {
+  background: radial-gradient(closest-side, rgba(96, 165, 250, 0.11), rgba(96, 165, 250, 0.03) 55%, transparent 75%);
+}
+
 /* Crisp, sharply-defined card: hairline edge + tight layered shadow (matches marketing pages) */
 .crisp-card {
   box-shadow:
@@ -72,7 +118,8 @@ const route = useRoute()
     0 12px 28px -10px rgba(15, 23, 42, 0.10);
 }
 
-:root.dark .crisp-card {
+:root.dark .crisp-card,
+.dark .crisp-card {
   box-shadow:
     0 0 0 1px rgba(255, 255, 255, 0.04),
     0 1px 2px rgba(0, 0, 0, 0.5),
@@ -80,7 +127,7 @@ const route = useRoute()
     0 12px 28px -10px rgba(0, 0, 0, 0.55);
 }
 
-/* Fade transition */
+/* Fade transition between auth views */
 .fade-enter-active,
 .fade-leave-active {
   transition: opacity 0.3s ease;
@@ -91,11 +138,15 @@ const route = useRoute()
   opacity: 0;
 }
 
-/* Fade in animation */
-@keyframes fade-in {
+/* Card rises gently on page load */
+.auth-card-rise {
+  animation: auth-rise 0.8s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@keyframes auth-rise {
   from {
     opacity: 0;
-    transform: translateY(20px);
+    transform: translateY(22px);
   }
   to {
     opacity: 1;
@@ -103,7 +154,27 @@ const route = useRoute()
   }
 }
 
-.animate-fade-in {
-  animation: fade-in 0.8s ease-out forwards;
+@media (prefers-reduced-motion: reduce) {
+  .auth-card-rise {
+    animation: none;
+  }
+
+  .fade-enter-active,
+  .fade-leave-active {
+    transition: none;
+  }
+}
+</style>
+
+<!-- Unscoped: brand-tinted text selection on the auth pages -->
+<style>
+.auth-page ::selection {
+  background: rgba(158, 205, 243, 0.55);
+  color: #172554;
+}
+
+.dark .auth-page ::selection {
+  background: rgba(96, 165, 250, 0.4);
+  color: #eff6ff;
 }
 </style>

--- a/frontend/vuejs/src/apps/auth/views/Login.vue
+++ b/frontend/vuejs/src/apps/auth/views/Login.vue
@@ -38,8 +38,8 @@
       <!-- Error message display -->
       <div class="space-y-5 pt-2">
         <transition name="fade-up">
-          <div v-if="serverError" 
-               class="p-4 rounded-xl border border-red-500/20 bg-red-50 dark:bg-red-500/10 backdrop-blur-sm transition-colors duration-300">
+          <div v-if="serverError"
+               class="p-4 rounded-xl border border-red-500/20 dark:border-red-400/25 bg-red-50 dark:bg-red-500/10 backdrop-blur-sm transition-colors duration-300">
             <div class="flex items-center gap-3">
               <div class="w-8 h-8 rounded-lg bg-red-100 dark:bg-red-500/20 border border-red-200 dark:border-red-500/30 flex items-center justify-center flex-shrink-0 transition-colors duration-300">
                 <i class="fas fa-exclamation-triangle text-red-600 dark:text-red-400 text-sm transition-colors duration-300"></i>
@@ -151,5 +151,17 @@ const onSubmit = async (values: LoginFormValues) => {
 .fade-up-leave-to {
   opacity: 0;
   transform: translateY(10px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fade-up-enter-active,
+  .fade-up-leave-active {
+    transition: none;
+  }
+
+  .fade-up-enter-from,
+  .fade-up-leave-to {
+    transform: none;
+  }
 }
 </style>

--- a/frontend/vuejs/src/apps/auth/views/Register.vue
+++ b/frontend/vuejs/src/apps/auth/views/Register.vue
@@ -17,7 +17,7 @@
             :hasError="!!errorMessage && formSubmitCount > 0"
           />
           <transition name="fade-up">
-            <div v-if="errorMessage && formSubmitCount > 0" class="mt-2 text-sm text-red-400 flex items-center gap-2">
+            <div v-if="errorMessage && formSubmitCount > 0" class="mt-2 text-sm text-red-600 dark:text-red-400 flex items-center gap-2">
               <i class="fas fa-exclamation-circle text-xs"></i>
               <span>{{ errorMessage }}</span>
             </div>
@@ -41,7 +41,7 @@
             :hasError="!!errorMessage && formSubmitCount > 0"
           />
           <transition name="fade-up">
-            <div v-if="errorMessage && formSubmitCount > 0" class="mt-2 text-sm text-red-400 flex items-center gap-2">
+            <div v-if="errorMessage && formSubmitCount > 0" class="mt-2 text-sm text-red-600 dark:text-red-400 flex items-center gap-2">
               <i class="fas fa-exclamation-circle text-xs"></i>
               <span>{{ errorMessage }}</span>
             </div>
@@ -64,10 +64,10 @@
               :disabled="authStore.loading || isSubmitting"
               :hasError="!!errorMessage && formSubmitCount > 0"
             />
-            <!-- Password requirements with premium glass styling -->
+            <!-- Password requirements on a warm porcelain inset panel -->
             <div class="mt-4 p-4 rounded-xl
-                        border border-blue-200/70 dark:border-white/[0.08]
-                        bg-blue-50/50 dark:bg-white/[0.02]
+                        border border-blue-950/[0.08] dark:border-white/[0.1]
+                        bg-[#fdf9f2]/80 dark:bg-white/[0.03]
                         backdrop-blur-sm
                         transition-all duration-300">
               <PasswordRequirements 
@@ -93,7 +93,7 @@
               :hasError="!!errorMessage && formSubmitCount > 0"
             />
             <transition name="fade-up">
-              <div v-if="errorMessage && formSubmitCount > 0" class="mt-2 text-sm text-red-400 flex items-center gap-2">
+              <div v-if="errorMessage && formSubmitCount > 0" class="mt-2 text-sm text-red-600 dark:text-red-400 flex items-center gap-2">
                 <i class="fas fa-exclamation-circle text-xs"></i>
                 <span>{{ errorMessage }}</span>
               </div>
@@ -104,13 +104,13 @@
 
       <!-- Bottom section -->
       <div class="space-y-5 pt-2">
-        <!-- Terms checkbox with premium styling -->
+        <!-- Terms checkbox on a warm porcelain inset panel -->
         <div class="p-4 rounded-xl
-                    border border-blue-200/70 dark:border-white/[0.08]
-                    bg-blue-50/50 dark:bg-white/[0.02]
+                    border border-blue-950/[0.08] dark:border-white/[0.1]
+                    bg-[#fdf9f2]/80 dark:bg-white/[0.03]
                     backdrop-blur-sm
-                    hover:bg-blue-50 dark:hover:bg-white/[0.04]
-                    hover:border-blue-300/70 dark:hover:border-white/[0.12]
+                    hover:bg-[#fdf9f2] dark:hover:bg-white/[0.05]
+                    hover:border-blue-950/[0.16] dark:hover:border-white/[0.16]
                     transition-all duration-300">
           <Field name="agreeToTerms" :rules="{ required: { allowFalse: false } }" :validateOnBlur="false" v-slot="{ errorMessage }">
             <FormCheckbox 
@@ -119,15 +119,15 @@
               :showError="false"
             >
               I agree to the
-              <router-link to="/terms" class="text-blue-700 dark:text-blue-300 hover:text-blue-800 dark:hover:text-blue-200 transition-colors duration-300 font-medium">
+              <router-link to="/terms" class="font-medium text-blue-950 dark:text-blue-100 border-b border-blue-950/25 dark:border-blue-100/30 hover:border-blue-950/60 dark:hover:border-blue-100/70 pb-0.5 transition-colors duration-200 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]">
                 Terms of Service
               </router-link>
               and
-              <router-link to="/privacy" class="text-blue-700 dark:text-blue-300 hover:text-blue-800 dark:hover:text-blue-200 transition-colors duration-300 font-medium">
+              <router-link to="/privacy" class="font-medium text-blue-950 dark:text-blue-100 border-b border-blue-950/25 dark:border-blue-100/30 hover:border-blue-950/60 dark:hover:border-blue-100/70 pb-0.5 transition-colors duration-200 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]">
                 Privacy Policy
               </router-link>
             </FormCheckbox>
-            <div v-if="(errorMessage || !hasAcceptedTerms) && formSubmitCount > 0" class="mt-2 text-sm text-red-400 flex items-center gap-2">
+            <div v-if="(errorMessage || !hasAcceptedTerms) && formSubmitCount > 0" class="mt-2 text-sm text-red-600 dark:text-red-400 flex items-center gap-2">
               <i class="fas fa-exclamation-circle text-xs"></i>
               <span>You must accept the terms to continue</span>
             </div>
@@ -137,7 +137,7 @@
         <!-- Error message with premium styling -->
         <transition name="fade-up">
           <div v-if="serverError"
-               class="p-4 rounded-xl border border-red-500/20 bg-red-50 dark:bg-red-500/10 backdrop-blur-sm transition-colors duration-300">
+               class="p-4 rounded-xl border border-red-500/20 dark:border-red-400/25 bg-red-50 dark:bg-red-500/10 backdrop-blur-sm transition-colors duration-300">
             <div class="flex items-center gap-3">
               <div class="w-8 h-8 rounded-lg bg-red-100 dark:bg-red-500/20 border border-red-200 dark:border-red-500/30 flex items-center justify-center flex-shrink-0 transition-colors duration-300">
                 <i class="fas fa-exclamation-triangle text-red-600 dark:text-red-400 text-sm transition-colors duration-300"></i>
@@ -162,9 +162,9 @@
 
     <!-- Auth Links -->
     <div class="text-center pt-2">
-      <p class="text-blue-950/70 dark:text-blue-100/70 text-sm transition-colors duration-300">
+      <p class="text-blue-950/65 dark:text-blue-100/65 text-sm transition-colors duration-300">
         Already have an account?
-        <router-link to="/auth/signin" class="text-blue-700 dark:text-blue-300 hover:text-blue-800 dark:hover:text-blue-200 font-medium transition-colors duration-200 ml-1">
+        <router-link to="/auth/signin" class="font-medium text-blue-950 dark:text-blue-100 border-b border-blue-950/25 dark:border-blue-100/30 hover:border-blue-950/60 dark:hover:border-blue-100/70 pb-0.5 transition-colors duration-200 ml-1 rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]">
           Sign in
         </router-link>
       </p>
@@ -281,5 +281,17 @@ const handleSubmit = async (values: RegisterFormValues) => {
 .fade-up-leave-to {
   opacity: 0;
   transform: translateY(10px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fade-up-enter-active,
+  .fade-up-leave-active {
+    transition: none;
+  }
+
+  .fade-up-enter-from,
+  .fade-up-leave-to {
+    transform: none;
+  }
 }
 </style>

--- a/frontend/vuejs/src/apps/docs/components/molecules/cards/DocsCard.vue
+++ b/frontend/vuejs/src/apps/docs/components/molecules/cards/DocsCard.vue
@@ -1,13 +1,13 @@
 <template>
-  <div class="crisp-card group relative h-full p-8 rounded-2xl border border-blue-200/70 dark:border-blue-300/[0.16] bg-white dark:bg-white/[0.05] transition-all duration-300">
+  <div class="crisp-card group relative h-full p-8 rounded-2xl border border-blue-200/70 dark:border-blue-300/[0.14] bg-white/85 dark:bg-white/[0.045] backdrop-blur-sm transition-all duration-300">
     <h3
       v-if="title"
-      class="text-xl font-semibold text-blue-950 dark:text-white mb-3 transition-colors duration-300"
+      class="text-xl font-semibold tracking-tight text-blue-950 dark:text-white mb-3 transition-colors duration-300"
     >
       {{ title }}
     </h3>
 
-    <div class="text-blue-950/70 dark:text-blue-100/70 leading-relaxed transition-colors duration-300">
+    <div class="text-blue-950/65 dark:text-blue-100/65 leading-relaxed text-pretty transition-colors duration-300">
       <slot></slot>
     </div>
   </div>

--- a/frontend/vuejs/src/apps/docs/components/molecules/cards/DocsNavigationCard.vue
+++ b/frontend/vuejs/src/apps/docs/components/molecules/cards/DocsNavigationCard.vue
@@ -1,25 +1,30 @@
 <template>
   <router-link
     :to="to"
-    class="crisp-card group relative block h-full p-8 rounded-2xl border border-blue-200/70 dark:border-blue-300/[0.16] bg-white dark:bg-white/[0.05] transition-all duration-300 hover:-translate-y-0.5"
+    class="crisp-card group relative block h-full p-8 rounded-2xl border border-blue-200/70 dark:border-blue-300/[0.14] bg-white/85 dark:bg-white/[0.045] backdrop-blur-sm transition-all duration-300 hover:-translate-y-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
   >
     <div class="flex items-start gap-4">
       <div class="flex-1">
-        <h3 class="text-xl font-semibold text-blue-950 dark:text-white mb-2 transition-colors duration-300">
+        <h3 class="text-xl font-semibold tracking-tight text-blue-950 dark:text-white mb-2 transition-colors duration-300">
           {{ title }}
         </h3>
-        <p class="text-blue-950/70 dark:text-blue-100/70 leading-relaxed transition-colors duration-300">
+        <p class="text-blue-950/65 dark:text-blue-100/65 leading-relaxed text-pretty transition-colors duration-300">
           {{ description }}
         </p>
       </div>
-      <svg
-        class="w-5 h-5 text-blue-500 dark:text-blue-300 transition-transform duration-300 group-hover:translate-x-1 flex-shrink-0 mt-1"
-        fill="none"
-        stroke="currentColor"
-        viewBox="0 0 24 24"
+      <span
+        aria-hidden="true"
+        class="nav-tile flex items-center justify-center w-10 h-10 rounded-xl ring-1 flex-shrink-0 bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] dark:from-blue-400/[0.18] dark:to-blue-500/[0.22] ring-blue-900/[0.08] dark:ring-blue-300/[0.18] text-blue-600 dark:text-blue-300 transition-all duration-300"
       >
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
-      </svg>
+        <svg
+          class="w-4 h-4 transition-transform duration-300 group-hover:translate-x-0.5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+        </svg>
+      </span>
     </div>
   </router-link>
 </template>

--- a/frontend/vuejs/src/apps/docs/components/molecules/cards/DocsStepCard.vue
+++ b/frontend/vuejs/src/apps/docs/components/molecules/cards/DocsStepCard.vue
@@ -1,11 +1,17 @@
 <template>
-  <div class="crisp-card relative p-8 rounded-2xl border border-blue-200/70 dark:border-blue-300/[0.16] bg-white dark:bg-white/[0.05] transition-all duration-300 my-8">
+  <div
+    class="crisp-card relative p-8 rounded-2xl border bg-white/85 dark:bg-white/[0.045] backdrop-blur-sm transition-all duration-300 my-8"
+    :class="isAlt ? 'border-orange-200/70 dark:border-orange-300/[0.14]' : 'border-blue-200/70 dark:border-blue-300/[0.14]'"
+  >
     <div class="flex items-start gap-6">
-      <div class="text-4xl font-bold text-blue-600 dark:text-blue-300 flex-shrink-0 leading-none w-10">
+      <div
+        class="flex items-center justify-center w-12 h-12 rounded-xl ring-1 flex-shrink-0 font-display text-2xl font-semibold leading-none transition-all duration-300"
+        :class="isAlt ? 'bg-orange-100 dark:bg-orange-400/[0.14] ring-orange-900/[0.08] dark:ring-orange-300/[0.18] text-orange-700 dark:text-orange-200' : 'bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] dark:from-blue-400/[0.18] dark:to-blue-500/[0.22] ring-blue-900/[0.08] dark:ring-blue-300/[0.18] text-blue-700 dark:text-blue-200'"
+      >
         {{ number }}
       </div>
       <div class="flex-1">
-        <h3 class="text-2xl font-semibold text-blue-950 dark:text-white mb-4 transition-colors duration-300">
+        <h3 class="text-2xl font-semibold tracking-tight text-blue-950 dark:text-white mb-4 transition-colors duration-300">
           {{ title }}
         </h3>
         <div class="text-blue-950/70 dark:text-blue-100/70 leading-relaxed transition-colors duration-300">
@@ -17,8 +23,13 @@
 </template>
 
 <script setup lang="ts">
-withDefaults(defineProps<{
+import { computed } from 'vue';
+
+const props = withDefaults(defineProps<{
   number: string | number;
   title: string;
 }>(), {});
+
+// Alternate the hairline tint and number tile between blue and orange steps
+const isAlt = computed(() => Number(props.number) % 2 === 0);
 </script>

--- a/frontend/vuejs/src/apps/docs/components/molecules/headers/DocsPageHeader.vue
+++ b/frontend/vuejs/src/apps/docs/components/molecules/headers/DocsPageHeader.vue
@@ -1,23 +1,80 @@
 <template>
   <div class="mb-12 md:mb-16 text-center">
-    <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-blue-200/70 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 text-xs font-semibold text-blue-700 dark:text-blue-300 uppercase tracking-[0.18em] mb-5 transition-colors duration-300">
-      {{ badgeText }}
-    </p>
-    <h1 class="text-4xl sm:text-5xl md:text-6xl font-semibold tracking-[-0.025em] text-blue-950 dark:text-white mb-6 leading-[1.08] text-balance transition-colors duration-300">
-      {{ title }}
+    <!-- Editorial kicker: tracked small caps flanked by fading hairline rules -->
+    <div class="docs-hero-item flex items-center justify-center gap-4 mb-6" style="animation-delay: 0ms">
+      <span aria-hidden="true" class="hidden sm:block h-px w-10 md:w-14 bg-gradient-to-l from-blue-950/25 to-transparent dark:from-white/25"></span>
+      <span class="flex items-center gap-3">
+        <span aria-hidden="true" class="w-1 h-1 rotate-45 bg-orange-500/80 dark:bg-orange-400/80"></span>
+        <span class="text-[10px] sm:text-[11px] font-semibold uppercase tracking-[0.25em] leading-none text-blue-950/70 dark:text-blue-100/55 whitespace-nowrap transition-colors duration-300">{{ badgeText }}</span>
+        <span aria-hidden="true" class="w-1 h-1 rotate-45 bg-orange-500/80 dark:bg-orange-400/80"></span>
+      </span>
+      <span aria-hidden="true" class="hidden sm:block h-px w-10 md:w-14 bg-gradient-to-r from-blue-950/25 to-transparent dark:from-white/25"></span>
+    </div>
+
+    <h1 class="docs-hero-item font-display font-semibold text-4xl sm:text-5xl md:text-6xl tracking-[-0.02em] text-blue-950 dark:text-white mb-6 leading-[1.05] text-balance transition-colors duration-300" style="animation-delay: 90ms">
+      {{ titleLead }} <em class="docs-accent not-italic">{{ titleAccent }}</em>
     </h1>
-    <p class="text-xl text-blue-950/70 dark:text-blue-100/70 max-w-3xl mx-auto leading-relaxed text-pretty transition-colors duration-300">
+
+    <p class="docs-hero-item text-xl text-blue-950/70 dark:text-blue-100/70 max-w-3xl mx-auto leading-relaxed text-pretty transition-colors duration-300" style="animation-delay: 180ms">
       {{ description }}
     </p>
   </div>
 </template>
 
 <script setup lang="ts">
-withDefaults(defineProps<{
+import { computed } from 'vue';
+
+const props = withDefaults(defineProps<{
   title: string;
   description: string;
   badgeText?: string;
 }>(), {
   badgeText: 'DOCUMENTATION'
 });
+
+// Split the title so its final word carries the italic gradient accent
+const titleLead = computed(() => props.title.split(' ').slice(0, -1).join(' '));
+const titleAccent = computed(() => props.title.split(' ').slice(-1)[0]);
 </script>
+
+<style scoped>
+/* Staggered entrance mirroring the home page's hero rise */
+.docs-hero-item {
+  animation: docs-hero-rise 0.9s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@keyframes docs-hero-rise {
+  from {
+    opacity: 0;
+    transform: translateY(22px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .docs-hero-item {
+    animation: none;
+  }
+}
+
+/* Italic serif accent with the warm gradient ink from the home hero */
+.docs-accent {
+  font-style: italic;
+  font-variation-settings: 'SOFT' 30, 'WONK' 1;
+  background: linear-gradient(115deg, #c2410c 5%, #ea580c 55%, #b45309 95%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  padding-right: 0.06em;
+}
+
+:root.dark .docs-accent {
+  background: linear-gradient(115deg, #fb923c 5%, #fcd34d 60%, #f59e0b 95%);
+  -webkit-background-clip: text;
+  background-clip: text;
+}
+</style>

--- a/frontend/vuejs/src/apps/docs/layouts/DocsLayout.vue
+++ b/frontend/vuejs/src/apps/docs/layouts/DocsLayout.vue
@@ -7,10 +7,10 @@
           :key="item.to"
           :to="item.to"
           :class="[
-            'group flex items-center px-3 py-2 text-sm font-medium rounded-lg transition-all duration-200',
+            'group flex items-center px-3 py-2 text-sm font-medium rounded-full transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]',
             isActive(item.to)
-              ? 'bg-blue-50 dark:bg-blue-500/10 text-blue-700 dark:text-blue-300'
-              : 'text-blue-950/70 dark:text-white/70 hover:bg-blue-50/70 dark:hover:bg-white/[0.04] hover:text-blue-950 dark:hover:text-white'
+              ? 'bg-blue-950 text-[#fdf9f2] dark:bg-[#f3ede2] dark:text-blue-950 shadow-[0_1px_2px_rgba(23,37,84,0.2),0_3px_8px_-2px_rgba(23,37,84,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)]'
+              : 'text-blue-950/70 dark:text-blue-100/60 hover:bg-blue-950/[0.04] dark:hover:bg-white/[0.06] hover:text-blue-950 dark:hover:text-white'
           ]"
         >
           <i
@@ -25,10 +25,11 @@
       </div>
     </template>
 
-    <!-- Minimal background with a subtle baby-blue wash (matching homepage) -->
-    <div class="fixed inset-0 pointer-events-none z-0">
-      <div class="absolute inset-0 bg-white dark:bg-[#0a0a0a] transition-colors duration-500"></div>
-      <div class="absolute inset-x-0 top-0 h-[480px] bg-gradient-to-b from-blue-50/70 via-white to-white dark:from-blue-400/[0.06] dark:via-[#0a0a0a] dark:to-[#0a0a0a] transition-colors duration-500"></div>
+    <!-- Warm porcelain canvas with a soft baby-blue wash and film grain (matching the home page) -->
+    <div class="fixed inset-0 pointer-events-none z-0" aria-hidden="true">
+      <div class="docs-canvas absolute inset-0 transition-colors duration-500"></div>
+      <div class="docs-wash-cool absolute -top-32 right-[-10%] w-[700px] h-[480px]"></div>
+      <div class="grain-overlay absolute inset-0"></div>
     </div>
 
     <div class="min-h-screen relative overflow-hidden">
@@ -55,6 +56,39 @@ const isActive = (path) => route.path === path
 </script>
 
 <style scoped>
+/* Warm porcelain canvas fading to white so it hands off to the footer,
+   mirroring the home page (footer is bg-white / dark #0a0a0a). */
+.docs-canvas {
+  background: linear-gradient(180deg, #fdf9f2 0%, #faf7f1 45%, #ffffff 100%);
+}
+
+:root.dark .docs-canvas {
+  background: linear-gradient(180deg, #0c0c0e 0%, #0a0b0f 50%, #0a0a0a 100%);
+}
+
+/* Soft baby-blue atmosphere wash, much fainter in dark mode */
+.docs-wash-cool {
+  background: radial-gradient(closest-side, rgba(158, 205, 243, 0.22), rgba(158, 205, 243, 0.06) 55%, transparent 75%);
+  filter: blur(48px);
+}
+
+:root.dark .docs-wash-cool {
+  background: radial-gradient(closest-side, rgba(96, 165, 250, 0.07), rgba(96, 165, 250, 0.02) 55%, transparent 75%);
+}
+
+/* Fine film grain keeps the soft gradients from banding and adds texture */
+.grain-overlay {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)' opacity='0.5'/%3E%3C/svg%3E");
+  background-size: 160px 160px;
+  opacity: 0.035;
+  mix-blend-mode: multiply;
+}
+
+:root.dark .grain-overlay {
+  opacity: 0.05;
+  mix-blend-mode: overlay;
+}
+
 .docs-content :deep(a) {
   text-decoration: none;
 }
@@ -76,13 +110,43 @@ const isActive = (path) => route.path === path
     0 12px 28px -10px rgba(0, 0, 0, 0.55);
 }
 
+/* Link cards lift on hover with the home page's stronger lift-card shadow */
+.docs-content :deep(a.crisp-card:hover) {
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.04),
+    0 2px 4px rgba(15, 23, 42, 0.06),
+    0 10px 20px -4px rgba(15, 23, 42, 0.1),
+    0 24px 44px -12px rgba(15, 23, 42, 0.14);
+}
+
+:root.dark .docs-content :deep(a.crisp-card:hover) {
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.06),
+    0 2px 4px rgba(0, 0, 0, 0.5),
+    0 12px 24px -4px rgba(0, 0, 0, 0.5),
+    0 28px 48px -12px rgba(0, 0, 0, 0.6);
+}
+
 /* Alternating blue / orange accent borders for cards in a grid, echoing the home page */
 .docs-content :deep(.grid > .crisp-card:nth-child(2n)) {
   border-color: rgba(254, 215, 170, 0.7);
 }
 
 :root.dark .docs-content :deep(.grid > .crisp-card:nth-child(2n)) {
-  border-color: rgba(253, 186, 116, 0.16);
+  border-color: rgba(253, 186, 116, 0.14);
+}
+
+/* Even grid cards swap their icon tile to the warm orange tint */
+.docs-content :deep(.grid > .crisp-card:nth-child(2n) .nav-tile) {
+  background: #ffedd5;
+  color: #ea580c;
+  --tw-ring-color: rgba(124, 45, 18, 0.08);
+}
+
+:root.dark .docs-content :deep(.grid > .crisp-card:nth-child(2n) .nav-tile) {
+  background: rgba(251, 146, 60, 0.14);
+  color: #fdba74;
+  --tw-ring-color: rgba(253, 186, 116, 0.18);
 }
 </style>
 
@@ -99,5 +163,16 @@ const isActive = (path) => route.path === path
 }
 .docs-layout .left-72 {
   left: 14rem;
+}
+
+/* Brand-tinted text selection, matching the home page */
+.docs-layout ::selection {
+  background: rgba(158, 205, 243, 0.55);
+  color: #172554;
+}
+
+.dark .docs-layout ::selection {
+  background: rgba(96, 165, 250, 0.4);
+  color: #eff6ff;
 }
 </style>

--- a/frontend/vuejs/src/apps/docs/views/DocsCreatingProjects.vue
+++ b/frontend/vuejs/src/apps/docs/views/DocsCreatingProjects.vue
@@ -21,27 +21,27 @@
 
         <ol class="space-y-4 mb-6">
           <li class="flex items-start gap-4">
-            <div class="w-8 h-8 rounded-full bg-blue-600 text-white font-bold text-sm flex items-center justify-center flex-shrink-0 shadow-md">1</div>
+            <div class="w-8 h-8 rounded-full bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] dark:from-blue-400/[0.18] dark:to-blue-500/[0.22] ring-1 ring-blue-900/[0.08] dark:ring-blue-300/[0.18] text-blue-700 dark:text-blue-200 font-semibold text-sm flex items-center justify-center flex-shrink-0 transition-all duration-300">1</div>
             <div class="text-lg leading-relaxed">
               <strong class="text-blue-950 dark:text-white font-semibold">Click the "New Project" button</strong> on your dashboard homepage or from the projects list.
             </div>
           </li>
           <li class="flex items-start gap-4">
-            <div class="w-8 h-8 rounded-full bg-blue-600 text-white font-bold text-sm flex items-center justify-center flex-shrink-0 shadow-md">2</div>
+            <div class="w-8 h-8 rounded-full bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] dark:from-blue-400/[0.18] dark:to-blue-500/[0.22] ring-1 ring-blue-900/[0.08] dark:ring-blue-300/[0.18] text-blue-700 dark:text-blue-200 font-semibold text-sm flex items-center justify-center flex-shrink-0 transition-all duration-300">2</div>
             <div class="text-lg leading-relaxed">
               <strong class="text-blue-950 dark:text-white font-semibold">Enter a project name</strong> — choose something descriptive that reflects the purpose of your application.
             </div>
           </li>
           <li class="flex items-start gap-4">
-            <div class="w-8 h-8 rounded-full bg-blue-600 text-white font-bold text-sm flex items-center justify-center flex-shrink-0 shadow-md">3</div>
+            <div class="w-8 h-8 rounded-full bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] dark:from-blue-400/[0.18] dark:to-blue-500/[0.22] ring-1 ring-blue-900/[0.08] dark:ring-blue-300/[0.18] text-blue-700 dark:text-blue-200 font-semibold text-sm flex items-center justify-center flex-shrink-0 transition-all duration-300">3</div>
             <div class="text-lg leading-relaxed">
               <strong class="text-blue-950 dark:text-white font-semibold">Select a project template</strong> (optional) — start from scratch or choose from pre-configured templates.
             </div>
           </li>
         </ol>
 
-        <div class="bg-blue-50/70 dark:bg-blue-400/[0.08] border border-blue-200/70 dark:border-blue-300/[0.16] rounded-xl p-6 transition-colors duration-300">
-          <h4 class="text-blue-950 dark:text-white mt-0 mb-3 text-lg font-semibold">Pro Tip</h4>
+        <div class="bg-blue-50/70 dark:bg-blue-400/[0.08] border border-blue-200/70 dark:border-blue-300/[0.14] rounded-xl p-6 transition-colors duration-300">
+          <h4 class="text-xs font-semibold uppercase tracking-[0.18em] text-blue-700 dark:text-blue-300 mt-0 mb-3 transition-colors duration-300">Pro Tip</h4>
           <p class="text-lg text-blue-950/70 dark:text-blue-100/70 mb-0 leading-relaxed">
             Starting with a template can save time, but creating from scratch gives you more control over the architecture.
             Choose based on your specific needs and timeline.

--- a/frontend/vuejs/src/apps/docs/views/DocsIntroduction.vue
+++ b/frontend/vuejs/src/apps/docs/views/DocsIntroduction.vue
@@ -9,7 +9,7 @@
 
       <!-- What is Imagi -->
       <section class="mb-16">
-        <h2 class="text-3xl sm:text-4xl font-semibold text-blue-950 dark:text-white mb-6 tracking-tight transition-colors duration-300">
+        <h2 class="font-display text-3xl sm:text-4xl font-semibold text-blue-950 dark:text-white mb-6 tracking-[-0.015em] transition-colors duration-300">
           What is Imagi?
         </h2>
         <div class="space-y-4 text-blue-950/70 dark:text-blue-100/70 text-lg leading-relaxed transition-colors duration-300">
@@ -28,7 +28,7 @@
 
       <!-- Who is it for -->
       <section class="mb-16">
-        <h2 class="text-3xl sm:text-4xl font-semibold text-blue-950 dark:text-white mb-8 tracking-tight transition-colors duration-300">
+        <h2 class="font-display text-3xl sm:text-4xl font-semibold text-blue-950 dark:text-white mb-8 tracking-[-0.015em] transition-colors duration-300">
           Who is it for?
         </h2>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
@@ -46,7 +46,7 @@
 
       <!-- How Does Imagi Work -->
       <section class="mb-16">
-        <h2 class="text-3xl sm:text-4xl font-semibold text-blue-950 dark:text-white mb-6 tracking-tight transition-colors duration-300">
+        <h2 class="font-display text-3xl sm:text-4xl font-semibold text-blue-950 dark:text-white mb-6 tracking-[-0.015em] transition-colors duration-300">
           How Does Imagi Work?
         </h2>
         <p class="text-blue-950/70 dark:text-blue-100/70 text-lg leading-relaxed mb-8 transition-colors duration-300">
@@ -75,7 +75,7 @@
 
       <!-- Why Choose Imagi -->
       <section class="mb-16">
-        <h2 class="text-3xl sm:text-4xl font-semibold text-blue-950 dark:text-white mb-6 tracking-tight transition-colors duration-300">
+        <h2 class="font-display text-3xl sm:text-4xl font-semibold text-blue-950 dark:text-white mb-6 tracking-[-0.015em] transition-colors duration-300">
           Why Choose Imagi?
         </h2>
         <p class="text-blue-950/70 dark:text-blue-100/70 text-lg leading-relaxed mb-8 transition-colors duration-300">
@@ -104,7 +104,7 @@
 
       <!-- Learn More Section -->
       <section class="mb-16">
-        <h2 class="text-3xl sm:text-4xl font-semibold text-blue-950 dark:text-white mb-6 tracking-tight transition-colors duration-300">
+        <h2 class="font-display text-3xl sm:text-4xl font-semibold text-blue-950 dark:text-white mb-6 tracking-[-0.015em] transition-colors duration-300">
           Learn More
         </h2>
         <p class="text-blue-950/70 dark:text-blue-100/70 text-lg leading-relaxed mb-8 transition-colors duration-300">

--- a/frontend/vuejs/src/apps/docs/views/DocsQuickStart.vue
+++ b/frontend/vuejs/src/apps/docs/views/DocsQuickStart.vue
@@ -12,7 +12,7 @@
           Navigate to the Builder Dashboard to get started. Click the "New Project" button to create your first project.
           Give it a name and description that reflects what you want to build.
         </p>
-        <div class="w-full h-px bg-blue-200/70 dark:bg-blue-300/[0.16] mb-6"></div>
+        <div class="w-full h-px bg-blue-950/[0.08] dark:bg-white/[0.14] mb-6" aria-hidden="true"></div>
         <router-link
           to="/imagi/projects"
           class="group inline-flex items-center justify-center gap-3 px-8 py-4 rounded-full font-medium text-lg bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white transition-all duration-200 hover:-translate-y-0.5 active:translate-y-0 shadow-[0_1px_2px_rgba(23,37,84,0.25),0_8px_20px_-6px_rgba(23,37,84,0.35),inset_0_1px_0_rgba(255,255,255,0.12)] hover:shadow-[0_2px_3px_rgba(23,37,84,0.22),0_14px_28px_-8px_rgba(23,37,84,0.4),inset_0_1px_0_rgba(255,255,255,0.12)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.5),0_10px_24px_-8px_rgba(0,0,0,0.55)] dark:hover:shadow-[0_2px_3px_rgba(0,0,0,0.5),0_14px_30px_-8px_rgba(0,0,0,0.6)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
@@ -37,28 +37,28 @@
 
         <ul class="space-y-3 mb-6">
           <li class="flex items-start gap-3">
-            <div class="w-1.5 h-1.5 rounded-full bg-blue-500 mt-2 flex-shrink-0"></div>
+            <div class="w-1.5 h-1.5 rotate-45 bg-orange-500/80 dark:bg-orange-400/80 mt-2.5 flex-shrink-0" aria-hidden="true"></div>
             <span class="text-lg leading-relaxed">Describe the <strong class="font-semibold text-blue-950 dark:text-white">purpose</strong> and functionality you need</span>
           </li>
           <li class="flex items-start gap-3">
-            <div class="w-1.5 h-1.5 rounded-full bg-blue-500 mt-2 flex-shrink-0"></div>
+            <div class="w-1.5 h-1.5 rotate-45 bg-orange-500/80 dark:bg-orange-400/80 mt-2.5 flex-shrink-0" aria-hidden="true"></div>
             <span class="text-lg leading-relaxed">Specify key <strong class="font-semibold text-blue-950 dark:text-white">features</strong> and user interactions</span>
           </li>
           <li class="flex items-start gap-3">
-            <div class="w-1.5 h-1.5 rounded-full bg-blue-500 mt-2 flex-shrink-0"></div>
+            <div class="w-1.5 h-1.5 rotate-45 bg-orange-500/80 dark:bg-orange-400/80 mt-2.5 flex-shrink-0" aria-hidden="true"></div>
             <span class="text-lg leading-relaxed">Mention any <strong class="font-semibold text-blue-950 dark:text-white">data models</strong> or structure requirements</span>
           </li>
           <li class="flex items-start gap-3">
-            <div class="w-1.5 h-1.5 rounded-full bg-blue-500 mt-2 flex-shrink-0"></div>
+            <div class="w-1.5 h-1.5 rotate-45 bg-orange-500/80 dark:bg-orange-400/80 mt-2.5 flex-shrink-0" aria-hidden="true"></div>
             <span class="text-lg leading-relaxed">Share <strong class="font-semibold text-blue-950 dark:text-white">design preferences</strong> or style inspiration</span>
           </li>
         </ul>
 
-        <div class="bg-blue-50/70 dark:bg-blue-400/[0.08] border border-blue-200/70 dark:border-blue-300/[0.16] rounded-xl p-6 transition-colors duration-300">
-          <h4 class="text-blue-950 dark:text-white mt-0 mb-3 text-lg font-semibold">
+        <div class="bg-blue-50/70 dark:bg-blue-400/[0.08] border border-blue-200/70 dark:border-blue-300/[0.14] rounded-xl p-6 transition-colors duration-300">
+          <h4 class="text-xs font-semibold uppercase tracking-[0.18em] text-blue-700 dark:text-blue-300 mt-0 mb-3 transition-colors duration-300">
             Example Prompt
           </h4>
-          <p class="text-lg text-blue-950/70 dark:text-blue-100/70 mb-0 leading-relaxed">
+          <p class="font-display italic text-lg text-blue-950/70 dark:text-blue-100/70 mb-0 leading-relaxed">
             "I need a task management application with user authentication. Users should be able to create projects,
             add tasks to projects, and mark tasks as complete. Each task should have a title, description, due date,
             and priority level. The app should have a dashboard showing task statistics and upcoming deadlines.
@@ -80,19 +80,19 @@
 
         <ul class="space-y-3 mb-6">
           <li class="flex items-start gap-3">
-            <div class="w-1.5 h-1.5 rounded-full bg-blue-500 mt-2 flex-shrink-0"></div>
+            <div class="w-1.5 h-1.5 rotate-45 bg-orange-500/80 dark:bg-orange-400/80 mt-2.5 flex-shrink-0" aria-hidden="true"></div>
             <span class="text-lg leading-relaxed">Review your application to ensure everything works as expected</span>
           </li>
           <li class="flex items-start gap-3">
-            <div class="w-1.5 h-1.5 rounded-full bg-blue-500 mt-2 flex-shrink-0"></div>
+            <div class="w-1.5 h-1.5 rotate-45 bg-orange-500/80 dark:bg-orange-400/80 mt-2.5 flex-shrink-0" aria-hidden="true"></div>
             <span class="text-lg leading-relaxed">Click the <strong class="font-semibold text-blue-950 dark:text-white">"Deploy"</strong> button in your project dashboard</span>
           </li>
           <li class="flex items-start gap-3">
-            <div class="w-1.5 h-1.5 rounded-full bg-blue-500 mt-2 flex-shrink-0"></div>
+            <div class="w-1.5 h-1.5 rotate-45 bg-orange-500/80 dark:bg-orange-400/80 mt-2.5 flex-shrink-0" aria-hidden="true"></div>
             <span class="text-lg leading-relaxed">Your app will be built and deployed to a live URL automatically</span>
           </li>
           <li class="flex items-start gap-3">
-            <div class="w-1.5 h-1.5 rounded-full bg-blue-500 mt-2 flex-shrink-0"></div>
+            <div class="w-1.5 h-1.5 rotate-45 bg-orange-500/80 dark:bg-orange-400/80 mt-2.5 flex-shrink-0" aria-hidden="true"></div>
             <span class="text-lg leading-relaxed">Share your URL with users and start gathering feedback</span>
           </li>
         </ul>
@@ -104,7 +104,7 @@
       </DocsStepCard>
 
       <section class="mb-16">
-        <h2 class="text-3xl sm:text-4xl font-semibold text-blue-950 dark:text-white mb-6 tracking-tight transition-colors duration-300">
+        <h2 class="font-display text-3xl sm:text-4xl font-semibold text-blue-950 dark:text-white mb-6 tracking-[-0.015em] transition-colors duration-300">
           Next Steps
         </h2>
         <p class="text-blue-950/70 dark:text-blue-100/70 text-lg leading-relaxed mb-8 transition-colors duration-300">

--- a/frontend/vuejs/src/apps/home/views/About.vue
+++ b/frontend/vuejs/src/apps/home/views/About.vue
@@ -1,142 +1,182 @@
-<!-- About Page - Clean Apple/Cursor-inspired design matching Home -->
+<!-- About Page - warm porcelain editorial design -->
 <template>
   <DefaultLayout :isHomeNav="true">
-    <div class="home-page min-h-screen bg-white dark:bg-[#0a0a0a] relative overflow-hidden transition-colors duration-500">
+    <div class="home-page relative min-h-screen overflow-hidden font-body transition-colors duration-500">
+
+      <!-- Grain texture over the whole canvas -->
+      <div class="grain-overlay absolute inset-0 z-[1] pointer-events-none" aria-hidden="true"></div>
 
       <!-- Main Content -->
       <main class="relative z-10">
         <!-- Hero Section -->
-        <section class="relative py-32 sm:py-40 md:py-48 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-[#16120e] transition-colors duration-500 overflow-hidden">
+        <section class="relative pt-32 pb-20 sm:pt-40 sm:pb-24 md:pt-48 md:pb-28 px-6 sm:px-8 lg:px-12 transition-colors duration-500">
+
+          <!-- Atmosphere: soft apricot + baby-blue washes over the porcelain canvas -->
+          <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
+            <div class="wash-warm absolute -top-40 left-1/2 -translate-x-1/3 w-[900px] h-[560px]"></div>
+            <div class="wash-cool absolute -top-24 -left-40 w-[700px] h-[520px]"></div>
+          </div>
+
           <div class="relative max-w-4xl mx-auto text-center">
 
+            <!-- Editorial kicker: tracked small caps flanked by fading hairline rules -->
+            <div class="hero-item flex items-center justify-center gap-4 mb-8" style="animation-delay: 0ms">
+              <span aria-hidden="true" class="hidden sm:block h-px w-12 md:w-16 bg-gradient-to-l from-blue-950/25 to-transparent dark:from-white/25"></span>
+              <span class="flex items-center gap-3">
+                <span aria-hidden="true" class="w-1 h-1 rotate-45 bg-orange-500/80 dark:bg-orange-400/80"></span>
+                <span class="text-[10px] sm:text-[11px] font-semibold uppercase tracking-[0.25em] sm:tracking-[0.3em] leading-none text-blue-950/70 dark:text-blue-100/55 whitespace-nowrap">About Imagi</span>
+                <span aria-hidden="true" class="w-1 h-1 rotate-45 bg-orange-500/80 dark:bg-orange-400/80"></span>
+              </span>
+              <span aria-hidden="true" class="hidden sm:block h-px w-12 md:w-16 bg-gradient-to-r from-blue-950/25 to-transparent dark:from-white/25"></span>
+            </div>
+
             <!-- Hero title -->
-            <h1 class="text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-semibold text-blue-950 dark:text-white mb-6 tracking-[-0.025em] leading-[1.08] text-balance transition-colors duration-300">
-              Build and run a business
+            <h1 class="hero-item font-display font-semibold text-[2.9rem] sm:text-6xl md:text-7xl mb-7 tracking-[-0.02em] leading-[1.05] text-balance text-blue-950 dark:text-white transition-colors duration-300" style="animation-delay: 90ms">
+              Build and run <em class="hero-accent not-italic">a business</em>
             </h1>
 
             <!-- Description -->
-            <p class="text-lg sm:text-xl text-blue-950/70 dark:text-blue-100/70 max-w-3xl mx-auto leading-relaxed text-pretty transition-colors duration-300">
+            <p class="hero-item text-lg sm:text-xl text-blue-950/65 dark:text-blue-100/65 max-w-3xl mx-auto leading-relaxed text-pretty transition-colors duration-300" style="animation-delay: 180ms">
               Imagi is an all-in-one platform for building and running a business. Create your web application with AI-powered tools, then run and grow it with everything you need for marketing, sales, and finance. We handle the technical complexity, so you can focus on your customers.
             </p>
           </div>
         </section>
 
         <!-- Mission Section -->
-        <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-blue-50 dark:bg-[#0e141f] border-t border-blue-200/60 dark:border-blue-400/[0.14] transition-colors duration-500 overflow-hidden">
+        <section class="relative py-20 md:py-28 px-6 sm:px-8 lg:px-12 transition-colors duration-500">
+
+          <!-- Cool baby-blue wash behind the section -->
+          <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
+            <div class="wash-cool absolute -top-20 right-[-15%] w-[760px] h-[560px]"></div>
+          </div>
+
           <div class="relative max-w-6xl mx-auto">
+
+            <!-- Hairline divider -->
+            <div class="section-divider mb-16 md:mb-20" aria-hidden="true"></div>
+
             <!-- Section header -->
-            <div class="text-center mb-16 md:mb-20">
-              <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-orange-200/70 dark:border-orange-400/25 bg-orange-50/80 dark:bg-orange-400/10 text-xs font-semibold text-orange-700 dark:text-orange-300 uppercase tracking-[0.18em] mb-5 transition-colors duration-300">Our Mission</p>
-              <h2 class="text-4xl sm:text-5xl md:text-6xl font-semibold text-blue-950 dark:text-white mb-6 tracking-tight text-balance transition-colors duration-300">
-                Making entrepreneurship accessible to everyone
+            <div v-reveal class="text-center mb-14 md:mb-16">
+              <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-orange-200/70 dark:border-orange-400/25 bg-orange-50/80 dark:bg-orange-400/10 text-xs font-semibold text-orange-700 dark:text-orange-300 uppercase tracking-[0.18em] mb-6 transition-colors duration-300">Our Mission</p>
+              <h2 class="font-display text-4xl sm:text-5xl md:text-[3.4rem] font-semibold text-blue-950 dark:text-white mb-6 tracking-[-0.015em] leading-[1.08] text-balance transition-colors duration-300">
+                Making entrepreneurship accessible to <em class="section-accent not-italic">everyone</em>
               </h2>
-              <p class="text-xl text-blue-950/70 dark:text-blue-100/70 max-w-3xl mx-auto leading-relaxed text-pretty transition-colors duration-300">
-                Our mission is to make starting and running a business accessible to everyone. We give you AI-powered tools to build your product and the marketing, sales, and finance tools to run it—so you can go from idea to thriving business without a technical team.
+              <p class="text-lg sm:text-xl text-blue-950/65 dark:text-blue-100/65 max-w-3xl mx-auto leading-relaxed text-pretty transition-colors duration-300">
+                Our mission is to make starting and running a business accessible to everyone. We give you AI-powered tools to build your product and the marketing, sales, and finance tools to run it&mdash;so you can go from idea to thriving business without a technical team.
               </p>
             </div>
 
             <!-- Mission cards -->
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              <div v-for="(card, index) in missionCards" :key="index" class="relative">
-                <div
-                  class="relative h-full p-8 rounded-2xl border crisp-card transition-colors duration-300"
-                  :class="index % 2 === 1 ? 'bg-white dark:bg-white/[0.05] border-orange-200/70 dark:border-orange-300/[0.16]' : 'bg-white dark:bg-white/[0.05] border-blue-200/70 dark:border-blue-300/[0.16]'"
-                >
-                  <!-- Content -->
-                  <h3 class="text-xl font-semibold tracking-tight text-blue-950 dark:text-white transition-colors duration-300 mb-5">
-                    {{ card.title }}
-                  </h3>
-                  <p class="text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty transition-colors duration-300">
-                    {{ card.description }}
-                  </p>
-                </div>
+              <div
+                v-for="(card, index) in missionCards"
+                :key="index"
+                v-reveal="{ delay: 90 + index * 90 }"
+                class="lift-card relative h-full p-8 rounded-2xl bg-white/85 dark:bg-white/[0.045] border backdrop-blur-sm transition-all duration-300"
+                :class="index % 2 === 1 ? 'border-orange-200/70 dark:border-orange-300/[0.14]' : 'border-blue-200/70 dark:border-blue-300/[0.14]'"
+              >
+                <h3 class="relative text-xl font-semibold tracking-tight text-blue-950 dark:text-white transition-colors duration-300 mb-3">
+                  {{ card.title }}
+                </h3>
+                <p class="relative text-blue-950/65 dark:text-blue-100/65 leading-relaxed text-pretty transition-colors duration-300">
+                  {{ card.description }}
+                </p>
               </div>
             </div>
           </div>
         </section>
 
         <!-- What We Do Section -->
-        <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-[#16120e] border-t border-orange-200/60 dark:border-orange-400/[0.14] transition-colors duration-500 overflow-hidden">
+        <section class="relative py-20 md:py-28 px-6 sm:px-8 lg:px-12 transition-colors duration-500">
+
+          <!-- Warm apricot wash behind the section -->
+          <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
+            <div class="wash-warm absolute -top-24 left-[-15%] w-[760px] h-[560px]"></div>
+          </div>
+
           <div class="relative max-w-6xl mx-auto">
+
+            <!-- Hairline divider -->
+            <div class="section-divider mb-16 md:mb-20" aria-hidden="true"></div>
+
             <!-- Section header -->
-            <div class="text-center mb-16 md:mb-20">
-              <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-blue-200/70 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 text-xs font-semibold text-blue-700 dark:text-blue-300 uppercase tracking-[0.18em] mb-5 transition-colors duration-300">What We Do</p>
-              <h2 class="text-4xl sm:text-5xl md:text-6xl font-semibold text-blue-950 dark:text-white mb-6 tracking-tight text-balance transition-colors duration-300">
-                One platform to build and run it all
+            <div v-reveal class="text-center mb-14 md:mb-16">
+              <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-blue-200/70 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 text-xs font-semibold text-blue-700 dark:text-blue-300 uppercase tracking-[0.18em] mb-6 transition-colors duration-300">What We Do</p>
+              <h2 class="font-display text-4xl sm:text-5xl md:text-[3.4rem] font-semibold text-blue-950 dark:text-white mb-6 tracking-[-0.015em] leading-[1.08] text-balance transition-colors duration-300">
+                One platform to build and run <em class="section-accent not-italic">it all</em>
               </h2>
-              <p class="text-xl text-blue-950/70 dark:text-blue-100/70 max-w-3xl mx-auto leading-relaxed text-pretty transition-colors duration-300">
-                Imagi combines AI-powered app building with the everyday tools you need to operate—marketing, sales, and finance—so you can launch your product and run your business without stitching together a dozen services.
+              <p class="text-lg sm:text-xl text-blue-950/65 dark:text-blue-100/65 max-w-3xl mx-auto leading-relaxed text-pretty transition-colors duration-300">
+                Imagi combines AI-powered app building with the everyday tools you need to operate&mdash;marketing, sales, and finance&mdash;so you can launch your product and run your business without stitching together a dozen services.
               </p>
             </div>
 
             <!-- Features grid -->
             <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-              <div v-for="(feature, index) in features" :key="index" class="relative">
-                <div
-                  class="relative h-full p-8 rounded-2xl border crisp-card transition-colors duration-300"
-                  :class="index % 2 === 1 ? 'bg-white dark:bg-white/[0.05] border-orange-200/70 dark:border-orange-300/[0.16]' : 'bg-white dark:bg-white/[0.05] border-blue-200/70 dark:border-blue-300/[0.16]'"
-                >
-                  <!-- Content -->
-                  <h3 class="text-xl font-semibold tracking-tight text-blue-950 dark:text-white transition-colors duration-300 mb-5 text-center">
-                    {{ feature.title }}
-                  </h3>
-                  <p class="text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty transition-colors duration-300 text-center">
-                    {{ feature.description }}
-                  </p>
-                </div>
+              <div
+                v-for="(feature, index) in features"
+                :key="index"
+                v-reveal="{ delay: 90 + index * 90 }"
+                class="lift-card relative h-full p-8 rounded-2xl bg-white/85 dark:bg-white/[0.045] border backdrop-blur-sm transition-all duration-300"
+                :class="index % 2 === 1 ? 'border-orange-200/70 dark:border-orange-300/[0.14]' : 'border-blue-200/70 dark:border-blue-300/[0.14]'"
+              >
+                <h3 class="relative text-xl font-semibold tracking-tight text-blue-950 dark:text-white transition-colors duration-300 mb-3">
+                  {{ feature.title }}
+                </h3>
+                <p class="relative text-blue-950/65 dark:text-blue-100/65 leading-relaxed text-pretty transition-colors duration-300">
+                  {{ feature.description }}
+                </p>
               </div>
             </div>
           </div>
         </section>
 
         <!-- Who We Serve Section -->
-        <section class="relative py-24 md:py-32 px-6 sm:px-8 lg:px-12 bg-blue-50 dark:bg-[#0e141f] border-t border-blue-200/60 dark:border-blue-400/[0.14] transition-colors duration-500 overflow-hidden">
+        <section class="relative py-20 md:py-28 px-6 sm:px-8 lg:px-12 transition-colors duration-500">
           <div class="relative max-w-6xl mx-auto">
+
+            <!-- Hairline divider -->
+            <div class="section-divider mb-16 md:mb-20" aria-hidden="true"></div>
+
             <!-- Section header -->
-            <div class="text-center mb-16 md:mb-20">
-              <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-orange-200/70 dark:border-orange-400/25 bg-orange-50/80 dark:bg-orange-400/10 text-xs font-semibold text-orange-700 dark:text-orange-300 uppercase tracking-[0.18em] mb-5 transition-colors duration-300">Who We Serve</p>
-              <h2 class="text-4xl sm:text-5xl md:text-6xl font-semibold text-blue-950 dark:text-white mb-6 tracking-tight text-balance transition-colors duration-300">
-                Built for creators, entrepreneurs, and innovators
+            <div v-reveal class="text-center mb-14 md:mb-16">
+              <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-orange-200/70 dark:border-orange-400/25 bg-orange-50/80 dark:bg-orange-400/10 text-xs font-semibold text-orange-700 dark:text-orange-300 uppercase tracking-[0.18em] mb-6 transition-colors duration-300">Who We Serve</p>
+              <h2 class="font-display text-4xl sm:text-5xl md:text-[3.4rem] font-semibold text-blue-950 dark:text-white mb-6 tracking-[-0.015em] leading-[1.08] text-balance transition-colors duration-300">
+                Built for creators, entrepreneurs, and <em class="section-accent not-italic">innovators</em>
               </h2>
-              <p class="text-xl text-blue-950/70 dark:text-blue-100/70 max-w-3xl mx-auto leading-relaxed text-pretty transition-colors duration-300">
+              <p class="text-lg sm:text-xl text-blue-950/65 dark:text-blue-100/65 max-w-3xl mx-auto leading-relaxed text-pretty transition-colors duration-300">
                 Whether you're launching a startup, running a small business, or growing a side project, Imagi gives you the tools to build your product and run every part of your business.
               </p>
             </div>
 
             <!-- User types grid -->
             <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <div v-for="(userType, index) in userTypes" :key="index" class="relative">
-                <div
-                  class="relative h-full p-8 rounded-2xl border crisp-card transition-colors duration-300"
-                  :class="index % 2 === 1 ? 'bg-white dark:bg-white/[0.05] border-orange-200/70 dark:border-orange-300/[0.16]' : 'bg-white dark:bg-white/[0.05] border-blue-200/70 dark:border-blue-300/[0.16]'"
-                >
-                  <!-- Content -->
-                  <h3 class="text-xl font-semibold tracking-tight text-blue-950 dark:text-white transition-colors duration-300 mb-5">
-                    {{ userType.title }}
-                  </h3>
-                  <p class="text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty transition-colors duration-300">
-                    {{ userType.description }}
-                  </p>
-                </div>
+              <div
+                v-for="(userType, index) in userTypes"
+                :key="index"
+                v-reveal="{ delay: 90 + index * 90 }"
+                class="lift-card relative h-full p-8 rounded-2xl bg-white/85 dark:bg-white/[0.045] border backdrop-blur-sm transition-all duration-300"
+                :class="index % 2 === 1 ? 'border-orange-200/70 dark:border-orange-300/[0.14]' : 'border-blue-200/70 dark:border-blue-300/[0.14]'"
+              >
+                <h3 class="relative text-xl font-semibold tracking-tight text-blue-950 dark:text-white transition-colors duration-300 mb-3">
+                  {{ userType.title }}
+                </h3>
+                <p class="relative text-blue-950/65 dark:text-blue-100/65 leading-relaxed text-pretty transition-colors duration-300">
+                  {{ userType.description }}
+                </p>
               </div>
             </div>
           </div>
         </section>
 
         <!-- CTA Section -->
-        <CTASection 
-          icon="fas fa-rocket"
+        <CTASection
           title="Ready to Start Your Business?"
-          highlightedText="No Coding Required!"
           description="Build your web app and run your business—marketing, sales, and finance—all in one place. Just bring your idea, and let Imagi do the rest."
-          highlightedStat=""
-          descriptionSuffix=""
           primaryButtonText="Start Building"
           primaryButtonTo="/imagi/projects"
           :showSecondaryButton="true"
           secondaryButtonText="Learn More"
           secondaryButtonTo="/docs"
-          secondaryButtonIcon="fas fa-book"
         />
       </main>
     </div>
@@ -147,6 +187,7 @@
 import { defineComponent } from 'vue'
 import { DefaultLayout } from '@/shared/layouts'
 import { CTASection } from '@/apps/home/components/organisms/sections'
+import reveal from '@/apps/home/directives/reveal'
 
 export default defineComponent({
   name: 'About',
@@ -154,6 +195,7 @@ export default defineComponent({
     DefaultLayout,
     CTASection
   },
+  directives: { reveal },
   setup() {
     const missionCards = [
       {
@@ -169,7 +211,7 @@ export default defineComponent({
         description: 'Our AI agents handle the technical details of building your app, and built-in tools take care of the operational heavy lifting. You focus on your vision and your customers; we handle the implementation.'
       }
     ]
-    
+
     const features = [
       {
         title: 'AI App Builder',
@@ -184,7 +226,7 @@ export default defineComponent({
         description: 'Run the day-to-day of your business with tools for invoicing, billing, and revenue and expense tracking, plus dashboards that show the health of your business at a glance.'
       }
     ]
-    
+
     const userTypes = [
       {
         title: 'Startup Founders',
@@ -203,7 +245,7 @@ export default defineComponent({
         description: 'Turn a project or passion into a real business. Build the app, market it, take payments, and track the money—without spending months learning to code or run a company.'
       }
     ]
-    
+
     return {
       missionCards,
       features,
@@ -214,11 +256,33 @@ export default defineComponent({
 </script>
 
 <style scoped>
-/* Crisp, sharp text rendering across the page */
+/* One continuous warm-porcelain canvas; sections paint soft washes on top.
+   The gradient ends on the footer's exact background so the page hands off
+   seamlessly (footer is bg-white / dark #0a0a0a). */
 .home-page {
+  background: linear-gradient(180deg, #fdf9f2 0%, #faf7f1 45%, #ffffff 100%);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
+}
+
+:root.dark .home-page,
+.dark .home-page {
+  background: linear-gradient(180deg, #0c0c0e 0%, #0a0b0f 50%, #0a0a0a 100%);
+}
+
+/* Fine film grain keeps large soft gradients from banding and adds texture */
+.grain-overlay {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)' opacity='0.5'/%3E%3C/svg%3E");
+  background-size: 160px 160px;
+  opacity: 0.035;
+  mix-blend-mode: multiply;
+}
+
+:root.dark .grain-overlay,
+.dark .grain-overlay {
+  opacity: 0.05;
+  mix-blend-mode: overlay;
 }
 
 .home-page :deep(h1),
@@ -229,8 +293,95 @@ export default defineComponent({
   font-feature-settings: 'kern' 1, 'liga' 1, 'calt' 1;
 }
 
-/* Crisp, sharply-defined cards: hairline edge + tight layered shadow */
-.crisp-card {
+/* Staggered entrance: each .hero-item rises in sequence on page load */
+.hero-item {
+  animation: hero-rise 0.9s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@keyframes hero-rise {
+  from {
+    opacity: 0;
+    transform: translateY(22px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-item {
+    animation: none;
+  }
+}
+
+/* Atmosphere washes */
+.wash-warm {
+  background: radial-gradient(closest-side, rgba(251, 146, 60, 0.13), rgba(251, 146, 60, 0.04) 55%, transparent 75%);
+  filter: blur(44px);
+}
+
+.wash-cool {
+  background: radial-gradient(closest-side, rgba(158, 205, 243, 0.22), rgba(158, 205, 243, 0.07) 55%, transparent 75%);
+  filter: blur(48px);
+}
+
+.dark .wash-warm {
+  background: radial-gradient(closest-side, rgba(251, 146, 60, 0.07), rgba(251, 146, 60, 0.02) 55%, transparent 75%);
+}
+
+.dark .wash-cool {
+  background: radial-gradient(closest-side, rgba(96, 165, 250, 0.09), rgba(96, 165, 250, 0.025) 55%, transparent 75%);
+}
+
+/* Italic serif accent with the hero's warm gradient ink */
+.hero-accent {
+  font-style: italic;
+  font-variation-settings: 'SOFT' 30, 'WONK' 1;
+  background: linear-gradient(115deg, #c2410c 5%, #ea580c 55%, #b45309 95%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  padding-right: 0.06em; /* keep the italic terminal from clipping */
+}
+
+.dark .hero-accent {
+  background: linear-gradient(115deg, #fb923c 5%, #fcd34d 60%, #f59e0b 95%);
+  -webkit-background-clip: text;
+  background-clip: text;
+}
+
+/* Italic serif accent in blue ink for section headlines */
+.section-accent {
+  font-style: italic;
+  font-variation-settings: 'SOFT' 30, 'WONK' 1;
+  background: linear-gradient(115deg, #1d4ed8 5%, #2563eb 55%, #0284c7 95%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  padding-right: 0.05em;
+}
+
+.dark .section-accent {
+  background: linear-gradient(115deg, #93c5fd 5%, #60a5fa 60%, #7dd3fc 95%);
+  -webkit-background-clip: text;
+  background-clip: text;
+}
+
+/* Hairline gradient divider that fades at the edges */
+.section-divider {
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(23, 37, 84, 0.12), transparent);
+}
+
+.dark .section-divider {
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.1), transparent);
+}
+
+/* Cards that lift gently on hover: hairline edge + tight layered shadow */
+.lift-card {
   box-shadow:
     0 0 0 1px rgba(15, 23, 42, 0.03),
     0 1px 2px rgba(15, 23, 42, 0.06),
@@ -238,7 +389,16 @@ export default defineComponent({
     0 12px 28px -10px rgba(15, 23, 42, 0.10);
 }
 
-.dark .crisp-card {
+.lift-card:hover {
+  transform: translateY(-4px);
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.04),
+    0 2px 4px rgba(15, 23, 42, 0.06),
+    0 10px 20px -4px rgba(15, 23, 42, 0.1),
+    0 24px 44px -12px rgba(15, 23, 42, 0.14);
+}
+
+.dark .lift-card {
   box-shadow:
     0 0 0 1px rgba(255, 255, 255, 0.04),
     0 1px 2px rgba(0, 0, 0, 0.5),
@@ -246,7 +406,23 @@ export default defineComponent({
     0 12px 28px -10px rgba(0, 0, 0, 0.55);
 }
 
-/* Minimal scrollbar matching Home page */
+.dark .lift-card:hover {
+  transform: translateY(-4px);
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.06),
+    0 2px 4px rgba(0, 0, 0, 0.5),
+    0 12px 24px -4px rgba(0, 0, 0, 0.5),
+    0 28px 48px -12px rgba(0, 0, 0, 0.6);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lift-card:hover,
+  .dark .lift-card:hover {
+    transform: none;
+  }
+}
+
+/* Refined minimal scrollbar */
 :deep(::-webkit-scrollbar) {
   width: 8px;
 }
@@ -276,5 +452,42 @@ export default defineComponent({
 /* Smooth scroll behavior */
 :deep(html) {
   scroll-behavior: smooth;
+}
+</style>
+
+<!-- Unscoped: reveal + selection styles (mirrors Home.vue so the page works standalone) -->
+<style>
+/* Scroll reveal (classes applied by the v-reveal directive) */
+.reveal-init {
+  opacity: 0;
+  transform: translateY(26px);
+  transition:
+    opacity 0.8s cubic-bezier(0.22, 1, 0.36, 1),
+    transform 0.8s cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: opacity, transform;
+}
+
+.reveal-init.is-revealed {
+  opacity: 1;
+  transform: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal-init {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+}
+
+/* Brand-tinted text selection */
+.home-page ::selection {
+  background: rgba(158, 205, 243, 0.55);
+  color: #172554;
+}
+
+.dark .home-page ::selection {
+  background: rgba(96, 165, 250, 0.4);
+  color: #eff6ff;
 }
 </style>

--- a/frontend/vuejs/src/apps/home/views/PrivacyPolicy.vue
+++ b/frontend/vuejs/src/apps/home/views/PrivacyPolicy.vue
@@ -1,52 +1,70 @@
-<!-- Privacy Policy Page - Clean Apple/Cursor-inspired design matching Home & About -->
+<!-- Privacy Policy Page - warm porcelain editorial design -->
 <template>
   <DefaultLayout :isHomeNav="true">
-    <div class="home-page min-h-screen bg-white dark:bg-[#0a0a0a] relative overflow-hidden transition-colors duration-500">
+    <div class="home-page relative min-h-screen overflow-hidden font-body transition-colors duration-500">
+
+      <!-- Grain texture over the whole canvas -->
+      <div class="grain-overlay absolute inset-0 z-[1] pointer-events-none" aria-hidden="true"></div>
 
       <!-- Main Content -->
       <main class="relative z-10">
         <!-- Hero Section -->
-        <section class="relative py-32 sm:py-40 md:py-48 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-[#16120e] transition-colors duration-500 overflow-hidden">
+        <section class="relative pt-32 pb-16 sm:pt-40 sm:pb-20 md:pt-48 md:pb-24 px-6 sm:px-8 lg:px-12 transition-colors duration-500">
+
+          <!-- One soft apricot wash behind the headline -->
+          <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
+            <div class="wash-warm absolute -top-32 left-1/2 -translate-x-1/2 w-[820px] h-[520px]"></div>
+          </div>
+
           <div class="relative max-w-4xl mx-auto text-center">
-            <!-- Eyebrow pill -->
-            <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-blue-200/70 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 text-xs font-semibold text-blue-700 dark:text-blue-300 uppercase tracking-[0.18em] mb-6 transition-colors duration-300">Legal</p>
+            <!-- Editorial kicker: tracked small caps flanked by fading hairline rules -->
+            <div class="hero-item flex items-center justify-center gap-4 mb-8" style="animation-delay: 0ms">
+              <span aria-hidden="true" class="hidden sm:block h-px w-12 md:w-16 bg-gradient-to-l from-blue-950/25 to-transparent dark:from-white/25"></span>
+              <span class="flex items-center gap-3">
+                <span aria-hidden="true" class="w-1 h-1 rotate-45 bg-orange-500/80 dark:bg-orange-400/80"></span>
+                <span class="text-[10px] sm:text-[11px] font-semibold uppercase tracking-[0.25em] sm:tracking-[0.3em] leading-none text-blue-950/70 dark:text-blue-100/55 whitespace-nowrap">Legal</span>
+                <span aria-hidden="true" class="w-1 h-1 rotate-45 bg-orange-500/80 dark:bg-orange-400/80"></span>
+              </span>
+              <span aria-hidden="true" class="hidden sm:block h-px w-12 md:w-16 bg-gradient-to-r from-blue-950/25 to-transparent dark:from-white/25"></span>
+            </div>
 
             <!-- Hero title -->
-            <h1 class="text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-semibold text-blue-950 dark:text-white mb-6 tracking-[-0.025em] leading-[1.08] text-balance transition-colors duration-300">
+            <h1 class="hero-item font-display font-semibold text-[2.9rem] sm:text-6xl md:text-7xl mb-7 tracking-[-0.02em] leading-[1.05] text-balance text-blue-950 dark:text-white transition-colors duration-300" style="animation-delay: 90ms">
               Privacy Policy
             </h1>
 
             <!-- Description -->
-            <p class="text-lg sm:text-xl text-blue-950/70 dark:text-blue-100/70 max-w-3xl mx-auto leading-relaxed text-pretty mb-6 transition-colors duration-300">
+            <p class="hero-item text-lg sm:text-xl text-blue-950/65 dark:text-blue-100/65 max-w-3xl mx-auto leading-relaxed text-pretty mb-8 transition-colors duration-300" style="animation-delay: 180ms">
               We are committed to protecting your privacy and ensuring the security of your personal information.
             </p>
 
-            <p class="text-base text-blue-950/50 dark:text-blue-100/50 transition-colors duration-300">
-              Last updated: June 18, 2026
+            <!-- Folio line: serif italic between hairlines -->
+            <p class="hero-item flex items-center justify-center gap-4 text-sm" style="animation-delay: 270ms">
+              <span aria-hidden="true" class="h-px w-10 bg-blue-950/20 dark:bg-white/20"></span>
+              <span class="font-display italic text-blue-950/70 dark:text-blue-100/55">Last updated: June 18, 2026</span>
+              <span aria-hidden="true" class="h-px w-10 bg-blue-950/20 dark:bg-white/20"></span>
             </p>
           </div>
         </section>
 
         <!-- Content Sections -->
         <section v-for="(section, index) in sections" :key="index"
-                 :class="[
-                   'relative py-20 md:py-24 px-6 sm:px-8 lg:px-12 border-t transition-colors duration-500 overflow-hidden',
-                   index % 2 === 0
-                     ? 'bg-blue-50 dark:bg-[#0e141f] border-blue-200/60 dark:border-blue-400/[0.14]'
-                     : 'bg-orange-50 dark:bg-[#16120e] border-orange-200/60 dark:border-orange-400/[0.14]'
-                 ]">
+                 class="relative py-14 md:py-16 px-6 sm:px-8 lg:px-12 transition-colors duration-500">
           <div class="relative max-w-3xl mx-auto">
+            <!-- Hairline divider -->
+            <div class="section-divider mb-12 md:mb-14" aria-hidden="true"></div>
+
             <!-- Section header -->
             <div class="mb-10">
               <p
-                class="inline-flex items-center px-3.5 py-1.5 rounded-full border text-xs font-semibold uppercase tracking-[0.18em] mb-5 transition-colors duration-300"
+                class="inline-flex items-center px-3.5 py-1.5 rounded-full border text-xs font-semibold uppercase tracking-[0.18em] mb-6 transition-colors duration-300"
                 :class="index % 2 === 0
                   ? 'border-orange-200/70 dark:border-orange-400/25 bg-orange-50/80 dark:bg-orange-400/10 text-orange-700 dark:text-orange-300'
                   : 'border-blue-200/70 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 text-blue-700 dark:text-blue-300'"
               >
                 {{ parseBadge(section.badge).eyebrow }}
               </p>
-              <h2 class="text-3xl sm:text-4xl font-semibold text-blue-950 dark:text-white mb-4 tracking-tight text-balance transition-colors duration-300">
+              <h2 class="font-display text-3xl sm:text-4xl font-semibold text-blue-950 dark:text-white mb-4 tracking-[-0.015em] leading-[1.1] text-balance transition-colors duration-300">
                 {{ parseBadge(section.badge).title }}
               </h2>
               <p v-if="section.description" class="text-lg text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty transition-colors duration-300">
@@ -57,9 +75,9 @@
             <!-- Content as cards -->
             <div v-if="section.items" class="space-y-4">
               <div v-for="(item, itemIndex) in section.items" :key="itemIndex"
-                   class="relative p-6 sm:p-8 rounded-2xl border crisp-card transition-colors duration-300"
-                   :class="itemIndex % 2 === 1 ? 'bg-white dark:bg-white/[0.05] border-orange-200/70 dark:border-orange-300/[0.16]' : 'bg-white dark:bg-white/[0.05] border-blue-200/70 dark:border-blue-300/[0.16]'">
-                <h3 class="text-lg sm:text-xl font-semibold text-blue-950 dark:text-white transition-colors duration-300 mb-3">
+                   class="crisp-card relative p-6 sm:p-8 rounded-2xl bg-white/85 dark:bg-white/[0.045] border backdrop-blur-sm transition-colors duration-300"
+                   :class="itemIndex % 2 === 1 ? 'border-orange-200/70 dark:border-orange-300/[0.14]' : 'border-blue-200/70 dark:border-blue-300/[0.14]'">
+                <h3 class="text-lg sm:text-xl font-semibold tracking-tight text-blue-950 dark:text-white transition-colors duration-300 mb-3">
                   {{ item.title }}
                 </h3>
                 <p class="text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty transition-colors duration-300">
@@ -72,18 +90,13 @@
 
         <!-- CTA Section -->
         <CTASection
-          icon="fas fa-rocket"
           title="Ready to Start Building?"
-          highlightedText="No Coding Required!"
           description="Your data stays private and secure. Just describe your idea, and let Imagi do the rest."
-          highlightedStat=""
-          descriptionSuffix=""
           primaryButtonText="Start Building"
           primaryButtonTo="/imagi/projects"
           :showSecondaryButton="true"
           secondaryButtonText="Terms of Service"
           secondaryButtonTo="/terms"
-          secondaryButtonIcon="fas fa-file-contract"
         />
       </main>
     </div>
@@ -294,11 +307,32 @@ export default defineComponent({
 </script>
 
 <style scoped>
-/* Crisp, sharp text rendering across the page */
+/* One continuous warm-porcelain canvas ending on the footer's background
+   (footer is bg-white / dark #0a0a0a) */
 .home-page {
+  background: linear-gradient(180deg, #fdf9f2 0%, #faf7f1 45%, #ffffff 100%);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
+}
+
+:root.dark .home-page,
+.dark .home-page {
+  background: linear-gradient(180deg, #0c0c0e 0%, #0a0b0f 50%, #0a0a0a 100%);
+}
+
+/* Fine film grain keeps large soft gradients from banding and adds texture */
+.grain-overlay {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)' opacity='0.5'/%3E%3C/svg%3E");
+  background-size: 160px 160px;
+  opacity: 0.035;
+  mix-blend-mode: multiply;
+}
+
+:root.dark .grain-overlay,
+.dark .grain-overlay {
+  opacity: 0.05;
+  mix-blend-mode: overlay;
 }
 
 .home-page :deep(h1),
@@ -307,6 +341,48 @@ export default defineComponent({
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
   font-feature-settings: 'kern' 1, 'liga' 1, 'calt' 1;
+}
+
+/* Staggered entrance: each .hero-item rises in sequence on page load */
+.hero-item {
+  animation: hero-rise 0.9s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@keyframes hero-rise {
+  from {
+    opacity: 0;
+    transform: translateY(22px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-item {
+    animation: none;
+  }
+}
+
+/* Soft warm wash over the porcelain canvas */
+.wash-warm {
+  background: radial-gradient(closest-side, rgba(251, 146, 60, 0.13), rgba(251, 146, 60, 0.04) 55%, transparent 75%);
+  filter: blur(44px);
+}
+
+.dark .wash-warm {
+  background: radial-gradient(closest-side, rgba(251, 146, 60, 0.07), rgba(251, 146, 60, 0.02) 55%, transparent 75%);
+}
+
+/* Hairline gradient divider that fades at the edges */
+.section-divider {
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(23, 37, 84, 0.12), transparent);
+}
+
+.dark .section-divider {
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.1), transparent);
 }
 
 /* Crisp, sharply-defined cards: hairline edge + tight layered shadow */
@@ -356,5 +432,18 @@ export default defineComponent({
 /* Smooth scroll behavior */
 :deep(html) {
   scroll-behavior: smooth;
+}
+</style>
+
+<!-- Unscoped: brand-tinted selection (mirrors Home.vue so the page works standalone) -->
+<style>
+.home-page ::selection {
+  background: rgba(158, 205, 243, 0.55);
+  color: #172554;
+}
+
+.dark .home-page ::selection {
+  background: rgba(96, 165, 250, 0.4);
+  color: #eff6ff;
 }
 </style>

--- a/frontend/vuejs/src/apps/home/views/TermsOfService.vue
+++ b/frontend/vuejs/src/apps/home/views/TermsOfService.vue
@@ -1,52 +1,70 @@
-<!-- Terms of Service Page - Clean Apple/Cursor-inspired design matching Home & About -->
+<!-- Terms of Service Page - warm porcelain editorial design -->
 <template>
   <DefaultLayout :isHomeNav="true">
-    <div class="home-page min-h-screen bg-white dark:bg-[#0a0a0a] relative overflow-hidden transition-colors duration-500">
+    <div class="home-page relative min-h-screen overflow-hidden font-body transition-colors duration-500">
+
+      <!-- Grain texture over the whole canvas -->
+      <div class="grain-overlay absolute inset-0 z-[1] pointer-events-none" aria-hidden="true"></div>
 
       <!-- Main Content -->
       <main class="relative z-10">
         <!-- Hero Section -->
-        <section class="relative py-32 sm:py-40 md:py-48 px-6 sm:px-8 lg:px-12 bg-orange-50 dark:bg-[#16120e] transition-colors duration-500 overflow-hidden">
+        <section class="relative pt-32 pb-16 sm:pt-40 sm:pb-20 md:pt-48 md:pb-24 px-6 sm:px-8 lg:px-12 transition-colors duration-500">
+
+          <!-- One soft apricot wash behind the headline -->
+          <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
+            <div class="wash-warm absolute -top-32 left-1/2 -translate-x-1/2 w-[820px] h-[520px]"></div>
+          </div>
+
           <div class="relative max-w-4xl mx-auto text-center">
-            <!-- Eyebrow pill -->
-            <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-blue-200/70 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 text-xs font-semibold text-blue-700 dark:text-blue-300 uppercase tracking-[0.18em] mb-6 transition-colors duration-300">Legal</p>
+            <!-- Editorial kicker: tracked small caps flanked by fading hairline rules -->
+            <div class="hero-item flex items-center justify-center gap-4 mb-8" style="animation-delay: 0ms">
+              <span aria-hidden="true" class="hidden sm:block h-px w-12 md:w-16 bg-gradient-to-l from-blue-950/25 to-transparent dark:from-white/25"></span>
+              <span class="flex items-center gap-3">
+                <span aria-hidden="true" class="w-1 h-1 rotate-45 bg-orange-500/80 dark:bg-orange-400/80"></span>
+                <span class="text-[10px] sm:text-[11px] font-semibold uppercase tracking-[0.25em] sm:tracking-[0.3em] leading-none text-blue-950/70 dark:text-blue-100/55 whitespace-nowrap">Legal</span>
+                <span aria-hidden="true" class="w-1 h-1 rotate-45 bg-orange-500/80 dark:bg-orange-400/80"></span>
+              </span>
+              <span aria-hidden="true" class="hidden sm:block h-px w-12 md:w-16 bg-gradient-to-r from-blue-950/25 to-transparent dark:from-white/25"></span>
+            </div>
 
             <!-- Hero title -->
-            <h1 class="text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-semibold text-blue-950 dark:text-white mb-6 tracking-[-0.025em] leading-[1.08] text-balance transition-colors duration-300">
+            <h1 class="hero-item font-display font-semibold text-[2.9rem] sm:text-6xl md:text-7xl mb-7 tracking-[-0.02em] leading-[1.05] text-balance text-blue-950 dark:text-white transition-colors duration-300" style="animation-delay: 90ms">
               Terms of Service
             </h1>
 
             <!-- Description -->
-            <p class="text-lg sm:text-xl text-blue-950/70 dark:text-blue-100/70 max-w-3xl mx-auto leading-relaxed text-pretty mb-6 transition-colors duration-300">
+            <p class="hero-item text-lg sm:text-xl text-blue-950/65 dark:text-blue-100/65 max-w-3xl mx-auto leading-relaxed text-pretty mb-8 transition-colors duration-300" style="animation-delay: 180ms">
               Please read these terms carefully before using our services. By accessing our platform, you agree to be bound by these terms.
             </p>
 
-            <p class="text-base text-blue-950/50 dark:text-blue-100/50 transition-colors duration-300">
-              Last updated: June 18, 2026
+            <!-- Folio line: serif italic between hairlines -->
+            <p class="hero-item flex items-center justify-center gap-4 text-sm" style="animation-delay: 270ms">
+              <span aria-hidden="true" class="h-px w-10 bg-blue-950/20 dark:bg-white/20"></span>
+              <span class="font-display italic text-blue-950/70 dark:text-blue-100/55">Last updated: June 18, 2026</span>
+              <span aria-hidden="true" class="h-px w-10 bg-blue-950/20 dark:bg-white/20"></span>
             </p>
           </div>
         </section>
 
         <!-- Content Sections -->
         <section v-for="(section, index) in sections" :key="index"
-                 :class="[
-                   'relative py-20 md:py-24 px-6 sm:px-8 lg:px-12 border-t transition-colors duration-500 overflow-hidden',
-                   index % 2 === 0
-                     ? 'bg-blue-50 dark:bg-[#0e141f] border-blue-200/60 dark:border-blue-400/[0.14]'
-                     : 'bg-orange-50 dark:bg-[#16120e] border-orange-200/60 dark:border-orange-400/[0.14]'
-                 ]">
+                 class="relative py-14 md:py-16 px-6 sm:px-8 lg:px-12 transition-colors duration-500">
           <div class="relative max-w-3xl mx-auto">
+            <!-- Hairline divider -->
+            <div class="section-divider mb-12 md:mb-14" aria-hidden="true"></div>
+
             <!-- Section header -->
             <div class="mb-10">
               <p
-                class="inline-flex items-center px-3.5 py-1.5 rounded-full border text-xs font-semibold uppercase tracking-[0.18em] mb-5 transition-colors duration-300"
+                class="inline-flex items-center px-3.5 py-1.5 rounded-full border text-xs font-semibold uppercase tracking-[0.18em] mb-6 transition-colors duration-300"
                 :class="index % 2 === 0
                   ? 'border-orange-200/70 dark:border-orange-400/25 bg-orange-50/80 dark:bg-orange-400/10 text-orange-700 dark:text-orange-300'
                   : 'border-blue-200/70 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 text-blue-700 dark:text-blue-300'"
               >
                 {{ parseBadge(section.badge).eyebrow }}
               </p>
-              <h2 class="text-3xl sm:text-4xl font-semibold text-blue-950 dark:text-white mb-4 tracking-tight text-balance transition-colors duration-300">
+              <h2 class="font-display text-3xl sm:text-4xl font-semibold text-blue-950 dark:text-white mb-4 tracking-[-0.015em] leading-[1.1] text-balance transition-colors duration-300">
                 {{ parseBadge(section.badge).title }}
               </h2>
               <p v-if="section.description" class="text-lg text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty transition-colors duration-300">
@@ -57,9 +75,9 @@
             <!-- Content as cards -->
             <div v-if="section.items" class="space-y-4">
               <div v-for="(item, itemIndex) in section.items" :key="itemIndex"
-                   class="relative p-6 sm:p-8 rounded-2xl border crisp-card transition-colors duration-300"
-                   :class="itemIndex % 2 === 1 ? 'bg-white dark:bg-white/[0.05] border-orange-200/70 dark:border-orange-300/[0.16]' : 'bg-white dark:bg-white/[0.05] border-blue-200/70 dark:border-blue-300/[0.16]'">
-                <h3 class="text-lg sm:text-xl font-semibold text-blue-950 dark:text-white transition-colors duration-300 mb-3">
+                   class="crisp-card relative p-6 sm:p-8 rounded-2xl bg-white/85 dark:bg-white/[0.045] border backdrop-blur-sm transition-colors duration-300"
+                   :class="itemIndex % 2 === 1 ? 'border-orange-200/70 dark:border-orange-300/[0.14]' : 'border-blue-200/70 dark:border-blue-300/[0.14]'">
+                <h3 class="text-lg sm:text-xl font-semibold tracking-tight text-blue-950 dark:text-white transition-colors duration-300 mb-3">
                   {{ item.title }}
                 </h3>
                 <p class="text-blue-950/70 dark:text-blue-100/70 leading-relaxed text-pretty transition-colors duration-300">
@@ -72,18 +90,13 @@
 
         <!-- CTA Section -->
         <CTASection
-          icon="fas fa-rocket"
           title="Ready to Start Building?"
-          highlightedText="No Coding Required!"
           description="Agree to the terms and bring your idea to life. Just describe what you want, and let Imagi do the rest."
-          highlightedStat=""
-          descriptionSuffix=""
           primaryButtonText="Start Building"
           primaryButtonTo="/imagi/projects"
           :showSecondaryButton="true"
           secondaryButtonText="Privacy Policy"
           secondaryButtonTo="/privacy"
-          secondaryButtonIcon="fas fa-shield-alt"
         />
       </main>
     </div>
@@ -292,11 +305,32 @@ export default defineComponent({
 </script>
 
 <style scoped>
-/* Crisp, sharp text rendering across the page */
+/* One continuous warm-porcelain canvas ending on the footer's background
+   (footer is bg-white / dark #0a0a0a) */
 .home-page {
+  background: linear-gradient(180deg, #fdf9f2 0%, #faf7f1 45%, #ffffff 100%);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
+}
+
+:root.dark .home-page,
+.dark .home-page {
+  background: linear-gradient(180deg, #0c0c0e 0%, #0a0b0f 50%, #0a0a0a 100%);
+}
+
+/* Fine film grain keeps large soft gradients from banding and adds texture */
+.grain-overlay {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)' opacity='0.5'/%3E%3C/svg%3E");
+  background-size: 160px 160px;
+  opacity: 0.035;
+  mix-blend-mode: multiply;
+}
+
+:root.dark .grain-overlay,
+.dark .grain-overlay {
+  opacity: 0.05;
+  mix-blend-mode: overlay;
 }
 
 .home-page :deep(h1),
@@ -305,6 +339,48 @@ export default defineComponent({
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
   font-feature-settings: 'kern' 1, 'liga' 1, 'calt' 1;
+}
+
+/* Staggered entrance: each .hero-item rises in sequence on page load */
+.hero-item {
+  animation: hero-rise 0.9s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@keyframes hero-rise {
+  from {
+    opacity: 0;
+    transform: translateY(22px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-item {
+    animation: none;
+  }
+}
+
+/* Soft warm wash over the porcelain canvas */
+.wash-warm {
+  background: radial-gradient(closest-side, rgba(251, 146, 60, 0.13), rgba(251, 146, 60, 0.04) 55%, transparent 75%);
+  filter: blur(44px);
+}
+
+.dark .wash-warm {
+  background: radial-gradient(closest-side, rgba(251, 146, 60, 0.07), rgba(251, 146, 60, 0.02) 55%, transparent 75%);
+}
+
+/* Hairline gradient divider that fades at the edges */
+.section-divider {
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(23, 37, 84, 0.12), transparent);
+}
+
+.dark .section-divider {
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.1), transparent);
 }
 
 /* Crisp, sharply-defined cards: hairline edge + tight layered shadow */
@@ -354,5 +430,18 @@ export default defineComponent({
 /* Smooth scroll behavior */
 :deep(html) {
   scroll-behavior: smooth;
+}
+</style>
+
+<!-- Unscoped: brand-tinted selection (mirrors Home.vue so the page works standalone) -->
+<style>
+.home-page ::selection {
+  background: rgba(158, 205, 243, 0.55);
+  color: #172554;
+}
+
+.dark .home-page ::selection {
+  background: rgba(96, 165, 250, 0.4);
+  color: #eff6ff;
 }
 </style>

--- a/frontend/vuejs/src/apps/imagi/build/components/molecules/display/AccountBalanceDisplay.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/molecules/display/AccountBalanceDisplay.vue
@@ -116,7 +116,6 @@ onBeforeUnmount(() => {
 
 <style scoped>
 .account-balance-display {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   transition: all 0.3s ease;
 }
 
@@ -138,7 +137,7 @@ onBeforeUnmount(() => {
 
 .text-wrap { display: flex; flex-direction: column; gap: 0.125rem; min-width: 5.5rem; }
 .label-row { display: flex; align-items: center; gap: 0.3rem; }
-.label { font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: rgba(23, 37, 84, 0.55); font-weight: 600; }
+.label { font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; color: rgba(23, 37, 84, 0.7); font-weight: 600; }
 .value-row { display: flex; align-items: center; gap: 0.25rem; }
 .value {
   color: rgb(23, 37, 84);
@@ -153,15 +152,20 @@ onBeforeUnmount(() => {
 /* Animation for slow pulsing effect */
 @keyframes pulse-slow { 0%,100%{opacity:0; transform:scale(1);} 50%{opacity:0.7; transform:scale(1.05);} }
 .animate-pulse-slow { animation: pulse-slow 3s infinite ease-in-out; }
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-pulse-slow { animation: none; }
+  .account-balance-display { transition: none; }
+}
 </style>
 
 <style>
 /* Dark mode styles - unscoped to access parent .dark class */
 .dark .account-balance-display .label {
-  color: rgba(255, 255, 255, 0.5);
+  color: rgba(219, 234, 254, 0.55);
 }
 
 .dark .account-balance-display .value {
-  color: rgba(255, 255, 255, 0.95);
+  color: rgb(255, 255, 255);
 }
 </style>

--- a/frontend/vuejs/src/apps/imagi/build/components/molecules/sidebar/AgentInstanceCard.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/molecules/sidebar/AgentInstanceCard.vue
@@ -4,7 +4,7 @@
       'group relative rounded-lg border px-2.5 py-2 cursor-pointer transition-all duration-200',
       isActive
         ? 'instance-card--active border-blue-300/80 dark:border-blue-400/40'
-        : 'border-blue-100 dark:border-white/[0.06] bg-blue-50/40 hover:bg-blue-50 hover:border-blue-200/90 dark:bg-white/[0.02] dark:hover:bg-white/[0.05] dark:hover:border-white/[0.1]',
+        : 'border-blue-950/[0.08] dark:border-white/[0.1] bg-blue-50/40 hover:bg-blue-50 hover:border-blue-950/[0.16] dark:bg-white/[0.02] dark:hover:bg-white/[0.05] dark:hover:border-white/[0.18]',
       isArchived ? 'opacity-70 hover:opacity-100' : ''
     ]"
     @click="emit('select')"
@@ -17,7 +17,7 @@
           ref="titleInput"
           v-model="draftTitle"
           type="text"
-          class="w-full bg-transparent text-xs font-semibold text-blue-950 dark:text-white/90 border-b border-blue-400 outline-none"
+          class="w-full bg-transparent text-xs font-semibold text-blue-950 dark:text-white/90 border-b border-blue-400 dark:border-blue-300/60 outline-none"
           @click.stop
           @keydown.enter.prevent="commitRename"
           @keydown.escape="cancelRename"
@@ -29,12 +29,12 @@
             'text-xs truncate transition-colors duration-200',
             isActive
               ? 'font-semibold text-blue-950 dark:text-white'
-              : 'font-medium text-blue-950/80 dark:text-white/75 group-hover:text-blue-950 dark:group-hover:text-white/90'
+              : 'font-medium text-blue-950/80 dark:text-blue-100/75 group-hover:text-blue-950 dark:group-hover:text-white'
           ]"
         >
           {{ instance.title || 'Untitled instance' }}
         </div>
-        <div class="flex items-center gap-1.5 mt-1 text-[10px] text-blue-950/40 dark:text-white/40">
+        <div class="flex items-center gap-1.5 mt-1 text-[10px] text-blue-950/40 dark:text-blue-100/45">
           <span>{{ relativeTime(instance.updatedAt) }}</span>
           <span v-if="instance.isProcessing" class="ml-1 flex items-center gap-1 text-blue-600 dark:text-blue-300">
             <i class="fas fa-circle-notch fa-spin text-[9px]"></i>
@@ -47,7 +47,7 @@
       <div ref="menuRef" class="relative shrink-0" @click.stop>
         <button
           :class="[
-            'w-6 h-6 flex items-center justify-center rounded-md transition-opacity hover:bg-blue-100 dark:hover:bg-white/[0.08] text-blue-950/50 dark:text-white/60 hover:text-blue-950/80 dark:hover:text-white/90',
+            'w-6 h-6 flex items-center justify-center rounded-md transition-opacity hover:bg-blue-100 dark:hover:bg-white/[0.08] text-blue-950/50 dark:text-blue-100/60 hover:text-blue-950/80 dark:hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]',
             menuOpen ? 'opacity-100 bg-blue-100 dark:bg-white/[0.08]' : 'opacity-0 group-hover:opacity-100 focus:opacity-100'
           ]"
           title="Options"
@@ -57,7 +57,7 @@
         </button>
         <div
           v-if="menuOpen"
-          class="absolute right-0 top-full mt-1 z-50 min-w-[140px] rounded-lg border border-blue-100 dark:border-white/[0.1] bg-white/95 dark:bg-[#161616]/95 backdrop-blur-sm shadow-xl shadow-blue-950/10 dark:shadow-black/40 py-1"
+          class="absolute right-0 top-full mt-1 z-50 min-w-[140px] rounded-lg border border-blue-950/[0.08] dark:border-white/[0.14] bg-white/95 dark:bg-[#161616]/95 backdrop-blur-sm shadow-xl shadow-blue-950/10 dark:shadow-black/40 py-1"
         >
           <button class="menu-item" @click.stop="onRename">
             <i class="fas fa-pen menu-item-icon"></i>
@@ -214,11 +214,21 @@ function relativeTime(iso: string): string {
 }
 
 .dark .menu-item {
-  color: rgba(255, 255, 255, 0.8);
+  color: rgba(219, 234, 254, 0.8);
 }
 
 .dark .menu-item:hover {
   background-color: rgba(255, 255, 255, 0.06);
+}
+
+/* Canonical focus ring, inset against the menu surface */
+.menu-item:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px rgba(59, 130, 246, 0.4);
+}
+
+.dark .menu-item:focus-visible {
+  box-shadow: inset 0 0 0 2px rgba(147, 197, 253, 0.5);
 }
 
 .menu-item--danger {
@@ -249,6 +259,6 @@ function relativeTime(iso: string): string {
 }
 
 .dark .menu-item-icon {
-  color: rgba(255, 255, 255, 0.45);
+  color: rgba(219, 234, 254, 0.5);
 }
 </style>

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/chat/ChatConversation.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/chat/ChatConversation.vue
@@ -7,8 +7,8 @@
         <div class="empty-icon flex items-center justify-center w-12 h-12 rounded-2xl mb-4">
           <i class="fas fa-wand-magic-sparkles text-base"></i>
         </div>
-        <h3 class="text-sm font-semibold text-blue-950/80 dark:text-white/85 mb-1.5">What should we build?</h3>
-        <p class="text-xs text-blue-950/45 dark:text-white/40 max-w-[230px] leading-relaxed">
+        <h3 class="text-sm font-semibold text-blue-950 dark:text-white mb-1.5">What should we build?</h3>
+        <p class="text-xs text-blue-950/45 dark:text-blue-100/45 max-w-[230px] leading-relaxed">
           Describe a page, feature, or change and the agent will build it into your project.
         </p>
       </div>
@@ -355,6 +355,24 @@ const copyToClipboard = (code: string) => {
   margin-bottom: 1rem;
 }
 
+/* Ink-tinted links instead of the typography plugin's gray */
+.prose a {
+  color: theme('colors.blue.700');
+}
+
+.dark .prose a {
+  color: theme('colors.blue.300');
+}
+
+/* Ink-tinted list markers instead of the typography plugin's gray */
+.prose ::marker {
+  color: rgba(23, 37, 84, 0.4);
+}
+
+.dark .prose ::marker {
+  color: rgba(219, 234, 254, 0.4);
+}
+
 .prose li {
   margin-bottom: 0.5rem;
 }
@@ -481,7 +499,9 @@ const copyToClipboard = (code: string) => {
 
 @media (prefers-reduced-motion: reduce) {
   .status-orb,
-  .status-shimmer {
+  .status-shimmer,
+  .animate-message-in,
+  .animate-fade-in {
     animation: none;
   }
 
@@ -493,7 +513,7 @@ const copyToClipboard = (code: string) => {
   }
 
   .dark .status-shimmer {
-    color: rgba(255, 255, 255, 0.6);
+    color: rgba(219, 234, 254, 0.65);
   }
 }
 

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/modals/ConfirmModal.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/modals/ConfirmModal.vue
@@ -37,7 +37,7 @@
               <!-- Close button -->
               <button
                 type="button"
-                class="text-blue-950/40 hover:text-blue-950/70 p-1 rounded-lg hover:bg-blue-50 transition-all flex-shrink-0"
+                class="text-blue-950/40 hover:text-blue-950/70 dark:text-blue-100/50 dark:hover:text-white p-1 rounded-lg hover:bg-blue-50 dark:hover:bg-white/[0.06] transition-colors duration-200 flex-shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#101014]"
                 @click="handleCancel"
                 aria-label="Close"
               >
@@ -47,20 +47,20 @@
           </div>
 
           <!-- Footer / Actions -->
-          <div class="px-6 py-4 bg-blue-50/60 flex items-center justify-end gap-3">
+          <div class="px-6 py-4 bg-blue-50/60 dark:bg-white/[0.03] flex items-center justify-end gap-3">
             <button
               type="button"
-              class="px-5 py-2.5 text-sm font-medium rounded-lg border transition-all duration-200"
+              class="px-5 py-2.5 text-sm font-medium rounded-full border transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#101014]"
               :class="cancelButtonClasses"
               @click="handleCancel"
               :disabled="isProcessing"
             >
               {{ options.cancelText || 'Cancel' }}
             </button>
-            
+
             <button
               type="button"
-              class="px-5 py-2.5 text-sm font-medium rounded-lg border transition-all duration-200 min-w-[100px]"
+              class="px-5 py-2.5 text-sm font-medium rounded-full border transition-colors duration-200 min-w-[100px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#101014]"
               :class="confirmButtonClasses"
               @click="handleConfirm"
               :disabled="isProcessing"
@@ -124,81 +124,81 @@ const defaultTitle = computed(() => {
 
 // Modal styling based on type
 const modalClasses = computed(() => {
-  const baseClasses = 'bg-white dark:bg-gray-50'
-  
+  const baseClasses = 'bg-white dark:bg-[#101014]'
+
   switch (props.options.type) {
     case 'danger':
-      return `${baseClasses} border-red-200 dark:border-red-300`
+      return `${baseClasses} border-red-200 dark:border-red-500/30`
     case 'warning':
-      return `${baseClasses} border-amber-200 dark:border-amber-300`
+      return `${baseClasses} border-amber-200 dark:border-amber-500/30`
     case 'success':
-      return `${baseClasses} border-green-200 dark:border-green-300`
+      return `${baseClasses} border-green-200 dark:border-green-500/30`
     default:
-      return `${baseClasses} border-blue-200 dark:border-blue-300`
+      return `${baseClasses} border-blue-200 dark:border-blue-300/[0.16]`
   }
 })
 
 const headerClasses = computed(() => {
   switch (props.options.type) {
     case 'danger':
-      return 'border-red-100 dark:border-red-200/50 bg-red-50/50 dark:bg-red-50/30'
+      return 'border-red-100 dark:border-red-500/20 bg-red-50/50 dark:bg-red-500/[0.06]'
     case 'warning':
-      return 'border-amber-100 dark:border-amber-200/50 bg-amber-50/50 dark:bg-amber-50/30'
+      return 'border-amber-100 dark:border-amber-500/20 bg-amber-50/50 dark:bg-amber-500/[0.06]'
     case 'success':
-      return 'border-green-100 dark:border-green-200/50 bg-green-50/50 dark:bg-green-50/30'
+      return 'border-green-100 dark:border-green-500/20 bg-green-50/50 dark:bg-green-500/[0.06]'
     default:
-      return 'border-blue-100 dark:border-blue-200/50 bg-blue-50/50 dark:bg-blue-50/30'
+      return 'border-blue-100 dark:border-blue-400/20 bg-blue-50/50 dark:bg-blue-400/[0.06]'
   }
 })
 
 const iconContainerClasses = computed(() => {
   switch (props.options.type) {
     case 'danger':
-      return 'bg-red-100 dark:bg-red-100 border border-red-200 dark:border-red-300'
+      return 'bg-red-100 dark:bg-red-500/[0.12] border border-red-200 dark:border-red-500/30'
     case 'warning':
-      return 'bg-amber-100 dark:bg-amber-100 border border-amber-200 dark:border-amber-300'
+      return 'bg-amber-100 dark:bg-amber-500/[0.12] border border-amber-200 dark:border-amber-500/30'
     case 'success':
-      return 'bg-green-100 dark:bg-green-100 border border-green-200 dark:border-green-300'
+      return 'bg-green-100 dark:bg-green-500/[0.12] border border-green-200 dark:border-green-500/30'
     default:
-      return 'bg-blue-100 dark:bg-blue-100 border border-blue-200 dark:border-blue-300'
+      return 'bg-blue-100 dark:bg-blue-400/[0.12] border border-blue-200 dark:border-blue-400/30'
   }
 })
 
 const iconClasses = computed(() => {
   switch (props.options.type) {
     case 'danger':
-      return 'fas fa-exclamation-triangle text-red-600 dark:text-red-600'
+      return 'fas fa-exclamation-triangle text-red-600 dark:text-red-400'
     case 'warning':
-      return 'fas fa-exclamation-circle text-amber-600 dark:text-amber-600'
+      return 'fas fa-exclamation-circle text-amber-600 dark:text-amber-400'
     case 'success':
-      return 'fas fa-check-circle text-green-600 dark:text-green-600'
+      return 'fas fa-check-circle text-green-600 dark:text-green-400'
     default:
-      return 'fas fa-info-circle text-blue-600 dark:text-blue-600'
+      return 'fas fa-info-circle text-blue-600 dark:text-blue-300'
   }
 })
 
 const titleClasses = computed(() => {
-  return 'text-blue-950 dark:text-blue-950'
+  return 'text-blue-950 dark:text-white'
 })
 
 const messageClasses = computed(() => {
-  return 'text-blue-950/70 dark:text-blue-950/70'
+  return 'text-blue-950/70 dark:text-blue-100/70'
 })
 
 const cancelButtonClasses = computed(() => {
-  return 'bg-white dark:bg-white border-blue-200 dark:border-blue-200 text-blue-950/70 dark:text-blue-950/70 hover:bg-blue-50 dark:hover:bg-blue-50 disabled:opacity-50 disabled:cursor-not-allowed'
+  return 'bg-white dark:bg-white/[0.03] border-blue-950/[0.14] dark:border-white/[0.16] text-blue-950/80 dark:text-blue-100/80 hover:text-blue-950 dark:hover:text-white hover:border-blue-950/30 dark:hover:border-white/30 hover:bg-blue-950/[0.03] dark:hover:bg-white/[0.06] disabled:opacity-50 disabled:cursor-not-allowed'
 })
 
 const confirmButtonClasses = computed(() => {
   switch (props.options.type) {
     case 'danger':
-      return 'bg-red-600 dark:bg-red-600 border-red-700 dark:border-red-700 text-white hover:bg-red-700 dark:hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed'
+      return 'bg-red-600 dark:bg-red-600 border-transparent text-white hover:bg-red-700 dark:hover:bg-red-500 shadow-[0_1px_2px_rgba(127,29,29,0.2),0_3px_8px_-2px_rgba(127,29,29,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)] disabled:opacity-50 disabled:cursor-not-allowed'
     case 'warning':
-      return 'bg-amber-600 dark:bg-amber-600 border-amber-700 dark:border-amber-700 text-white hover:bg-amber-700 dark:hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed'
+      return 'bg-amber-600 dark:bg-amber-600 border-transparent text-white hover:bg-amber-700 dark:hover:bg-amber-500 shadow-[0_1px_2px_rgba(120,53,15,0.2),0_3px_8px_-2px_rgba(120,53,15,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)] disabled:opacity-50 disabled:cursor-not-allowed'
     case 'success':
-      return 'bg-green-600 dark:bg-green-600 border-green-700 dark:border-green-700 text-white hover:bg-green-700 dark:hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed'
+      return 'bg-green-600 dark:bg-green-600 border-transparent text-white hover:bg-green-700 dark:hover:bg-green-500 shadow-[0_1px_2px_rgba(20,83,45,0.2),0_3px_8px_-2px_rgba(20,83,45,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)] disabled:opacity-50 disabled:cursor-not-allowed'
     default:
-      return 'bg-blue-600 dark:bg-blue-600 border-blue-700 dark:border-blue-700 text-white hover:bg-blue-700 dark:hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed'
+      return 'bg-blue-950 dark:bg-[#f3ede2] border-transparent text-[#fdf9f2] dark:text-blue-950 hover:bg-blue-900 dark:hover:bg-white shadow-[0_1px_2px_rgba(23,37,84,0.2),0_3px_8px_-2px_rgba(23,37,84,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)] disabled:opacity-50 disabled:cursor-not-allowed'
   }
 })
 
@@ -250,5 +250,19 @@ function handleCancel() {
 .modal-leave-from > div {
   transform: scale(1);
   opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .modal-enter-active,
+  .modal-leave-active,
+  .modal-enter-active > div,
+  .modal-leave-active > div {
+    transition: none;
+  }
+
+  .modal-enter-from > div,
+  .modal-leave-to > div {
+    transform: none;
+  }
 }
 </style>

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/AgentManagerPanel.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/AgentManagerPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col h-full bg-white dark:bg-[#0a0a0a] border-r border-blue-100 dark:border-white/[0.08] transition-colors duration-300">
+  <div class="flex flex-col h-full bg-white dark:bg-[#0a0a0a] border-r border-blue-950/[0.08] dark:border-white/[0.14] transition-colors duration-300">
     <!-- Confirm Modal (uses Teleport to body) -->
     <ConfirmModal
       :is-open="confirmModal.isModalOpen.value"
@@ -8,11 +8,11 @@
       @cancel="confirmModal.handleCancel"
     />
     <!-- Header -->
-    <div class="shrink-0 flex items-center gap-1 px-2 py-2 border-b border-blue-100 dark:border-white/[0.08]">
+    <div class="shrink-0 flex items-center gap-1 px-2 py-2 border-b border-blue-950/[0.08] dark:border-white/[0.14]">
       <!-- Collapse (desktop only; mobile uses the navbar view switcher) -->
       <div class="relative group max-md:hidden">
         <button
-          class="flex items-center justify-center w-7 h-7 rounded-md text-blue-950/60 dark:text-white/70 hover:bg-blue-50 dark:hover:bg-white/[0.08] hover:text-blue-950 dark:hover:text-white transition-colors"
+          class="flex items-center justify-center w-7 h-7 rounded-md text-blue-950/60 dark:text-blue-100/70 hover:bg-blue-50 dark:hover:bg-white/[0.08] hover:text-blue-950 dark:hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
           @click="emit('collapse')"
         >
           <i class="fas fa-chevron-left text-xs"></i>
@@ -29,17 +29,17 @@
         <div class="agents-icon-chip flex items-center justify-center w-5 h-5 rounded-md shrink-0">
           <i class="fas fa-layer-group text-[9px] text-blue-950/80 dark:text-[#f3ede2]/90"></i>
         </div>
-        <span class="text-xs font-semibold text-blue-950/80 dark:text-white/80 truncate">Agents</span>
+        <span class="text-xs font-semibold text-blue-950/80 dark:text-blue-100/85 truncate">Agents</span>
       </div>
 
       <!-- Search -->
       <div class="relative group">
         <button
           :class="[
-            'flex items-center justify-center w-7 h-7 rounded-md transition-colors',
+            'flex items-center justify-center w-7 h-7 rounded-md transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]',
             showSearch
               ? 'bg-blue-50 dark:bg-white/[0.08] text-blue-950 dark:text-white'
-              : 'text-blue-950/60 dark:text-white/70 hover:bg-blue-50 dark:hover:bg-white/[0.08] hover:text-blue-950 dark:hover:text-white'
+              : 'text-blue-950/60 dark:text-blue-100/70 hover:bg-blue-50 dark:hover:bg-white/[0.08] hover:text-blue-950 dark:hover:text-white'
           ]"
           @click="toggleSearch"
         >
@@ -55,7 +55,7 @@
       <!-- New agent instance -->
       <div class="relative group">
         <button
-          class="btn-new flex items-center justify-center w-7 h-7 rounded-md text-[#fdf9f2] dark:text-blue-950 transition-all duration-200"
+          class="btn-new flex items-center justify-center w-7 h-7 rounded-md text-[#fdf9f2] dark:text-blue-950 transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
           @click="handleCreate"
         >
           <i class="fas fa-plus text-xs"></i>
@@ -69,20 +69,20 @@
     </div>
 
     <!-- Search input -->
-    <div v-if="showSearch" class="shrink-0 px-2 py-2 border-b border-blue-100 dark:border-white/[0.08]">
-      <div class="search-shell flex items-center gap-2 rounded-lg bg-blue-50/50 dark:bg-white/[0.03] border border-blue-200/70 dark:border-white/[0.08] px-2.5 py-1.5">
-        <i class="fas fa-search text-[11px] text-blue-950/40 dark:text-white/40 shrink-0"></i>
+    <div v-if="showSearch" class="shrink-0 px-2 py-2 border-b border-blue-950/[0.08] dark:border-white/[0.14]">
+      <div class="search-shell flex items-center gap-2 rounded-lg bg-blue-50/50 dark:bg-white/[0.03] border border-blue-200/70 dark:border-white/[0.14] px-2.5 py-1.5">
+        <i class="fas fa-search text-[11px] text-blue-950/40 dark:text-blue-100/45 shrink-0"></i>
         <input
           ref="searchInput"
           v-model="searchQuery"
           type="text"
           placeholder="Search chats"
-          class="flex-1 min-w-0 bg-transparent text-xs text-blue-950 dark:text-white/90 placeholder-blue-950/40 dark:placeholder-white/30 outline-none"
+          class="flex-1 min-w-0 bg-transparent text-xs text-blue-950 dark:text-white/90 placeholder-blue-950/40 dark:placeholder-blue-100/40 outline-none"
           @keydown.escape="closeSearch"
         />
         <button
           v-if="searchQuery"
-          class="shrink-0 text-blue-950/40 hover:text-blue-950/70 dark:text-white/40 dark:hover:text-white/70 transition-colors"
+          class="shrink-0 text-blue-950/40 hover:text-blue-950/70 dark:text-blue-100/45 dark:hover:text-blue-100/80 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a] rounded"
           @click="searchQuery = ''"
         >
           <i class="fas fa-times text-[11px]"></i>
@@ -95,7 +95,7 @@
       <!-- Loading state -->
       <div
         v-if="store.instancesLoading && store.instances.length === 0"
-        class="flex items-center justify-center gap-2 px-2 py-8 text-xs text-blue-950/40 dark:text-white/40"
+        class="flex items-center justify-center gap-2 px-2 py-8 text-xs text-blue-950/40 dark:text-blue-100/45"
       >
         <i class="fas fa-circle-notch fa-spin text-[11px]"></i>
         <span>Loading agents…</span>
@@ -106,11 +106,11 @@
         v-else-if="showSearch && searchQuery.trim() && !hasResults"
         class="flex flex-col items-center px-4 py-8 text-center"
       >
-        <div class="flex items-center justify-center w-9 h-9 rounded-full bg-blue-50 dark:bg-white/[0.05] border border-blue-100 dark:border-white/[0.08] mb-2.5">
-          <i class="fas fa-search text-xs text-blue-400 dark:text-white/40"></i>
+        <div class="flex items-center justify-center w-9 h-9 rounded-full bg-blue-50 dark:bg-white/[0.05] border border-blue-950/[0.08] dark:border-white/[0.14] mb-2.5">
+          <i class="fas fa-search text-xs text-blue-400 dark:text-blue-300/60"></i>
         </div>
-        <div class="text-xs font-medium text-blue-950/60 dark:text-white/50">No matching chats</div>
-        <div class="text-[11px] text-blue-950/40 dark:text-white/30 mt-1 break-all">
+        <div class="text-xs font-medium text-blue-950/60 dark:text-blue-100/60">No matching chats</div>
+        <div class="text-[11px] text-blue-950/40 dark:text-blue-100/40 mt-1 break-all">
           Nothing matches "{{ searchQuery.trim() }}"
         </div>
       </div>
@@ -120,16 +120,16 @@
         v-else-if="!hasResults"
         class="flex flex-col items-center px-4 py-8 text-center"
       >
-        <div class="flex items-center justify-center w-9 h-9 rounded-full bg-blue-50 dark:bg-white/[0.05] border border-blue-100 dark:border-white/[0.08] mb-2.5">
-          <i class="fas fa-layer-group text-xs text-blue-400 dark:text-white/40"></i>
+        <div class="flex items-center justify-center w-9 h-9 rounded-full bg-blue-50 dark:bg-white/[0.05] border border-blue-950/[0.08] dark:border-white/[0.14] mb-2.5">
+          <i class="fas fa-layer-group text-xs text-blue-400 dark:text-blue-300/60"></i>
         </div>
-        <div class="text-xs font-medium text-blue-950/60 dark:text-white/50">No agents yet</div>
-        <div class="text-[11px] text-blue-950/40 dark:text-white/30 mt-1">Create one with the + button above</div>
+        <div class="text-xs font-medium text-blue-950/60 dark:text-blue-100/60">No agents yet</div>
+        <div class="text-[11px] text-blue-950/40 dark:text-blue-100/40 mt-1">Create one with the + button above</div>
       </div>
 
       <!-- Active instances -->
       <template v-if="activeInstances.length > 0">
-        <div class="text-[10px] font-semibold uppercase tracking-wider text-blue-950/40 dark:text-white/40 px-2 pt-1 pb-1.5">
+        <div class="text-[10px] font-semibold uppercase tracking-wider text-blue-950/40 dark:text-blue-100/45 px-2 pt-1 pb-1.5">
           Active
         </div>
         <InstanceCard
@@ -147,7 +147,7 @@
       <!-- Archived / past instances -->
       <template v-if="archivedInstances.length > 0">
         <button
-          class="w-full flex items-center justify-between rounded-md px-2 py-2 mt-3 text-[10px] font-semibold uppercase tracking-wider text-blue-950/40 dark:text-white/40 hover:text-blue-950/70 dark:hover:text-white/70 hover:bg-blue-50/60 dark:hover:bg-white/[0.04] transition-colors"
+          class="w-full flex items-center justify-between rounded-md px-2 py-2 mt-3 text-[10px] font-semibold uppercase tracking-wider text-blue-950/40 dark:text-blue-100/45 hover:text-blue-950/70 dark:hover:text-blue-100/80 hover:bg-blue-50/60 dark:hover:bg-white/[0.04] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
           @click="showArchived = !showArchived"
         >
           <span>Past ({{ archivedInstances.length }})</span>

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
@@ -1,10 +1,10 @@
 <template>
-  <div v-if="!isCollapsed" class="flex flex-col h-full bg-white dark:bg-[#0a0a0a] border-r border-blue-100 dark:border-white/[0.08] transition-colors duration-300">
+  <div v-if="!isCollapsed" class="flex flex-col h-full bg-white dark:bg-[#0a0a0a] border-r border-blue-950/[0.08] dark:border-white/[0.14] transition-colors duration-300">
     <!-- Header: manager toggle + instance title -->
-    <div class="shrink-0 flex items-center gap-2 px-3 py-2 border-b border-blue-100 dark:border-white/[0.08]">
+    <div class="shrink-0 flex items-center gap-2 px-3 py-2 border-b border-blue-950/[0.08] dark:border-white/[0.14]">
       <div v-if="!isManagerOpen" class="relative group max-md:hidden">
         <button
-          class="flex items-center justify-center w-8 h-8 rounded-md text-blue-950/60 dark:text-white/60 hover:bg-blue-50 dark:hover:bg-white/[0.08] hover:text-blue-950 dark:hover:text-white transition-colors duration-200"
+          class="flex items-center justify-center w-8 h-8 rounded-md text-blue-950/60 dark:text-blue-100/65 hover:bg-blue-50 dark:hover:bg-white/[0.08] hover:text-blue-950 dark:hover:text-white transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
           @click="$emit('toggleManager')"
         >
           <i class="fas fa-chevron-right text-sm"></i>
@@ -15,12 +15,12 @@
           Show agent manager
         </div>
       </div>
-      <div class="flex-1 min-w-0 text-xs font-semibold text-blue-950/80 dark:text-white/80 truncate">
+      <div class="flex-1 min-w-0 text-xs font-semibold text-blue-950/80 dark:text-blue-100/85 truncate">
         {{ activeInstance?.title || 'New instance' }}
       </div>
       <div v-if="onCollapseSidebar" class="relative group shrink-0 max-md:hidden">
         <button
-          class="flex items-center justify-center w-8 h-8 rounded-md text-blue-950/60 dark:text-white/60 hover:bg-blue-50 dark:hover:bg-white/[0.08] hover:text-blue-950 dark:hover:text-white transition-colors duration-200"
+          class="flex items-center justify-center w-8 h-8 rounded-md text-blue-950/60 dark:text-blue-100/65 hover:bg-blue-50 dark:hover:bg-white/[0.08] hover:text-blue-950 dark:hover:text-white transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
           @click="onCollapseSidebar()"
         >
           <i class="fas fa-chevron-left text-sm"></i>
@@ -48,7 +48,7 @@
     <div class="shrink-0 bg-white dark:bg-[#0a0a0a] transition-colors duration-300">
       <div class="px-2 pt-1 pb-3">
         <!-- Input shell: textarea on top, controls toolbar below -->
-        <div class="chat-input-shell rounded-2xl bg-blue-50/40 dark:bg-white/[0.03] border border-blue-100 dark:border-white/[0.08] shadow-sm">
+        <div class="chat-input-shell rounded-2xl bg-blue-50/40 dark:bg-white/[0.03] border border-blue-950/[0.08] dark:border-white/[0.14] shadow-sm">
           <textarea
             ref="promptTextarea"
             v-model="prompt"
@@ -58,7 +58,7 @@
             @input="autoResizeTextarea"
             :disabled="!activeInstance || activeInstance.isProcessing"
             rows="4"
-            class="chat-textarea w-full bg-transparent text-blue-950 dark:text-white/90 placeholder-blue-950/40 dark:placeholder-white/30 text-sm px-3 pt-3 pb-1 resize-none leading-relaxed"
+            class="chat-textarea w-full bg-transparent text-blue-950 dark:text-white/90 placeholder-blue-950/40 dark:placeholder-blue-100/40 text-sm px-3 pt-3 pb-1 resize-none leading-relaxed"
             style="min-height: 92px; max-height: 240px;"
           ></textarea>
 
@@ -111,10 +111,10 @@
               @click="handlePrompt"
               :disabled="!prompt.trim() || !activeInstance || activeInstance.isProcessing"
               aria-label="Send message"
-              class="btn-send flex shrink-0 items-center justify-center w-9 h-9 rounded-full transition-all duration-300"
+              class="btn-send flex shrink-0 items-center justify-center w-9 h-9 rounded-full transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
               :class="prompt.trim() && activeInstance && !activeInstance.isProcessing
                 ? 'btn-send--active text-[#fdf9f2] dark:text-blue-950'
-                : 'bg-blue-100/60 dark:bg-white/[0.05] text-blue-950/40 dark:text-white/40 cursor-not-allowed border border-blue-200/70 dark:border-white/[0.12] shadow-sm'"
+                : 'bg-blue-100/60 dark:bg-white/[0.05] text-blue-950/40 dark:text-blue-100/40 cursor-not-allowed border border-blue-200/70 dark:border-white/[0.12] shadow-sm'"
             >
               <i v-if="activeInstance?.isProcessing" class="fas fa-circle-notch fa-spin text-sm"></i>
               <i v-else class="fas fa-arrow-up text-sm"></i>
@@ -290,28 +290,28 @@ async function handleEffortSelect(effort: ReasoningEffort) {
   top: 50%;
   transform: translateY(-50%);
   font-size: 0.6875rem;
-  color: rgba(107, 114, 128, 0.8);
+  color: rgba(23, 37, 84, 0.55);
   pointer-events: none;
   transition: color 0.2s ease;
   z-index: 1;
 }
 
 .dark .dropdown-icon {
-  color: rgba(255, 255, 255, 0.55);
+  color: rgba(219, 234, 254, 0.55);
 }
 
 .dropdown-wrapper:hover .dropdown-icon {
-  color: rgb(55, 65, 81);
+  color: rgb(23, 37, 84);
 }
 
 .dark .dropdown-wrapper:hover .dropdown-icon {
-  color: rgba(255, 255, 255, 0.85);
+  color: rgba(219, 234, 254, 0.9);
 }
 
 /* Ghost dropdown select: quiet until hovered, so the input shell stays the
    focal point */
 .dropdown-select {
-  background-image: url('data:image/svg+xml;charset=UTF-8,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 24 24%27 fill=%27none%27 stroke=%27rgba(107,114,128,0.8)%27 stroke-width=%272.5%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27%3e%3cpolyline points=%276 9 12 15 18 9%27%3e%3c/polyline%3e%3c/svg%3e');
+  background-image: url('data:image/svg+xml;charset=UTF-8,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 24 24%27 fill=%27none%27 stroke=%27rgba(23,37,84,0.55)%27 stroke-width=%272.5%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27%3e%3cpolyline points=%276 9 12 15 18 9%27%3e%3c/polyline%3e%3c/svg%3e');
   background-repeat: no-repeat;
   background-position: right 0.55rem center;
   background-size: 0.85em;
@@ -336,8 +336,8 @@ async function handleEffortSelect(effort: ReasoningEffort) {
 }
 
 .dark .dropdown-select {
-  background-image: url('data:image/svg+xml;charset=UTF-8,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 24 24%27 fill=%27none%27 stroke=%27rgba(255,255,255,0.6)%27 stroke-width=%272.5%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27%3e%3cpolyline points=%276 9 12 15 18 9%27%3e%3c/polyline%3e%3c/svg%3e');
-  color: rgba(255, 255, 255, 0.65);
+  background-image: url('data:image/svg+xml;charset=UTF-8,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 viewBox=%270 0 24 24%27 fill=%27none%27 stroke=%27rgba(219,234,254,0.6)%27 stroke-width=%272.5%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27%3e%3cpolyline points=%276 9 12 15 18 9%27%3e%3c/polyline%3e%3c/svg%3e');
+  color: rgba(219, 234, 254, 0.7);
 }
 
 .dropdown-select:hover {
@@ -351,19 +351,19 @@ async function handleEffortSelect(effort: ReasoningEffort) {
 }
 
 .dropdown-select:focus-visible {
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.35);
+  box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px rgba(59, 130, 246, 0.4);
   outline: none;
 }
 
 .dark .dropdown-select:focus-visible {
-  box-shadow: 0 0 0 2px rgba(147, 197, 253, 0.35);
+  box-shadow: 0 0 0 2px #0a0a0a, 0 0 0 4px rgba(147, 197, 253, 0.5);
 }
 
 
 /* Style dropdown options to match the page */
 .dropdown-select option {
   background-color: white;
-  color: #374151;
+  color: #172554;
   padding: 8px 12px;
   font-size: 0.75rem;
   font-weight: 500;
@@ -372,7 +372,7 @@ async function handleEffortSelect(effort: ReasoningEffort) {
 
 .dark .dropdown-select option {
   background-color: #0a0a0a;
-  color: rgba(255, 255, 255, 0.7);
+  color: rgba(219, 234, 254, 0.8);
   outline: none !important;
 }
 

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspaceError.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspaceError.vue
@@ -26,7 +26,7 @@
               </router-link>
               <button
                 @click="$emit('retry')"
-                class="inline-flex items-center justify-center px-6 py-3 rounded-full border border-blue-200/70 dark:border-white/[0.12] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-blue-950/80 dark:text-white/70 hover:text-blue-950 dark:hover:text-white shadow-sm hover:shadow-md transition-all duration-300 font-medium"
+                class="inline-flex items-center justify-center px-6 py-3 rounded-full border border-blue-950/[0.14] dark:border-white/[0.16] bg-white dark:bg-white/[0.03] hover:bg-blue-950/[0.03] dark:hover:bg-white/[0.06] hover:border-blue-950/30 dark:hover:border-white/30 text-blue-950/80 dark:text-blue-100/80 hover:text-blue-950 dark:hover:text-white shadow-sm hover:shadow-md transition-all duration-300 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
               >
                 <i class="fas fa-sync-alt mr-2"></i>
                 Retry

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspacePreview.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/workspace/WorkspacePreview.vue
@@ -1,14 +1,14 @@
 <template>
   <div class="relative w-full h-full flex flex-col bg-white dark:bg-[#0a0a0a]">
     <!-- Toolbar -->
-    <div class="flex flex-col gap-2 px-3 py-1.5 border-b border-blue-200/60 dark:border-white/[0.08] bg-blue-50/50 dark:bg-white/[0.02]">
+    <div class="flex flex-col gap-2 px-3 py-1.5 border-b border-blue-950/[0.08] dark:border-white/[0.14] bg-blue-50/50 dark:bg-white/[0.02]">
       <div class="flex items-center gap-1.5 flex-wrap">
         <button
           type="button"
           @click="goBack"
           :disabled="!canGoBack || phase !== 'ready'"
           title="Back"
-          class="inline-flex items-center justify-center w-8 h-8 shrink-0 rounded-full border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-blue-950/60 dark:text-white/60 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          class="inline-flex items-center justify-center w-8 h-8 shrink-0 rounded-full border border-blue-950/[0.14] dark:border-white/[0.16] bg-white dark:bg-white/[0.03] hover:bg-blue-950/[0.03] dark:hover:bg-white/[0.06] text-blue-950/70 hover:text-blue-950 dark:text-blue-100/70 dark:hover:text-white hover:border-blue-950/30 dark:hover:border-white/30 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a] disabled:opacity-40 disabled:cursor-not-allowed"
         >
           <i class="fas fa-arrow-left text-xs"></i>
         </button>
@@ -18,7 +18,7 @@
           @click="goForward"
           :disabled="!canGoForward || phase !== 'ready'"
           title="Forward"
-          class="inline-flex items-center justify-center w-8 h-8 shrink-0 rounded-full border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-blue-950/60 dark:text-white/60 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          class="inline-flex items-center justify-center w-8 h-8 shrink-0 rounded-full border border-blue-950/[0.14] dark:border-white/[0.16] bg-white dark:bg-white/[0.03] hover:bg-blue-950/[0.03] dark:hover:bg-white/[0.06] text-blue-950/70 hover:text-blue-950 dark:text-blue-100/70 dark:hover:text-white hover:border-blue-950/30 dark:hover:border-white/30 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a] disabled:opacity-40 disabled:cursor-not-allowed"
         >
           <i class="fas fa-arrow-right text-xs"></i>
         </button>
@@ -27,7 +27,7 @@
           type="button"
           @click="reload"
           title="Refresh page"
-          class="inline-flex items-center justify-center w-8 h-8 shrink-0 rounded-full border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-blue-950/60 dark:text-white/60 transition-colors"
+          class="inline-flex items-center justify-center w-8 h-8 shrink-0 rounded-full border border-blue-950/[0.14] dark:border-white/[0.16] bg-white dark:bg-white/[0.03] hover:bg-blue-950/[0.03] dark:hover:bg-white/[0.06] text-blue-950/70 hover:text-blue-950 dark:text-blue-100/70 dark:hover:text-white hover:border-blue-950/30 dark:hover:border-white/30 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
         >
           <i class="fas fa-sync-alt text-xs" :class="{ 'fa-spin': phase === 'starting' }"></i>
         </button>
@@ -36,7 +36,7 @@
           type="button"
           @click="goHome"
           title="Go to home page"
-          class="inline-flex items-center justify-center w-8 h-8 shrink-0 rounded-full border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-blue-950/60 dark:text-white/60 transition-colors"
+          class="inline-flex items-center justify-center w-8 h-8 shrink-0 rounded-full border border-blue-950/[0.14] dark:border-white/[0.16] bg-white dark:bg-white/[0.03] hover:bg-blue-950/[0.03] dark:hover:bg-white/[0.06] text-blue-950/70 hover:text-blue-950 dark:text-blue-100/70 dark:hover:text-white hover:border-blue-950/30 dark:hover:border-white/30 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
         >
           <i class="fas fa-home text-xs"></i>
         </button>
@@ -47,16 +47,16 @@
             type="button"
             @click="onMenuToggle"
             :disabled="apps.length === 0"
-            class="group w-full flex items-center gap-2 h-8 rounded-full border border-blue-200/60 dark:border-white/[0.08] bg-white/80 dark:bg-white/[0.04] hover:bg-blue-50 dark:hover:bg-white/[0.07] focus:border-blue-400 dark:focus:border-blue-300/40 focus:ring-2 focus:ring-blue-400/15 outline-none pl-3 pr-8 text-[13px] font-medium text-blue-950 dark:text-white/90 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            class="group w-full flex items-center gap-2 h-8 rounded-full border border-blue-950/[0.14] dark:border-white/[0.16] bg-white/80 dark:bg-white/[0.04] hover:bg-blue-50 dark:hover:bg-white/[0.07] hover:border-blue-950/30 dark:hover:border-white/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a] pl-3 pr-8 text-[13px] font-medium text-blue-950 dark:text-white transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <span class="truncate flex-1 text-left">{{ triggerLabel }}</span>
-            <span class="truncate max-w-[10rem] text-[11px] text-blue-950/35 dark:text-white/35 font-normal hidden sm:block">{{ currentPath }}</span>
-            <i class="fas fa-chevron-down absolute right-3 top-1/2 -translate-y-1/2 text-[10px] text-blue-950/40 dark:text-white/35 pointer-events-none transition-transform duration-200" :class="{ 'rotate-180': menuOpen }"></i>
+            <span class="truncate max-w-[10rem] text-[11px] text-blue-950/35 dark:text-blue-100/45 font-normal hidden sm:block">{{ currentPath }}</span>
+            <i class="fas fa-chevron-down absolute right-3 top-1/2 -translate-y-1/2 text-[10px] text-blue-950/40 dark:text-blue-100/45 pointer-events-none transition-transform duration-200" :class="{ 'rotate-180': menuOpen }"></i>
           </button>
 
           <div
             v-if="menuOpen && apps.length > 0"
-            class="absolute z-20 mt-1.5 left-0 max-md:left-auto max-md:right-0 min-w-[14rem] max-md:max-w-[calc(100vw-1.5rem)] rounded-xl border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-[#0f0f0f] shadow-xl py-1"
+            class="absolute z-20 mt-1.5 left-0 max-md:left-auto max-md:right-0 min-w-[14rem] max-md:max-w-[calc(100vw-1.5rem)] rounded-xl border border-blue-950/[0.08] dark:border-white/[0.14] bg-white dark:bg-[#0f0f0f] shadow-xl py-1"
           >
             <div
               v-for="app in apps"
@@ -68,20 +68,20 @@
               <button
                 type="button"
                 @click="hoveredApp = hoveredApp === app.name ? '' : app.name"
-                class="w-full flex items-center justify-between gap-2 px-3 py-2 text-sm text-blue-950 dark:text-white/90 hover:bg-blue-50 dark:hover:bg-white/[0.05]"
+                class="w-full flex items-center justify-between gap-2 px-3 py-2 text-sm text-blue-950 dark:text-white hover:bg-blue-50 dark:hover:bg-white/[0.05] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50"
               >
                 <span class="flex items-center gap-2 truncate">
                   {{ app.title }}
                 </span>
                 <i
-                  class="fas fa-chevron-right text-[10px] text-blue-950/40 dark:text-white/40 transition-transform duration-200"
+                  class="fas fa-chevron-right text-[10px] text-blue-950/40 dark:text-blue-100/45 transition-transform duration-200"
                   :class="{ 'max-md:rotate-90': hoveredApp === app.name }"
                 ></i>
               </button>
 
               <div
                 v-if="hoveredApp === app.name && app.pages.length"
-                class="py-1 md:absolute md:top-0 md:left-full md:ml-1 md:min-w-[14rem] md:rounded-lg md:border md:border-blue-200/60 md:dark:border-white/[0.08] md:bg-white md:dark:bg-[#0f0f0f] md:shadow-lg max-md:ml-4 max-md:mt-0.5 max-md:mb-1 max-md:border-l max-md:border-blue-100 max-md:dark:border-white/[0.08]"
+                class="py-1 md:absolute md:top-0 md:left-full md:ml-1 md:min-w-[14rem] md:rounded-lg md:border md:border-blue-950/[0.08] md:dark:border-white/[0.14] md:bg-white md:dark:bg-[#0f0f0f] md:shadow-lg max-md:ml-4 max-md:mt-0.5 max-md:mb-1 max-md:border-l max-md:border-blue-950/[0.08] max-md:dark:border-white/[0.14]"
                 @mouseenter="onAppEnter(app.name)"
                 @mouseleave="onAppLeave(app.name)"
               >
@@ -90,10 +90,10 @@
                   :key="page.path"
                   type="button"
                   @click="onSelectPage(page.path)"
-                  :class="['w-full flex items-center gap-2 px-3 py-2 text-sm text-left',
+                  :class="['w-full flex items-center gap-2 px-3 py-2 text-sm text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50',
                            page.path === currentPath
                              ? 'bg-blue-50 dark:bg-white/[0.08] text-blue-950 dark:text-white'
-                             : 'text-blue-950/70 dark:text-white/80 hover:bg-blue-50 dark:hover:bg-white/[0.05]']"
+                             : 'text-blue-950/70 dark:text-blue-100/80 hover:bg-blue-50 dark:hover:bg-white/[0.05]']"
                 >
                   <span class="truncate">{{ page.title }}</span>
                 </button>
@@ -132,11 +132,11 @@
       <!-- Starting overlay -->
       <div
         v-if="phase === 'starting'"
-        class="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-white/90 dark:bg-[#0a0a0a]/90 text-blue-950/60 dark:text-white/60"
+        class="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-white/90 dark:bg-[#0a0a0a]/90 text-blue-950/60 dark:text-blue-100/65"
       >
         <i class="fas fa-spinner fa-spin text-2xl"></i>
         <span class="text-sm font-medium">Starting preview…</span>
-        <span class="text-xs text-blue-950/40 dark:text-white/40 max-w-xs text-center">
+        <span class="text-xs text-blue-950/40 dark:text-blue-100/45 max-w-xs text-center">
           The first start can take a few minutes while your project's dependencies install.
         </span>
       </div>
@@ -149,10 +149,10 @@
         <div class="w-12 h-12 bg-red-50 dark:bg-red-900/10 border border-red-200 dark:border-red-800/30 rounded-xl flex items-center justify-center">
           <i class="fas fa-exclamation-triangle text-red-600 dark:text-red-400"></i>
         </div>
-        <p class="text-sm text-blue-950/70 dark:text-white/70 max-w-md break-words">{{ error }}</p>
+        <p class="text-sm text-blue-950/70 dark:text-blue-100/70 max-w-md break-words">{{ error }}</p>
         <button
           @click="startPreview"
-          class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-sm font-medium text-blue-950/70 dark:text-white/70 transition-colors"
+          class="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-blue-950/[0.14] dark:border-white/[0.16] bg-white dark:bg-white/[0.03] hover:bg-blue-950/[0.03] dark:hover:bg-white/[0.06] hover:border-blue-950/30 dark:hover:border-white/30 text-sm font-medium text-blue-950/80 hover:text-blue-950 dark:text-blue-100/80 dark:hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
         >
           <i class="fas fa-sync-alt text-xs"></i>
           Retry
@@ -164,13 +164,13 @@
         v-else-if="phase === 'stopped'"
         class="absolute inset-0 flex flex-col items-center justify-center gap-4 px-8 text-center bg-white/95 dark:bg-[#0a0a0a]/95"
       >
-        <div class="w-12 h-12 bg-blue-50 dark:bg-white/[0.05] border border-blue-200/60 dark:border-white/[0.08] rounded-xl flex items-center justify-center">
+        <div class="w-12 h-12 bg-blue-50 dark:bg-white/[0.05] border border-blue-950/[0.08] dark:border-white/[0.14] rounded-xl flex items-center justify-center">
           <i class="fas fa-pause text-blue-600 dark:text-blue-300"></i>
         </div>
-        <p class="text-sm text-blue-950/70 dark:text-white/70 max-w-md">The preview session has stopped.</p>
+        <p class="text-sm text-blue-950/70 dark:text-blue-100/70 max-w-md">The preview session has stopped.</p>
         <button
           @click="startPreview"
-          class="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-blue-200/60 dark:border-white/[0.08] bg-white dark:bg-white/[0.03] hover:bg-blue-50 dark:hover:bg-white/[0.06] text-sm font-medium text-blue-950/70 dark:text-white/70 transition-colors"
+          class="inline-flex items-center gap-2 px-4 py-2 rounded-full border border-blue-950/[0.14] dark:border-white/[0.16] bg-white dark:bg-white/[0.03] hover:bg-blue-950/[0.03] dark:hover:bg-white/[0.06] hover:border-blue-950/30 dark:hover:border-white/30 text-sm font-medium text-blue-950/80 hover:text-blue-950 dark:text-blue-100/80 dark:hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
         >
           <i class="fas fa-play text-xs"></i>
           Start preview

--- a/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
+++ b/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
@@ -43,7 +43,7 @@
            One view fills the screen at a time. -->
       <template #navbar-center="{ setSidebarCollapsed }">
         <div
-          class="md:hidden flex items-center gap-0.5 rounded-lg border border-blue-100 dark:border-white/[0.08] bg-blue-50/70 dark:bg-white/[0.05] p-0.5"
+          class="md:hidden flex items-center gap-0.5 rounded-lg border border-blue-950/[0.08] dark:border-white/[0.14] bg-blue-50/70 dark:bg-white/[0.05] p-0.5"
           role="tablist"
           aria-label="Workspace view"
         >
@@ -57,10 +57,10 @@
             :title="opt.label"
             @click="selectMobileView(opt.value, setSidebarCollapsed)"
             :class="[
-              'flex items-center justify-center rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors',
+              'flex items-center justify-center rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]',
               mobileView === opt.value
                 ? 'bg-white dark:bg-white/[0.12] text-blue-700 dark:text-white shadow-sm'
-                : 'text-blue-950/55 dark:text-white/55 hover:text-blue-950 dark:hover:text-white'
+                : 'text-blue-950/55 dark:text-blue-100/55 hover:text-blue-950 dark:hover:text-white'
             ]"
           >
             <i :class="[opt.icon, 'text-sm']"></i>

--- a/frontend/vuejs/src/apps/imagi/marketing/components/AdConnectionCard.vue
+++ b/frontend/vuejs/src/apps/imagi/marketing/components/AdConnectionCard.vue
@@ -20,7 +20,7 @@
     </div>
     <p class="text-sm text-blue-950/60 dark:text-blue-100/60 mb-5">
       {{ description }}
-      <a :href="docsUrl" target="_blank" rel="noopener noreferrer" class="text-violet-700 dark:text-violet-300 hover:underline">Setup guide</a>.
+      <a :href="docsUrl" target="_blank" rel="noopener noreferrer" class="text-blue-700 dark:text-blue-300 hover:underline rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]">Setup guide</a>.
     </p>
 
     <p v-if="connection?.account_name" class="text-xs text-blue-950/50 dark:text-blue-100/50 mb-4 -mt-2">
@@ -53,7 +53,7 @@
 
       <div class="flex flex-wrap items-center gap-3 pt-1">
         <button type="submit" :class="ui.primaryBtn" :disabled="saving">
-          <i v-if="saving" class="fas fa-circle-notch animate-spin"></i>
+          <i v-if="saving" class="fas fa-circle-notch animate-spin motion-reduce:animate-none"></i>
           Save
         </button>
         <button
@@ -62,7 +62,7 @@
           :disabled="verifying || !connection?.is_configured"
           @click="verify"
         >
-          <i :class="['fas', verifying ? 'fa-circle-notch animate-spin' : 'fa-plug-circle-bolt']" class="text-xs"></i>
+          <i :class="['fas', verifying ? 'fa-circle-notch animate-spin motion-reduce:animate-none' : 'fa-plug-circle-bolt']" class="text-xs"></i>
           Test connection
         </button>
         <button
@@ -72,7 +72,7 @@
           :disabled="disconnecting"
           @click="disconnect"
         >
-          <i :class="['fas', disconnecting ? 'fa-circle-notch animate-spin' : 'fa-link-slash']" class="text-xs"></i>
+          <i :class="['fas', disconnecting ? 'fa-circle-notch animate-spin motion-reduce:animate-none' : 'fa-link-slash']" class="text-xs"></i>
           Disconnect
         </button>
       </div>

--- a/frontend/vuejs/src/apps/imagi/marketing/components/CampaignForm.vue
+++ b/frontend/vuejs/src/apps/imagi/marketing/components/CampaignForm.vue
@@ -26,10 +26,10 @@
           v-for="option in channelOptions"
           :key="option.value"
           type="button"
-          class="flex items-start gap-3 p-3.5 rounded-xl border text-left transition-all duration-200"
+          class="flex items-start gap-3 p-3.5 rounded-xl border text-left transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]"
           :class="form.channel === option.value
-            ? 'border-violet-300 dark:border-violet-400/50 bg-violet-50/80 dark:bg-violet-400/10 ring-1 ring-violet-300/50 dark:ring-violet-400/30'
-            : 'border-blue-200/70 dark:border-white/[0.12] bg-white dark:bg-white/[0.04] hover:border-violet-200 dark:hover:border-violet-400/30'"
+            ? 'border-blue-300 dark:border-blue-400/50 bg-blue-50/80 dark:bg-blue-400/10 ring-1 ring-blue-300/50 dark:ring-blue-400/30'
+            : 'border-blue-200/70 dark:border-white/[0.12] bg-white dark:bg-white/[0.04] hover:border-blue-300/70 dark:hover:border-blue-400/30'"
           @click="form.channel = option.value"
         >
           <div class="w-9 h-9 shrink-0" :class="ui.iconTile">
@@ -70,11 +70,11 @@
       <span :class="ui.label">Audience</span>
       <div class="space-y-2.5">
         <label class="flex items-center gap-2.5 text-sm text-blue-950 dark:text-white cursor-pointer">
-          <input v-model="form.audience_type" type="radio" value="all" class="accent-violet-600" />
+          <input v-model="form.audience_type" type="radio" value="all" class="accent-blue-700 dark:accent-blue-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]" />
           All subscribed contacts
         </label>
         <label class="flex items-center gap-2.5 text-sm text-blue-950 dark:text-white cursor-pointer">
-          <input v-model="form.audience_type" type="radio" value="tags" class="accent-violet-600" />
+          <input v-model="form.audience_type" type="radio" value="tags" class="accent-blue-700 dark:accent-blue-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]" />
           Contacts with any of these tags
         </label>
         <div v-if="form.audience_type === 'tags'" class="pl-6">
@@ -83,10 +83,10 @@
               v-for="tag in tags"
               :key="tag.tag"
               type="button"
-              class="px-3 py-1.5 rounded-full border text-xs font-medium transition-all duration-200"
+              class="px-3 py-1.5 rounded-full border text-xs font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]"
               :class="isTagSelected(tag.tag)
-                ? 'border-violet-300 dark:border-violet-400/50 bg-violet-100/80 dark:bg-violet-400/20 text-violet-800 dark:text-violet-200'
-                : 'border-blue-200/70 dark:border-white/[0.12] bg-white dark:bg-white/[0.04] text-blue-950/70 dark:text-blue-100/70 hover:border-violet-200 dark:hover:border-violet-400/30'"
+                ? 'border-blue-300/80 dark:border-blue-400/40 bg-blue-100/80 dark:bg-blue-400/20 text-blue-900 dark:text-blue-200'
+                : 'border-blue-200/70 dark:border-white/[0.12] bg-white dark:bg-white/[0.04] text-blue-950/70 dark:text-blue-100/70 hover:border-blue-300/70 dark:hover:border-blue-400/30'"
               @click="toggleTag(tag.tag)"
             >
               {{ tag.tag }} <span class="opacity-60">· {{ tag.count }}</span>
@@ -104,7 +104,7 @@
     <div class="flex items-center justify-end gap-3 pt-1">
       <button type="button" :class="ui.secondaryBtn" @click="$emit('cancel')">Cancel</button>
       <button type="submit" :class="ui.primaryBtn" :disabled="busy || !isValid">
-        <i v-if="busy" class="fas fa-circle-notch animate-spin"></i>
+        <i v-if="busy" class="fas fa-circle-notch animate-spin motion-reduce:animate-none"></i>
         {{ submitLabel }}
       </button>
     </div>

--- a/frontend/vuejs/src/apps/imagi/marketing/components/MarketingModal.vue
+++ b/frontend/vuejs/src/apps/imagi/marketing/components/MarketingModal.vue
@@ -12,7 +12,7 @@
 
       <!-- Panel -->
       <div
-        class="relative w-full max-h-[88vh] overflow-y-auto crisp-card rounded-2xl bg-white dark:bg-[#211b16] border border-blue-200/70 dark:border-blue-300/[0.16] p-6"
+        class="relative w-full max-h-[88vh] overflow-y-auto crisp-card rounded-2xl bg-white dark:bg-[#16161a] border border-blue-200/70 dark:border-blue-300/[0.16] p-6"
         :class="wide ? 'max-w-2xl' : 'max-w-lg'"
         role="dialog"
         aria-modal="true"
@@ -21,7 +21,7 @@
           <h3 class="text-lg font-semibold text-blue-950 dark:text-white transition-colors duration-300">{{ title }}</h3>
           <button
             type="button"
-            class="w-8 h-8 -mt-1 -mr-1 rounded-lg flex items-center justify-center text-blue-950/50 dark:text-white/50 hover:text-blue-950 dark:hover:text-white hover:bg-blue-50 dark:hover:bg-white/[0.08] transition-colors duration-200"
+            class="w-8 h-8 -mt-1 -mr-1 rounded-lg flex items-center justify-center text-blue-950/50 dark:text-blue-100/50 hover:text-blue-950 dark:hover:text-white hover:bg-blue-50 dark:hover:bg-white/[0.08] transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#16161a]"
             aria-label="Close"
             @click="$emit('close')"
           >

--- a/frontend/vuejs/src/apps/imagi/marketing/components/StatusBadge.vue
+++ b/frontend/vuejs/src/apps/imagi/marketing/components/StatusBadge.vue
@@ -6,7 +6,7 @@
     class="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-full border text-[11px] font-semibold uppercase tracking-[0.1em] whitespace-nowrap transition-colors duration-300"
     :class="colorClasses"
   >
-    <span v-if="pulse" class="w-1.5 h-1.5 rounded-full bg-current animate-pulse"></span>
+    <span v-if="pulse" class="w-1.5 h-1.5 rounded-full bg-current animate-pulse motion-reduce:animate-none"></span>
     {{ label }}
   </span>
 </template>
@@ -44,6 +44,6 @@ const colorClasses = computed(() => {
     return 'border-amber-200/80 dark:border-amber-400/25 bg-amber-50/80 dark:bg-amber-400/10 text-amber-700 dark:text-amber-300'
   }
   // draft, canceled, unknown
-  return 'border-blue-950/10 dark:border-white/15 bg-blue-950/[0.03] dark:bg-white/[0.04] text-blue-950/60 dark:text-white/60'
+  return 'border-blue-950/10 dark:border-white/15 bg-blue-950/[0.03] dark:bg-white/[0.04] text-blue-950/60 dark:text-blue-100/60'
 })
 </script>

--- a/frontend/vuejs/src/apps/imagi/marketing/utils/ui.ts
+++ b/frontend/vuejs/src/apps/imagi/marketing/utils/ui.ts
@@ -1,25 +1,26 @@
 /**
  * Shared Tailwind class strings for the Marketing workspace, so every view
- * uses the same design language as the project hub (crisp cards, blue-950
- * ink, violet accent). Keep these as full static strings for the JIT compiler.
+ * uses the same design language as the home page (warm porcelain editorial:
+ * crisp cards, blue-950 ink, navy pill buttons). Keep these as full static
+ * strings for the JIT compiler.
  */
 
 export const ui = {
-  card: 'crisp-card rounded-2xl bg-white dark:bg-white/[0.05] border border-blue-200/70 dark:border-blue-300/[0.16] transition-colors duration-300',
+  card: 'crisp-card rounded-2xl bg-white/85 dark:bg-white/[0.045] backdrop-blur-sm border border-blue-200/70 dark:border-blue-300/[0.14] transition-colors duration-300',
 
-  label: 'block text-xs font-semibold uppercase tracking-[0.14em] text-blue-950/60 dark:text-blue-100/60 mb-1.5 transition-colors duration-300',
+  label: 'block text-xs font-semibold uppercase tracking-[0.14em] text-blue-950/70 dark:text-blue-100/55 mb-1.5 transition-colors duration-300',
 
-  input: 'w-full px-3.5 py-2.5 rounded-xl bg-white dark:bg-white/[0.06] border border-blue-200/70 dark:border-white/[0.12] text-blue-950 dark:text-white text-sm placeholder-blue-950/40 dark:placeholder-white/30 focus:outline-none focus:ring-2 focus:ring-violet-400/40 focus:border-violet-300 dark:focus:border-violet-400/40 transition-colors duration-200',
+  input: 'w-full px-3.5 py-2.5 rounded-xl bg-white dark:bg-white/[0.06] border border-blue-200/70 dark:border-white/[0.12] text-blue-950 dark:text-white text-sm placeholder-blue-950/40 dark:placeholder-blue-100/30 focus:outline-none focus:ring-2 focus:ring-blue-500/40 dark:focus:ring-blue-300/50 focus:border-blue-300 dark:focus:border-blue-400/40 transition-colors duration-200',
 
-  primaryBtn: 'inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl bg-violet-600 hover:bg-violet-500 text-white text-sm font-medium transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed',
+  primaryBtn: 'inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-full bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white text-sm font-medium transition-colors duration-200 shadow-[0_1px_2px_rgba(23,37,84,0.2),0_3px_8px_-2px_rgba(23,37,84,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e] disabled:opacity-50 disabled:cursor-not-allowed',
 
-  secondaryBtn: 'inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl bg-white dark:bg-white/[0.06] hover:bg-blue-50 dark:hover:bg-white/[0.1] border border-blue-200/70 dark:border-white/[0.12] text-blue-950 dark:text-white text-sm font-medium transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed',
+  secondaryBtn: 'inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-full border border-blue-950/[0.14] text-blue-950/80 hover:text-blue-950 hover:border-blue-950/30 hover:bg-blue-950/[0.03] dark:border-white/[0.16] dark:text-blue-100/80 dark:hover:text-white dark:hover:border-white/30 dark:hover:bg-white/[0.06] text-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e] disabled:opacity-50 disabled:cursor-not-allowed',
 
-  dangerBtn: 'inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl bg-white dark:bg-white/[0.06] hover:bg-red-50 dark:hover:bg-red-500/10 border border-red-200/80 dark:border-red-400/25 text-red-600 dark:text-red-300 text-sm font-medium transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed',
+  dangerBtn: 'inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-full border border-red-200/80 dark:border-red-400/25 text-red-600 dark:text-red-300 hover:border-red-300 dark:hover:border-red-400/40 hover:bg-red-50 dark:hover:bg-red-500/10 text-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e] disabled:opacity-50 disabled:cursor-not-allowed',
 
-  iconTile: 'rounded-xl flex items-center justify-center border bg-violet-50 dark:bg-violet-400/10 border-violet-200/60 dark:border-violet-400/25 text-violet-600 dark:text-violet-300 transition-colors duration-300',
+  iconTile: 'rounded-xl flex items-center justify-center ring-1 bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] dark:from-blue-400/[0.18] dark:to-blue-500/[0.22] ring-blue-900/[0.08] dark:ring-blue-300/[0.18] text-blue-600 dark:text-blue-300 transition-colors duration-300',
 
-  sectionBadge: 'inline-flex items-center px-3 py-1 rounded-full border border-violet-200/70 dark:border-violet-400/25 bg-violet-50/80 dark:bg-violet-400/10 text-xs font-semibold uppercase tracking-[0.18em] text-violet-700 dark:text-violet-300 transition-colors duration-300',
+  sectionBadge: 'inline-flex items-center px-3 py-1 rounded-full border border-blue-200/70 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 text-xs font-semibold uppercase tracking-[0.18em] text-blue-700 dark:text-blue-300 transition-colors duration-300',
 
   errorBox: 'p-3.5 rounded-xl border border-red-200/80 dark:border-red-400/25 bg-red-50/80 dark:bg-red-500/10 text-sm text-red-700 dark:text-red-300',
 

--- a/frontend/vuejs/src/apps/imagi/marketing/views/MarketingAds.vue
+++ b/frontend/vuejs/src/apps/imagi/marketing/views/MarketingAds.vue
@@ -10,7 +10,7 @@
   <div>
     <!-- Loading -->
     <div v-if="initialLoading" class="flex justify-center py-16">
-      <div class="w-6 h-6 border-2 border-violet-200 dark:border-violet-300/30 border-t-violet-600 dark:border-t-violet-300 rounded-full animate-spin"></div>
+      <div class="w-6 h-6 border-2 border-blue-200 dark:border-blue-300/30 border-t-blue-700 dark:border-t-blue-300 rounded-full animate-spin motion-reduce:animate-none"></div>
     </div>
 
     <!-- Nothing connected yet -->
@@ -29,7 +29,7 @@
           Connect ad accounts
         </router-link>
       </div>
-      <div class="flex items-center justify-center gap-6 mt-7 text-blue-950/40 dark:text-white/40">
+      <div class="flex items-center justify-center gap-6 mt-7 text-blue-950/40 dark:text-blue-100/40">
         <span class="inline-flex items-center gap-2 text-sm"><i class="fab fa-google"></i> Google Ads</span>
         <span class="inline-flex items-center gap-2 text-sm"><i class="fab fa-meta"></i> Meta Ads</span>
       </div>
@@ -40,7 +40,7 @@
       <section v-if="summary" class="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
         <div v-for="stat in statCards" :key="stat.label" class="p-5" :class="ui.card">
           <div class="flex items-center gap-2 mb-2">
-            <i :class="['fas', stat.icon]" class="text-xs text-violet-600 dark:text-violet-300"></i>
+            <i :class="['fas', stat.icon]" class="text-xs text-blue-700 dark:text-blue-300"></i>
             <p class="text-xs font-semibold uppercase tracking-[0.14em] text-blue-950/50 dark:text-blue-100/50">{{ stat.label }}</p>
           </div>
           <p class="text-2xl font-semibold text-blue-950 dark:text-white tabular-nums">{{ stat.value }}</p>
@@ -55,9 +55,9 @@
             v-for="option in providerFilters"
             :key="option.value"
             type="button"
-            class="px-3.5 py-2 rounded-xl text-sm font-medium border transition-colors duration-200"
+            class="px-3.5 py-2 rounded-full text-sm font-medium border transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
             :class="providerFilter === option.value
-              ? 'border-violet-300 dark:border-violet-400/40 bg-violet-50 dark:bg-violet-400/10 text-violet-800 dark:text-violet-200'
+              ? 'border-blue-300/80 dark:border-blue-400/40 bg-blue-100/80 dark:bg-blue-400/20 text-blue-900 dark:text-blue-200'
               : 'border-blue-200/70 dark:border-white/[0.12] bg-white dark:bg-white/[0.06] text-blue-950/70 dark:text-blue-100/70 hover:text-blue-950 dark:hover:text-white'"
             @click="setProviderFilter(option.value)"
           >
@@ -70,7 +70,7 @@
           Synced {{ formatDateTime(summary.last_synced_at) }}
         </p>
         <button type="button" :class="ui.secondaryBtn" :disabled="store.adsSyncing" @click="sync">
-          <i :class="['fas', store.adsSyncing ? 'fa-circle-notch animate-spin' : 'fa-rotate']" class="text-xs"></i>
+          <i :class="['fas', store.adsSyncing ? 'fa-circle-notch animate-spin motion-reduce:animate-none' : 'fa-rotate']" class="text-xs"></i>
           {{ store.adsSyncing ? 'Syncing…' : 'Sync now' }}
         </button>
       </section>
@@ -81,7 +81,7 @@
       <!-- Campaign table -->
       <section :class="ui.card">
         <div v-if="store.adCampaignsLoading && !campaigns.length" class="flex justify-center py-16">
-          <div class="w-6 h-6 border-2 border-violet-200 dark:border-violet-300/30 border-t-violet-600 dark:border-t-violet-300 rounded-full animate-spin"></div>
+          <div class="w-6 h-6 border-2 border-blue-200 dark:border-blue-300/30 border-t-blue-700 dark:border-t-blue-300 rounded-full animate-spin motion-reduce:animate-none"></div>
         </div>
 
         <div v-else-if="campaigns.length" class="overflow-x-auto">
@@ -108,7 +108,7 @@
               >
                 <td class="px-5 py-3.5">
                   <div class="flex items-center gap-3 min-w-0">
-                    <i :class="AD_PROVIDERS[campaign.provider].icon" class="text-blue-950/50 dark:text-white/50 shrink-0" :title="AD_PROVIDERS[campaign.provider].label"></i>
+                    <i :class="AD_PROVIDERS[campaign.provider].icon" class="text-blue-950/50 dark:text-blue-100/50 shrink-0" :title="AD_PROVIDERS[campaign.provider].label"></i>
                     <div class="min-w-0">
                       <p class="font-medium text-blue-950 dark:text-white truncate max-w-56" :title="campaign.name">{{ campaign.name }}</p>
                       <p v-if="campaign.objective" class="text-xs text-blue-950/50 dark:text-blue-100/50 truncate">{{ formatObjective(campaign.objective) }}</p>
@@ -128,18 +128,18 @@
                     <button
                       v-if="campaign.status === 'active' || campaign.status === 'paused'"
                       type="button"
-                      class="w-8 h-8 rounded-lg flex items-center justify-center text-blue-950/50 dark:text-white/50 hover:text-blue-950 dark:hover:text-white hover:bg-blue-50 dark:hover:bg-white/[0.08] transition-colors duration-150 disabled:opacity-40"
+                      class="w-8 h-8 rounded-lg flex items-center justify-center text-blue-950/50 dark:text-blue-100/50 hover:text-blue-950 dark:hover:text-white hover:bg-blue-50 dark:hover:bg-white/[0.08] transition-colors duration-150 disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]"
                       :title="campaign.status === 'active' ? 'Pause campaign' : 'Resume campaign'"
                       :disabled="togglingId === campaign.id"
                       @click="toggle(campaign)"
                     >
-                      <i :class="['fas', togglingId === campaign.id ? 'fa-circle-notch animate-spin' : campaign.status === 'active' ? 'fa-pause' : 'fa-play']" class="text-xs"></i>
+                      <i :class="['fas', togglingId === campaign.id ? 'fa-circle-notch animate-spin motion-reduce:animate-none' : campaign.status === 'active' ? 'fa-pause' : 'fa-play']" class="text-xs"></i>
                     </button>
                     <a
                       :href="campaign.manager_url"
                       target="_blank"
                       rel="noopener noreferrer"
-                      class="w-8 h-8 rounded-lg flex items-center justify-center text-blue-950/50 dark:text-white/50 hover:text-blue-950 dark:hover:text-white hover:bg-blue-50 dark:hover:bg-white/[0.08] transition-colors duration-150"
+                      class="w-8 h-8 rounded-lg flex items-center justify-center text-blue-950/50 dark:text-blue-100/50 hover:text-blue-950 dark:hover:text-white hover:bg-blue-50 dark:hover:bg-white/[0.08] transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]"
                       :title="`Open in ${AD_PROVIDERS[campaign.provider].consoleLabel}`"
                     >
                       <i class="fas fa-arrow-up-right-from-square text-xs"></i>
@@ -158,7 +158,7 @@
               : 'No campaigns synced yet. Pull them in from your connected ad accounts.' }}
           </p>
           <button type="button" :class="ui.primaryBtn" :disabled="store.adsSyncing" @click="sync">
-            <i :class="['fas', store.adsSyncing ? 'fa-circle-notch animate-spin' : 'fa-rotate']" class="text-xs"></i>
+            <i :class="['fas', store.adsSyncing ? 'fa-circle-notch animate-spin motion-reduce:animate-none' : 'fa-rotate']" class="text-xs"></i>
             Sync campaigns
           </button>
         </div>
@@ -167,9 +167,9 @@
       <!-- Where ads are created -->
       <p class="text-xs text-blue-950/50 dark:text-blue-100/50 mt-4">
         New campaigns are created in
-        <a href="https://ads.google.com" target="_blank" rel="noopener noreferrer" class="text-violet-700 dark:text-violet-300 hover:underline">Google Ads</a>
+        <a href="https://ads.google.com" target="_blank" rel="noopener noreferrer" class="text-blue-700 dark:text-blue-300 hover:underline rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]">Google Ads</a>
         or
-        <a href="https://adsmanager.facebook.com" target="_blank" rel="noopener noreferrer" class="text-violet-700 dark:text-violet-300 hover:underline">Meta Ads Manager</a>
+        <a href="https://adsmanager.facebook.com" target="_blank" rel="noopener noreferrer" class="text-blue-700 dark:text-blue-300 hover:underline rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]">Meta Ads Manager</a>
         — once live, they appear here on the next sync.
       </p>
     </template>

--- a/frontend/vuejs/src/apps/imagi/marketing/views/MarketingAudience.vue
+++ b/frontend/vuejs/src/apps/imagi/marketing/views/MarketingAudience.vue
@@ -8,7 +8,7 @@
     <!-- Toolbar -->
     <div class="flex flex-col lg:flex-row lg:items-center gap-3 mb-6">
       <div class="relative flex-1">
-        <i class="fas fa-magnifying-glass absolute left-3.5 top-1/2 -translate-y-1/2 text-xs text-blue-950/40 dark:text-white/30"></i>
+        <i class="fas fa-magnifying-glass absolute left-3.5 top-1/2 -translate-y-1/2 text-xs text-blue-950/40 dark:text-blue-100/30"></i>
         <input
           v-model="search"
           type="search"
@@ -41,7 +41,7 @@
 
     <!-- Loading -->
     <div v-if="store.contactsLoading && !store.contacts.length" class="flex justify-center py-16">
-      <div class="w-6 h-6 border-2 border-violet-200 dark:border-violet-300/30 border-t-violet-600 dark:border-t-violet-300 rounded-full animate-spin"></div>
+      <div class="w-6 h-6 border-2 border-blue-200 dark:border-blue-300/30 border-t-blue-700 dark:border-t-blue-300 rounded-full animate-spin motion-reduce:animate-none"></div>
     </div>
 
     <!-- Table -->
@@ -62,7 +62,7 @@
             <tr
               v-for="contact in store.contacts"
               :key="contact.id"
-              class="border-b border-blue-200/40 dark:border-white/[0.05] last:border-b-0 hover:bg-violet-50/40 dark:hover:bg-violet-400/[0.05] transition-colors duration-150"
+              class="border-b border-blue-200/40 dark:border-white/[0.05] last:border-b-0 hover:bg-blue-50/40 dark:hover:bg-blue-400/[0.05] transition-colors duration-150"
             >
               <td class="px-5 py-3.5">
                 <p class="font-medium text-blue-950 dark:text-white">{{ contact.display_name }}</p>
@@ -74,11 +74,11 @@
                   <span
                     v-for="tag in contact.tags"
                     :key="tag"
-                    class="px-2 py-0.5 rounded-full border border-violet-200/70 dark:border-violet-400/25 bg-violet-50/80 dark:bg-violet-400/10 text-[11px] font-medium text-violet-700 dark:text-violet-300"
+                    class="px-2 py-0.5 rounded-full border border-blue-200/70 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 text-[11px] font-medium text-blue-700 dark:text-blue-300"
                   >
                     {{ tag }}
                   </span>
-                  <span v-if="!contact.tags.length" class="text-xs text-blue-950/40 dark:text-white/30">—</span>
+                  <span v-if="!contact.tags.length" class="text-xs text-blue-950/40 dark:text-blue-100/30">—</span>
                 </div>
               </td>
               <td class="px-5 py-3.5"><StatusBadge :status="contact.consent" /></td>
@@ -88,14 +88,14 @@
                   <router-link
                     v-if="contact.consent === 'subscribed'"
                     :to="{ name: 'marketing-inbox', params: { projectName: route.params.projectName }, query: { contact: contact.id } }"
-                    class="w-8 h-8 rounded-lg flex items-center justify-center text-blue-950/50 dark:text-white/50 hover:text-violet-700 dark:hover:text-violet-300 hover:bg-violet-50 dark:hover:bg-violet-400/10 transition-colors duration-150"
+                    class="w-8 h-8 rounded-lg flex items-center justify-center text-blue-950/50 dark:text-blue-100/50 hover:text-blue-700 dark:hover:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-400/10 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]"
                     title="Send a message"
                   >
                     <i class="fas fa-paper-plane text-xs"></i>
                   </router-link>
                   <button
                     type="button"
-                    class="w-8 h-8 rounded-lg flex items-center justify-center text-blue-950/50 dark:text-white/50 hover:text-blue-950 dark:hover:text-white hover:bg-blue-50 dark:hover:bg-white/[0.08] transition-colors duration-150"
+                    class="w-8 h-8 rounded-lg flex items-center justify-center text-blue-950/50 dark:text-blue-100/50 hover:text-blue-950 dark:hover:text-white hover:bg-blue-50 dark:hover:bg-white/[0.08] transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]"
                     title="Edit contact"
                     @click="openEdit(contact)"
                   >
@@ -103,7 +103,7 @@
                   </button>
                   <button
                     type="button"
-                    class="w-8 h-8 rounded-lg flex items-center justify-center text-blue-950/50 dark:text-white/50 hover:text-red-600 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-500/10 transition-colors duration-150"
+                    class="w-8 h-8 rounded-lg flex items-center justify-center text-blue-950/50 dark:text-blue-100/50 hover:text-red-600 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-500/10 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]"
                     title="Delete contact"
                     @click="removeContact(contact)"
                   >
@@ -182,7 +182,7 @@
         </div>
         <div v-if="editingContact">
           <label class="flex items-center gap-2.5 text-sm text-blue-950 dark:text-white cursor-pointer">
-            <input v-model="form.subscribed" type="checkbox" class="accent-violet-600" />
+            <input v-model="form.subscribed" type="checkbox" class="accent-blue-700 dark:accent-blue-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#16161a]" />
             Subscribed to messages
           </label>
         </div>
@@ -195,7 +195,7 @@
         <div class="flex items-center justify-end gap-3 pt-1">
           <button type="button" :class="ui.secondaryBtn" @click="closeForm">Cancel</button>
           <button type="submit" :class="ui.primaryBtn" :disabled="formBusy || !form.phone_number.trim()">
-            <i v-if="formBusy" class="fas fa-circle-notch animate-spin"></i>
+            <i v-if="formBusy" class="fas fa-circle-notch animate-spin motion-reduce:animate-none"></i>
             {{ editingContact ? 'Save changes' : 'Add contact' }}
           </button>
         </div>
@@ -246,7 +246,7 @@
             :disabled="importBusy || !parsedImportRows.length"
             @click="runImport"
           >
-            <i v-if="importBusy" class="fas fa-circle-notch animate-spin"></i>
+            <i v-if="importBusy" class="fas fa-circle-notch animate-spin motion-reduce:animate-none"></i>
             Import {{ parsedImportRows.length || '' }} contact{{ parsedImportRows.length === 1 ? '' : 's' }}
           </button>
         </div>

--- a/frontend/vuejs/src/apps/imagi/marketing/views/MarketingCampaignDetail.vue
+++ b/frontend/vuejs/src/apps/imagi/marketing/views/MarketingCampaignDetail.vue
@@ -9,7 +9,7 @@
   <div>
     <router-link
       :to="{ name: 'marketing-campaigns', params: { projectName: route.params.projectName } }"
-      class="inline-flex items-center gap-2 text-sm font-medium text-blue-950/60 dark:text-blue-100/60 hover:text-blue-950 dark:hover:text-white transition-colors duration-200 mb-5"
+      class="inline-flex items-center gap-2 text-sm font-medium text-blue-950/60 dark:text-blue-100/60 hover:text-blue-950 dark:hover:text-white transition-colors duration-200 mb-5 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
     >
       <i class="fas fa-arrow-left text-xs"></i>
       <span>All campaigns</span>
@@ -17,7 +17,7 @@
 
     <!-- Loading -->
     <div v-if="loading" class="flex justify-center py-16">
-      <div class="w-6 h-6 border-2 border-violet-200 dark:border-violet-300/30 border-t-violet-600 dark:border-t-violet-300 rounded-full animate-spin"></div>
+      <div class="w-6 h-6 border-2 border-blue-200 dark:border-blue-300/30 border-t-blue-700 dark:border-t-blue-300 rounded-full animate-spin motion-reduce:animate-none"></div>
     </div>
 
     <div v-else-if="loadError" :class="ui.errorBox">{{ loadError }}</div>
@@ -47,7 +47,7 @@
             :disabled="acting"
             @click="sync"
           >
-            <i class="fas fa-rotate text-xs" :class="{ 'animate-spin': acting }"></i>
+            <i class="fas fa-rotate text-xs" :class="{ 'animate-spin motion-reduce:animate-none': acting }"></i>
             Refresh statuses
           </button>
           <button
@@ -57,7 +57,7 @@
             :disabled="acting"
             @click="sync"
           >
-            <i class="fas fa-rotate text-xs" :class="{ 'animate-spin': acting }"></i>
+            <i class="fas fa-rotate text-xs" :class="{ 'animate-spin motion-reduce:animate-none': acting }"></i>
             Refresh statuses
           </button>
           <button

--- a/frontend/vuejs/src/apps/imagi/marketing/views/MarketingCampaigns.vue
+++ b/frontend/vuejs/src/apps/imagi/marketing/views/MarketingCampaigns.vue
@@ -12,9 +12,9 @@
           v-for="option in statusFilters"
           :key="option.value"
           type="button"
-          class="px-3.5 py-1.5 rounded-full border text-xs font-semibold transition-all duration-200"
+          class="px-3.5 py-1.5 rounded-full border text-xs font-semibold transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
           :class="statusFilter === option.value
-            ? 'border-violet-300 dark:border-violet-400/50 bg-violet-100/80 dark:bg-violet-400/20 text-violet-800 dark:text-violet-200'
+            ? 'border-blue-300/80 dark:border-blue-400/40 bg-blue-100/80 dark:bg-blue-400/20 text-blue-900 dark:text-blue-200'
             : 'border-blue-200/70 dark:border-white/[0.12] bg-white dark:bg-white/[0.04] text-blue-950/60 dark:text-blue-100/60 hover:text-blue-950 dark:hover:text-white'"
           @click="setStatusFilter(option.value)"
         >
@@ -29,7 +29,7 @@
 
     <!-- Loading -->
     <div v-if="store.campaignsLoading && !store.campaigns.length" class="flex justify-center py-16">
-      <div class="w-6 h-6 border-2 border-violet-200 dark:border-violet-300/30 border-t-violet-600 dark:border-t-violet-300 rounded-full animate-spin"></div>
+      <div class="w-6 h-6 border-2 border-blue-200 dark:border-blue-300/30 border-t-blue-700 dark:border-t-blue-300 rounded-full animate-spin motion-reduce:animate-none"></div>
     </div>
 
     <!-- List -->
@@ -38,7 +38,7 @@
         v-for="campaign in store.campaigns"
         :key="campaign.id"
         :to="{ name: 'marketing-campaign-detail', params: { projectName: route.params.projectName, campaignId: campaign.id } }"
-        class="flex flex-col sm:flex-row sm:items-center gap-4 p-5 group"
+        class="flex flex-col sm:flex-row sm:items-center gap-4 p-5 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
         :class="ui.card"
       >
         <div class="flex items-center gap-4 flex-1 min-w-0">
@@ -46,7 +46,7 @@
             <i :class="['fas', campaign.channel === 'voice' ? 'fa-phone-volume' : 'fa-comment-sms']"></i>
           </div>
           <div class="min-w-0">
-            <p class="text-base font-semibold text-blue-950 dark:text-white truncate group-hover:text-violet-800 dark:group-hover:text-violet-200 transition-colors duration-200">
+            <p class="text-base font-semibold text-blue-950 dark:text-white truncate group-hover:text-blue-800 dark:group-hover:text-blue-200 transition-colors duration-200">
               {{ campaign.name }}
             </p>
             <p class="text-sm text-blue-950/60 dark:text-blue-100/60 truncate">{{ campaign.body }}</p>
@@ -64,7 +64,7 @@
             <p class="text-xs text-blue-950/50 dark:text-blue-100/50">{{ campaign.scheduled_at ? 'scheduled for' : 'created' }}</p>
           </div>
           <StatusBadge :status="campaign.status" />
-          <i class="fas fa-chevron-right text-xs text-blue-950/30 dark:text-white/30 group-hover:translate-x-0.5 transition-transform duration-200"></i>
+          <i class="fas fa-chevron-right text-xs text-blue-950/30 dark:text-blue-100/30 group-hover:translate-x-0.5 transition-transform duration-200"></i>
         </div>
       </router-link>
     </div>

--- a/frontend/vuejs/src/apps/imagi/marketing/views/MarketingInbox.vue
+++ b/frontend/vuejs/src/apps/imagi/marketing/views/MarketingInbox.vue
@@ -6,7 +6,7 @@
   <div>
     <!-- Loading -->
     <div v-if="store.conversationsLoading && !store.conversations.length" class="flex justify-center py-16">
-      <div class="w-6 h-6 border-2 border-violet-200 dark:border-violet-300/30 border-t-violet-600 dark:border-t-violet-300 rounded-full animate-spin"></div>
+      <div class="w-6 h-6 border-2 border-blue-200 dark:border-blue-300/30 border-t-blue-700 dark:border-t-blue-300 rounded-full animate-spin motion-reduce:animate-none"></div>
     </div>
 
     <!-- Empty -->
@@ -39,11 +39,11 @@
           <h2 class="text-sm font-semibold text-blue-950 dark:text-white">Conversations</h2>
           <button
             type="button"
-            class="w-8 h-8 rounded-lg flex items-center justify-center text-blue-950/50 dark:text-white/50 hover:text-blue-950 dark:hover:text-white hover:bg-blue-50 dark:hover:bg-white/[0.08] transition-colors duration-150"
+            class="w-8 h-8 rounded-lg flex items-center justify-center text-blue-950/50 dark:text-blue-100/50 hover:text-blue-950 dark:hover:text-white hover:bg-blue-50 dark:hover:bg-white/[0.08] transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]"
             title="Refresh"
             @click="refresh"
           >
-            <i class="fas fa-rotate text-xs" :class="{ 'animate-spin': store.conversationsLoading }"></i>
+            <i class="fas fa-rotate text-xs" :class="{ 'animate-spin motion-reduce:animate-none': store.conversationsLoading }"></i>
           </button>
         </div>
         <div class="overflow-y-auto flex-1">
@@ -51,13 +51,13 @@
             v-for="conversation in store.conversations"
             :key="conversation.id"
             type="button"
-            class="w-full flex items-start gap-3 px-4 py-3.5 text-left border-b border-blue-200/40 dark:border-white/[0.05] last:border-b-0 transition-colors duration-150"
+            class="w-full flex items-start gap-3 px-4 py-3.5 text-left border-b border-blue-200/40 dark:border-white/[0.05] last:border-b-0 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50"
             :class="selectedId === conversation.id
-              ? 'bg-violet-50/80 dark:bg-violet-400/10'
+              ? 'bg-blue-50/80 dark:bg-blue-400/10'
               : 'hover:bg-blue-50/60 dark:hover:bg-white/[0.04]'"
             @click="selectConversation(conversation.id)"
           >
-            <div class="w-9 h-9 shrink-0 rounded-full flex items-center justify-center bg-violet-100 dark:bg-violet-400/20 text-violet-700 dark:text-violet-200 text-xs font-semibold uppercase">
+            <div class="w-9 h-9 shrink-0 rounded-full flex items-center justify-center bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] dark:from-blue-400/[0.18] dark:to-blue-500/[0.22] ring-1 ring-blue-900/[0.08] dark:ring-blue-300/[0.18] text-blue-700 dark:text-blue-200 text-xs font-semibold uppercase">
               {{ initials(conversation.display_name) }}
             </div>
             <div class="flex-1 min-w-0">
@@ -91,7 +91,7 @@
           <!-- Messages -->
           <div ref="threadPane" class="flex-1 overflow-y-auto px-5 py-4 space-y-3">
             <div v-if="threadLoading" class="flex justify-center py-8">
-              <div class="w-5 h-5 border-2 border-violet-200 dark:border-violet-300/30 border-t-violet-600 dark:border-t-violet-300 rounded-full animate-spin"></div>
+              <div class="w-5 h-5 border-2 border-blue-200 dark:border-blue-300/30 border-t-blue-700 dark:border-t-blue-300 rounded-full animate-spin motion-reduce:animate-none"></div>
             </div>
             <template v-else>
               <div
@@ -104,7 +104,7 @@
                   <div
                     class="px-3.5 py-2.5 rounded-2xl text-sm whitespace-pre-wrap break-words"
                     :class="message.direction === 'outbound'
-                      ? 'bg-violet-600 text-white rounded-br-md'
+                      ? 'bg-blue-950 text-[#fdf9f2] dark:bg-[#f3ede2] dark:text-blue-950 rounded-br-md'
                       : 'bg-blue-50 dark:bg-white/[0.08] text-blue-950 dark:text-white border border-blue-200/60 dark:border-white/[0.08] rounded-bl-md'"
                   >
                     <span v-if="message.channel === 'voice'" class="block text-[11px] uppercase tracking-wide opacity-70 mb-0.5">
@@ -141,7 +141,7 @@
                 @keydown.enter.exact.prevent="sendReply"
               ></textarea>
               <button type="submit" :class="ui.primaryBtn" :disabled="sending || !replyText.trim()">
-                <i :class="['fas', sending ? 'fa-circle-notch animate-spin' : 'fa-paper-plane']" class="text-xs"></i>
+                <i :class="['fas', sending ? 'fa-circle-notch animate-spin motion-reduce:animate-none' : 'fa-paper-plane']" class="text-xs"></i>
                 Send
               </button>
             </form>
@@ -150,7 +150,7 @@
         </template>
 
         <div v-else class="flex-1 flex flex-col items-center justify-center py-16 text-center px-6">
-          <i class="fas fa-comments text-2xl text-blue-950/20 dark:text-white/20 mb-4"></i>
+          <i class="fas fa-comments text-2xl text-blue-950/20 dark:text-blue-100/20 mb-4"></i>
           <p class="text-sm text-blue-950/60 dark:text-blue-100/60">Select a conversation to read and reply.</p>
         </div>
       </section>

--- a/frontend/vuejs/src/apps/imagi/marketing/views/MarketingOverview.vue
+++ b/frontend/vuejs/src/apps/imagi/marketing/views/MarketingOverview.vue
@@ -6,7 +6,7 @@
   <div>
     <!-- Loading -->
     <div v-if="store.overviewLoading && !overview" class="flex justify-center py-16">
-      <div class="w-6 h-6 border-2 border-violet-200 dark:border-violet-300/30 border-t-violet-600 dark:border-t-violet-300 rounded-full animate-spin"></div>
+      <div class="w-6 h-6 border-2 border-blue-200 dark:border-blue-300/30 border-t-blue-700 dark:border-t-blue-300 rounded-full animate-spin motion-reduce:animate-none"></div>
     </div>
 
     <template v-else-if="overview">
@@ -14,7 +14,7 @@
       <section class="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
         <div v-for="stat in statCards" :key="stat.label" class="p-5" :class="ui.card">
           <div class="flex items-center gap-2 mb-2">
-            <i :class="['fas', stat.icon]" class="text-xs text-violet-600 dark:text-violet-300"></i>
+            <i :class="['fas', stat.icon]" class="text-xs text-blue-700 dark:text-blue-300"></i>
             <p class="text-xs font-semibold uppercase tracking-[0.14em] text-blue-950/50 dark:text-blue-100/50">{{ stat.label }}</p>
           </div>
           <p class="text-2xl font-semibold text-blue-950 dark:text-white tabular-nums">{{ stat.value }}</p>
@@ -43,14 +43,14 @@
         <div class="flex items-center justify-between mb-4">
           <div class="flex items-center gap-3">
             <h2 class="text-base font-semibold text-blue-950 dark:text-white">Advertising</h2>
-            <span class="flex items-center gap-2 text-blue-950/40 dark:text-white/40 text-xs">
+            <span class="flex items-center gap-2 text-blue-950/40 dark:text-blue-100/40 text-xs">
               <i v-if="ads.connected_providers.includes('google')" class="fab fa-google" title="Google Ads connected"></i>
               <i v-if="ads.connected_providers.includes('meta')" class="fab fa-meta" title="Meta Ads connected"></i>
             </span>
           </div>
           <router-link
             :to="{ name: 'marketing-ads', params: { projectName: route.params.projectName } }"
-            class="text-sm font-medium text-violet-700 dark:text-violet-300 hover:text-violet-900 dark:hover:text-violet-200 transition-colors duration-200"
+            class="text-sm font-medium text-blue-700 dark:text-blue-300 hover:text-blue-900 dark:hover:text-blue-200 transition-colors duration-200 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]"
           >
             Open ads dashboard
           </router-link>
@@ -63,7 +63,7 @@
         </div>
         <p v-else class="text-sm text-blue-950/60 dark:text-blue-100/60">
           Run ads on Google and Meta? Connect your ad accounts to watch spend and results here —
-          <router-link :to="{ name: 'marketing-settings', params: { projectName: route.params.projectName } }" class="text-violet-700 dark:text-violet-300 hover:underline">connect in settings</router-link>.
+          <router-link :to="{ name: 'marketing-settings', params: { projectName: route.params.projectName } }" class="text-blue-700 dark:text-blue-300 hover:underline rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]">connect in settings</router-link>.
         </p>
       </section>
 
@@ -74,7 +74,7 @@
             <h2 class="text-base font-semibold text-blue-950 dark:text-white">Recent campaigns</h2>
             <router-link
               :to="{ name: 'marketing-campaigns', params: { projectName: route.params.projectName } }"
-              class="text-sm font-medium text-violet-700 dark:text-violet-300 hover:text-violet-900 dark:hover:text-violet-200 transition-colors duration-200"
+              class="text-sm font-medium text-blue-700 dark:text-blue-300 hover:text-blue-900 dark:hover:text-blue-200 transition-colors duration-200 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]"
             >
               View all
             </router-link>
@@ -84,7 +84,7 @@
               v-for="campaign in overview.recent_campaigns"
               :key="campaign.id"
               :to="{ name: 'marketing-campaign-detail', params: { projectName: route.params.projectName, campaignId: campaign.id } }"
-              class="flex items-center gap-3 p-3 rounded-xl border border-blue-200/60 dark:border-white/[0.08] hover:border-violet-200 dark:hover:border-violet-400/30 hover:bg-violet-50/50 dark:hover:bg-violet-400/[0.06] transition-all duration-200"
+              class="flex items-center gap-3 p-3 rounded-xl border border-blue-200/60 dark:border-white/[0.08] hover:border-blue-300/70 dark:hover:border-blue-400/30 hover:bg-blue-50/50 dark:hover:bg-blue-400/[0.06] transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]"
             >
               <div class="w-9 h-9 shrink-0" :class="ui.iconTile">
                 <i :class="['fas', campaign.channel === 'voice' ? 'fa-phone-volume' : 'fa-comment-sms']" class="text-sm"></i>
@@ -112,7 +112,7 @@
             <h2 class="text-base font-semibold text-blue-950 dark:text-white">Latest replies</h2>
             <router-link
               :to="{ name: 'marketing-inbox', params: { projectName: route.params.projectName } }"
-              class="text-sm font-medium text-violet-700 dark:text-violet-300 hover:text-violet-900 dark:hover:text-violet-200 transition-colors duration-200"
+              class="text-sm font-medium text-blue-700 dark:text-blue-300 hover:text-blue-900 dark:hover:text-blue-200 transition-colors duration-200 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]"
             >
               Open inbox
             </router-link>

--- a/frontend/vuejs/src/apps/imagi/marketing/views/MarketingSettings.vue
+++ b/frontend/vuejs/src/apps/imagi/marketing/views/MarketingSettings.vue
@@ -20,7 +20,7 @@
       </div>
       <p class="text-sm text-blue-950/60 dark:text-blue-100/60 mb-6">
         Find these in the
-        <a href="https://console.twilio.com" target="_blank" rel="noopener noreferrer" class="text-violet-700 dark:text-violet-300 hover:underline">Twilio Console</a>.
+        <a href="https://console.twilio.com" target="_blank" rel="noopener noreferrer" class="text-blue-700 dark:text-blue-300 hover:underline rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]">Twilio Console</a>.
         Messages and calls are sent from your own Twilio account.
       </p>
 
@@ -98,7 +98,7 @@
 
         <div class="flex items-center gap-3 pt-1">
           <button type="submit" :class="ui.primaryBtn" :disabled="saving">
-            <i v-if="saving" class="fas fa-circle-notch animate-spin"></i>
+            <i v-if="saving" class="fas fa-circle-notch animate-spin motion-reduce:animate-none"></i>
             Save settings
           </button>
           <button
@@ -107,7 +107,7 @@
             :disabled="verifying || !settings?.twilio_account_sid || !settings?.twilio_auth_token_set"
             @click="verify"
           >
-            <i :class="['fas', verifying ? 'fa-circle-notch animate-spin' : 'fa-plug-circle-bolt']" class="text-xs"></i>
+            <i :class="['fas', verifying ? 'fa-circle-notch animate-spin motion-reduce:animate-none' : 'fa-plug-circle-bolt']" class="text-xs"></i>
             Test connection
           </button>
         </div>
@@ -126,7 +126,7 @@
               v-for="number in verifyResult.phone_numbers"
               :key="number.phone_number"
               type="button"
-              class="px-3 py-1.5 rounded-full border border-emerald-300/70 dark:border-emerald-400/30 bg-white/70 dark:bg-white/[0.06] font-mono text-xs hover:bg-white dark:hover:bg-white/[0.12] transition-colors duration-150"
+              class="px-3 py-1.5 rounded-full border border-emerald-300/70 dark:border-emerald-400/30 bg-white/70 dark:bg-white/[0.06] font-mono text-xs hover:bg-white dark:hover:bg-white/[0.12] transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]"
               @click="useNumber(number.phone_number)"
             >
               {{ number.phone_number }}
@@ -153,7 +153,7 @@
                 <code class="flex-1 px-3 py-2 rounded-lg bg-blue-950/[0.04] dark:bg-white/[0.06] border border-blue-200/60 dark:border-white/[0.08] font-mono text-[11px] text-blue-950/80 dark:text-blue-100/80 break-all">{{ settings.inbound_webhook_url }}</code>
                 <button
                   type="button"
-                  class="w-8 h-8 shrink-0 rounded-lg flex items-center justify-center text-blue-950/50 dark:text-white/50 hover:text-blue-950 dark:hover:text-white hover:bg-blue-50 dark:hover:bg-white/[0.08] transition-colors duration-150"
+                  class="w-8 h-8 shrink-0 rounded-lg flex items-center justify-center text-blue-950/50 dark:text-blue-100/50 hover:text-blue-950 dark:hover:text-white hover:bg-blue-50 dark:hover:bg-white/[0.08] transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]"
                   title="Copy"
                   @click="copy(settings.inbound_webhook_url)"
                 >
@@ -170,7 +170,7 @@
                 <code class="flex-1 px-3 py-2 rounded-lg bg-blue-950/[0.04] dark:bg-white/[0.06] border border-blue-200/60 dark:border-white/[0.08] font-mono text-[11px] text-blue-950/80 dark:text-blue-100/80 break-all">{{ settings.status_callback_url }}</code>
                 <button
                   type="button"
-                  class="w-8 h-8 shrink-0 rounded-lg flex items-center justify-center text-blue-950/50 dark:text-white/50 hover:text-blue-950 dark:hover:text-white hover:bg-blue-50 dark:hover:bg-white/[0.08] transition-colors duration-150"
+                  class="w-8 h-8 shrink-0 rounded-lg flex items-center justify-center text-blue-950/50 dark:text-blue-100/50 hover:text-blue-950 dark:hover:text-white hover:bg-blue-50 dark:hover:bg-white/[0.08] transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]"
                   title="Copy"
                   @click="copy(settings.status_callback_url)"
                 >
@@ -209,7 +209,7 @@
           <li class="flex gap-2.5">
             <i class="fas fa-circle-check text-emerald-600 dark:text-emerald-300 mt-0.5 text-xs"></i>
             US numbers may need
-            <a href="https://www.twilio.com/docs/messaging/compliance/a2p-10dlc" target="_blank" rel="noopener noreferrer" class="text-violet-700 dark:text-violet-300 hover:underline">A2P 10DLC registration</a>
+            <a href="https://www.twilio.com/docs/messaging/compliance/a2p-10dlc" target="_blank" rel="noopener noreferrer" class="text-blue-700 dark:text-blue-300 hover:underline rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]">A2P 10DLC registration</a>
             in Twilio for reliable delivery.
           </li>
         </ul>
@@ -222,7 +222,7 @@
     <h2 class="text-lg font-semibold text-blue-950 dark:text-white mb-1.5 transition-colors duration-300">Ad platforms</h2>
     <p class="text-sm text-blue-950/60 dark:text-blue-100/60 mb-5">
       Connect your ad accounts to watch campaign performance and pause or resume campaigns from the
-      <router-link :to="{ name: 'marketing-ads', params: { projectName: route.params.projectName } }" class="text-violet-700 dark:text-violet-300 hover:underline">Ads tab</router-link>.
+      <router-link :to="{ name: 'marketing-ads', params: { projectName: route.params.projectName } }" class="text-blue-700 dark:text-blue-300 hover:underline rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]">Ads tab</router-link>.
       Credentials are stored encrypted, and Imagi never creates or edits ads without you.
     </p>
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">

--- a/frontend/vuejs/src/apps/imagi/marketing/views/MarketingWorkspace.vue
+++ b/frontend/vuejs/src/apps/imagi/marketing/views/MarketingWorkspace.vue
@@ -9,20 +9,14 @@
 -->
 <template>
   <DefaultLayout :isHomeNav="true">
-    <div class="bg-orange-50 dark:bg-[#16120e] relative transition-colors duration-500 min-h-screen overflow-hidden">
-      <!-- Subtle background matching home page -->
-      <div class="absolute inset-0 pointer-events-none">
-        <div class="absolute inset-0 opacity-[0.015] dark:opacity-[0.02]"
-             style="background-image: linear-gradient(rgba(128,128,128,0.1) 1px, transparent 1px), linear-gradient(90deg, rgba(128,128,128,0.1) 1px, transparent 1px); background-size: 64px 64px;"></div>
-      </div>
-
+    <div class="marketing-canvas relative transition-colors duration-500 min-h-screen overflow-hidden">
       <main class="relative z-10 flex flex-col px-6 sm:px-8 lg:px-12 pt-20 pb-16 min-h-screen">
         <div class="max-w-6xl mx-auto w-full">
 
           <!-- Back link -->
           <router-link
             :to="{ name: 'project-hub', params: { projectName } }"
-            class="inline-flex items-center gap-2 text-sm font-medium text-blue-950/60 dark:text-blue-100/60 hover:text-blue-950 dark:hover:text-white transition-colors duration-200 mb-6"
+            class="inline-flex items-center gap-2 text-sm font-medium text-blue-950/60 dark:text-blue-100/60 hover:text-blue-950 dark:hover:text-white transition-colors duration-200 mb-6 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
           >
             <i class="fas fa-arrow-left text-xs"></i>
             <span>Project workspace</span>
@@ -31,7 +25,7 @@
           <!-- Loading -->
           <div v-if="isLoading" class="flex flex-col items-center justify-center py-24">
             <div class="w-12 h-12 bg-blue-50 dark:bg-white/[0.06] border border-blue-200/60 dark:border-white/[0.12] rounded-full flex items-center justify-center mb-4">
-              <div class="w-6 h-6 border-2 border-violet-200 dark:border-violet-300/30 border-t-violet-600 dark:border-t-violet-300 rounded-full animate-spin"></div>
+              <div class="w-6 h-6 border-2 border-blue-200 dark:border-blue-300/30 border-t-blue-700 dark:border-t-blue-300 rounded-full animate-spin motion-reduce:animate-none"></div>
             </div>
             <p class="text-blue-950/70 dark:text-blue-100/70 text-sm transition-colors duration-300">Loading marketing workspace...</p>
           </div>
@@ -39,7 +33,7 @@
           <!-- Not found -->
           <div v-else-if="!project" class="flex flex-col items-center justify-center py-24 text-center">
             <div class="w-16 h-16 bg-blue-50 dark:bg-white/[0.06] border border-blue-200/60 dark:border-white/[0.12] rounded-full flex items-center justify-center mb-6">
-              <i class="fas fa-folder-open text-2xl text-blue-950/40 dark:text-white/40"></i>
+              <i class="fas fa-folder-open text-2xl text-blue-950/40 dark:text-blue-100/40"></i>
             </div>
             <h2 class="text-2xl font-semibold text-blue-950 dark:text-white mb-3 transition-colors duration-300">Project not found</h2>
             <p class="text-blue-950/70 dark:text-blue-100/70 mb-8 max-w-md transition-colors duration-300">We couldn't find this project. It may have been deleted.</p>
@@ -57,7 +51,7 @@
               </div>
               <div class="min-w-0">
                 <div class="flex flex-wrap items-center gap-3 mb-1.5">
-                  <h1 class="text-3xl font-semibold text-blue-950 dark:text-white tracking-tight transition-colors duration-300">Marketing</h1>
+                  <h1 class="font-display text-3xl md:text-[2.1rem] font-semibold text-blue-950 dark:text-white tracking-[-0.02em] leading-[1.05] transition-colors duration-300">Marketing</h1>
                   <span :class="ui.sectionBadge">{{ project.name }}</span>
                 </div>
                 <p class="text-base text-blue-950/70 dark:text-blue-100/70 max-w-2xl transition-colors duration-300">
@@ -69,11 +63,11 @@
             <!-- Connect banner -->
             <div
               v-if="showConnectBanner"
-              class="flex flex-col sm:flex-row sm:items-center gap-4 p-4 rounded-2xl border border-violet-200/80 dark:border-violet-400/25 bg-violet-50/80 dark:bg-violet-400/10 mb-6 transition-colors duration-300"
+              class="flex flex-col sm:flex-row sm:items-center gap-4 p-4 rounded-2xl border border-blue-200/80 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 mb-6 transition-colors duration-300"
             >
               <div class="flex items-center gap-3 flex-1 min-w-0">
-                <i class="fas fa-plug-circle-bolt text-violet-600 dark:text-violet-300"></i>
-                <p class="text-sm text-violet-900 dark:text-violet-100">
+                <i class="fas fa-plug-circle-bolt text-blue-700 dark:text-blue-300"></i>
+                <p class="text-sm text-blue-950/80 dark:text-blue-100/80">
                   Connect your Twilio account to start sending. You'll need your Account SID, auth token, and a Twilio phone number.
                 </p>
               </div>
@@ -92,9 +86,9 @@
                 v-for="tab in tabs"
                 :key="tab.name"
                 :to="{ name: tab.name, params: { projectName } }"
-                class="inline-flex items-center gap-2 px-4 py-2.5 rounded-t-xl text-sm font-medium whitespace-nowrap border-b-2 -mb-px transition-colors duration-200"
+                class="inline-flex items-center gap-2 px-4 py-2.5 rounded-t-xl text-sm font-medium whitespace-nowrap border-b-2 -mb-px transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
                 :class="isActiveTab(tab)
-                  ? 'border-violet-500 dark:border-violet-400 text-blue-950 dark:text-white'
+                  ? 'border-blue-950 dark:border-blue-300 text-blue-950 dark:text-white'
                   : 'border-transparent text-blue-950/60 dark:text-blue-100/60 hover:text-blue-950 dark:hover:text-white'"
               >
                 <i :class="['fas', tab.icon]" class="text-xs"></i>
@@ -197,6 +191,19 @@ onMounted(loadProject)
 
 watch(() => props.projectName, loadProject)
 </script>
+
+<style scoped>
+/* Warm porcelain canvas fading to the footer's exact background (white /
+   #0a0a0a) so the page hands off seamlessly — same recipe as Home. */
+.marketing-canvas {
+  background: linear-gradient(180deg, #fdf9f2 0%, #faf7f1 60%, #ffffff 100%);
+}
+
+:root.dark .marketing-canvas,
+.dark .marketing-canvas {
+  background: linear-gradient(180deg, #0c0c0e 0%, #0a0b0f 60%, #0a0a0a 100%);
+}
+</style>
 
 <!-- Unscoped so the crisp-card treatment reaches the tab views rendered in
      the child router-view. Matches the definition used on Home/hub cards. -->

--- a/frontend/vuejs/src/apps/imagi/operate/components/CashflowChart.vue
+++ b/frontend/vuejs/src/apps/imagi/operate/components/CashflowChart.vue
@@ -24,7 +24,7 @@
       <!-- Tooltip -->
       <div
         v-if="hovered"
-        class="absolute z-10 -top-2 -translate-y-full -translate-x-1/2 px-3 py-2 rounded-xl bg-blue-950 dark:bg-[#2a241e] text-white text-xs shadow-lg whitespace-nowrap pointer-events-none"
+        class="absolute z-10 -top-2 -translate-y-full -translate-x-1/2 px-3 py-2 rounded-xl bg-blue-950 dark:bg-[#26262c] text-white text-xs shadow-lg whitespace-nowrap pointer-events-none"
         :style="{ left: `${(hoveredIndex + 0.5) / points.length * 100}%` }"
       >
         <p class="font-semibold mb-1">{{ hovered.label }}</p>
@@ -39,7 +39,7 @@
           v-for="(point, index) in points"
           :key="point.month"
           type="button"
-          class="flex-1 flex flex-col justify-end items-center group focus:outline-none"
+          class="flex-1 flex flex-col justify-end items-center group rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50"
           :aria-label="`${point.label}: income ${formatMoney(point.income)}, expenses ${formatMoney(point.expenses)}`"
           @mouseenter="hoveredIndex = index"
           @mouseleave="hoveredIndex = -1"

--- a/frontend/vuejs/src/apps/imagi/operate/components/InvoiceForm.vue
+++ b/frontend/vuejs/src/apps/imagi/operate/components/InvoiceForm.vue
@@ -74,7 +74,7 @@
           />
           <button
             type="button"
-            class="w-10 h-10 shrink-0 rounded-xl flex items-center justify-center text-blue-950/40 dark:text-white/40 hover:text-red-600 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-500/10 transition-colors duration-200 disabled:opacity-40"
+            class="w-10 h-10 shrink-0 rounded-xl flex items-center justify-center text-blue-950/40 dark:text-blue-100/40 hover:text-red-600 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-500/10 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#16161a] disabled:opacity-40"
             :disabled="form.line_items.length === 1"
             :aria-label="`Remove line item ${index + 1}`"
             @click="removeItem(index)"

--- a/frontend/vuejs/src/apps/imagi/operate/components/OperateModal.vue
+++ b/frontend/vuejs/src/apps/imagi/operate/components/OperateModal.vue
@@ -12,7 +12,7 @@
 
       <!-- Panel -->
       <div
-        class="relative w-full max-h-[88vh] overflow-y-auto crisp-card rounded-2xl bg-white dark:bg-[#211b16] border border-blue-200/70 dark:border-blue-300/[0.16] p-6"
+        class="relative w-full max-h-[88vh] overflow-y-auto crisp-card rounded-2xl bg-white dark:bg-[#16161a] border border-blue-200/70 dark:border-blue-300/[0.16] p-6"
         :class="wide ? 'max-w-2xl' : 'max-w-lg'"
         role="dialog"
         aria-modal="true"
@@ -21,7 +21,7 @@
           <h3 class="text-lg font-semibold text-blue-950 dark:text-white transition-colors duration-300">{{ title }}</h3>
           <button
             type="button"
-            class="w-8 h-8 -mt-1 -mr-1 rounded-lg flex items-center justify-center text-blue-950/50 dark:text-white/50 hover:text-blue-950 dark:hover:text-white hover:bg-blue-50 dark:hover:bg-white/[0.08] transition-colors duration-200"
+            class="w-8 h-8 -mt-1 -mr-1 rounded-lg flex items-center justify-center text-blue-950/50 dark:text-blue-100/50 hover:text-blue-950 dark:hover:text-white hover:bg-blue-50 dark:hover:bg-white/[0.08] transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#16161a]"
             aria-label="Close"
             @click="$emit('close')"
           >

--- a/frontend/vuejs/src/apps/imagi/operate/components/StatusBadge.vue
+++ b/frontend/vuejs/src/apps/imagi/operate/components/StatusBadge.vue
@@ -41,6 +41,6 @@ const colorClasses = computed(() => {
     return 'border-amber-200/80 dark:border-amber-400/25 bg-amber-50/80 dark:bg-amber-400/10 text-amber-700 dark:text-amber-300'
   }
   // draft, todo, void, unknown
-  return 'border-blue-950/10 dark:border-white/15 bg-blue-950/[0.03] dark:bg-white/[0.04] text-blue-950/60 dark:text-white/60'
+  return 'border-blue-950/10 dark:border-white/15 bg-blue-950/[0.03] dark:bg-white/[0.04] text-blue-950/60 dark:text-blue-100/60'
 })
 </script>

--- a/frontend/vuejs/src/apps/imagi/operate/components/TransactionForm.vue
+++ b/frontend/vuejs/src/apps/imagi/operate/components/TransactionForm.vue
@@ -13,9 +13,9 @@
           v-for="option in kindOptions"
           :key="option.value"
           type="button"
-          class="px-4 py-2.5 rounded-xl border text-sm font-medium transition-colors duration-200"
+          class="px-4 py-2.5 rounded-xl border text-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#16161a]"
           :class="form.kind === option.value
-            ? 'border-amber-300 dark:border-amber-400/40 bg-amber-50 dark:bg-amber-400/10 text-amber-700 dark:text-amber-300'
+            ? 'border-orange-200/70 dark:border-orange-400/25 bg-orange-50/80 dark:bg-orange-400/10 text-orange-700 dark:text-orange-300'
             : 'border-blue-200/70 dark:border-white/[0.12] text-blue-950/60 dark:text-blue-100/60 hover:text-blue-950 dark:hover:text-white'"
           @click="setKind(option.value)"
         >

--- a/frontend/vuejs/src/apps/imagi/operate/utils/ui.ts
+++ b/frontend/vuejs/src/apps/imagi/operate/utils/ui.ts
@@ -1,7 +1,8 @@
 /**
  * Shared Tailwind class strings for the Operate workspace, so every view
- * uses the same design language as the project hub (crisp cards, blue-950
- * ink, amber accent). Keep these as full static strings for the JIT compiler.
+ * uses the same design language as the home page and project hub (crisp
+ * cards, blue-950 ink, navy pill buttons, warm orange accent). Keep these
+ * as full static strings for the JIT compiler.
  */
 
 export const ui = {
@@ -9,17 +10,17 @@ export const ui = {
 
   label: 'block text-xs font-semibold uppercase tracking-[0.14em] text-blue-950/60 dark:text-blue-100/60 mb-1.5 transition-colors duration-300',
 
-  input: 'w-full px-3.5 py-2.5 rounded-xl bg-white dark:bg-white/[0.06] border border-blue-200/70 dark:border-white/[0.12] text-blue-950 dark:text-white text-sm placeholder-blue-950/40 dark:placeholder-white/30 focus:outline-none focus:ring-2 focus:ring-amber-400/40 focus:border-amber-300 dark:focus:border-amber-400/40 transition-colors duration-200',
+  input: 'w-full px-3.5 py-2.5 rounded-xl bg-white dark:bg-white/[0.06] border border-blue-200/70 dark:border-white/[0.12] text-blue-950 dark:text-white text-sm placeholder-blue-950/40 dark:placeholder-blue-100/30 focus:outline-none focus:ring-2 focus:ring-blue-500/40 dark:focus:ring-blue-300/50 focus:border-blue-400/60 dark:focus:border-blue-300/40 transition-colors duration-200',
 
-  primaryBtn: 'inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl bg-amber-600 hover:bg-amber-500 text-white text-sm font-medium transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed',
+  primaryBtn: 'inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-full bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white text-sm font-medium transition-colors duration-200 shadow-[0_1px_2px_rgba(23,37,84,0.2),0_3px_8px_-2px_rgba(23,37,84,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e] disabled:opacity-50 disabled:cursor-not-allowed',
 
-  secondaryBtn: 'inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl bg-white dark:bg-white/[0.06] hover:bg-blue-50 dark:hover:bg-white/[0.1] border border-blue-200/70 dark:border-white/[0.12] text-blue-950 dark:text-white text-sm font-medium transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed',
+  secondaryBtn: 'inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-full border border-blue-950/[0.14] text-blue-950/80 hover:text-blue-950 hover:border-blue-950/30 hover:bg-blue-950/[0.03] dark:border-white/[0.16] dark:text-blue-100/80 dark:hover:text-white dark:hover:border-white/30 dark:hover:bg-white/[0.06] text-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e] disabled:opacity-50 disabled:cursor-not-allowed',
 
-  dangerBtn: 'inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl bg-white dark:bg-white/[0.06] hover:bg-red-50 dark:hover:bg-red-500/10 border border-red-200/80 dark:border-red-400/25 text-red-600 dark:text-red-300 text-sm font-medium transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed',
+  dangerBtn: 'inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-full border border-red-200/80 dark:border-red-400/25 text-red-600 dark:text-red-300 hover:bg-red-50 dark:hover:bg-red-500/10 hover:border-red-300 dark:hover:border-red-400/40 text-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e] disabled:opacity-50 disabled:cursor-not-allowed',
 
-  iconTile: 'rounded-xl flex items-center justify-center border bg-amber-50 dark:bg-amber-400/10 border-amber-200/60 dark:border-amber-400/25 text-amber-600 dark:text-amber-300 transition-colors duration-300',
+  iconTile: 'rounded-xl flex items-center justify-center ring-1 bg-orange-100 dark:bg-orange-400/[0.14] ring-orange-900/[0.08] dark:ring-orange-300/[0.18] text-orange-600 dark:text-orange-300 transition-colors duration-300',
 
-  sectionBadge: 'inline-flex items-center px-3 py-1 rounded-full border border-amber-200/70 dark:border-amber-400/25 bg-amber-50/80 dark:bg-amber-400/10 text-xs font-semibold uppercase tracking-[0.18em] text-amber-700 dark:text-amber-300 transition-colors duration-300',
+  sectionBadge: 'inline-flex items-center px-3 py-1 rounded-full border border-orange-200/70 dark:border-orange-400/25 bg-orange-50/80 dark:bg-orange-400/10 text-xs font-semibold uppercase tracking-[0.18em] text-orange-700 dark:text-orange-300 transition-colors duration-300',
 
   errorBox: 'p-3.5 rounded-xl border border-red-200/80 dark:border-red-400/25 bg-red-50/80 dark:bg-red-500/10 text-sm text-red-700 dark:text-red-300',
 

--- a/frontend/vuejs/src/apps/imagi/operate/views/OperateDashboard.vue
+++ b/frontend/vuejs/src/apps/imagi/operate/views/OperateDashboard.vue
@@ -7,7 +7,7 @@
   <div>
     <!-- Loading -->
     <div v-if="store.dashboardLoading && !dashboard" class="flex justify-center py-16">
-      <div class="w-6 h-6 border-2 border-amber-200 dark:border-amber-300/30 border-t-amber-600 dark:border-t-amber-300 rounded-full animate-spin"></div>
+      <div class="w-6 h-6 border-2 border-blue-200 dark:border-blue-300/30 border-t-blue-600 dark:border-t-blue-300 rounded-full animate-spin"></div>
     </div>
 
     <template v-else-if="dashboard">
@@ -15,7 +15,7 @@
       <section class="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
         <div v-for="stat in statCards" :key="stat.label" class="p-5" :class="ui.card">
           <div class="flex items-center gap-2 mb-2">
-            <i :class="['fas', stat.icon]" class="text-xs text-amber-600 dark:text-amber-300"></i>
+            <i :class="['fas', stat.icon]" class="text-xs text-orange-600 dark:text-orange-300"></i>
             <p class="text-xs font-semibold uppercase tracking-[0.14em] text-blue-950/50 dark:text-blue-100/50">{{ stat.label }}</p>
           </div>
           <p class="text-2xl font-semibold tabular-nums" :class="stat.tone ?? 'text-blue-950 dark:text-white'">{{ stat.value }}</p>
@@ -55,7 +55,7 @@
             <h2 class="text-base font-semibold text-blue-950 dark:text-white">Awaiting payment</h2>
             <router-link
               :to="{ name: 'operate-invoices', params: { projectName: route.params.projectName } }"
-              class="text-sm font-medium text-amber-700 dark:text-amber-300 hover:text-amber-900 dark:hover:text-amber-200 transition-colors duration-200"
+              class="rounded-md text-sm font-medium text-blue-950/70 dark:text-blue-100/70 hover:text-blue-950 dark:hover:text-white underline decoration-blue-950/20 dark:decoration-blue-100/25 hover:decoration-blue-950/50 dark:hover:decoration-blue-100/60 underline-offset-4 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]"
             >
               View all
             </router-link>
@@ -92,7 +92,7 @@
             <h2 class="text-base font-semibold text-blue-950 dark:text-white">Up next</h2>
             <router-link
               :to="{ name: 'operate-tasks', params: { projectName: route.params.projectName } }"
-              class="text-sm font-medium text-amber-700 dark:text-amber-300 hover:text-amber-900 dark:hover:text-amber-200 transition-colors duration-200"
+              class="rounded-md text-sm font-medium text-blue-950/70 dark:text-blue-100/70 hover:text-blue-950 dark:hover:text-white underline decoration-blue-950/20 dark:decoration-blue-100/25 hover:decoration-blue-950/50 dark:hover:decoration-blue-100/60 underline-offset-4 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]"
             >
               View all
             </router-link>
@@ -133,13 +133,13 @@
           <div class="flex items-center gap-4">
             <router-link
               :to="{ name: 'sell-overview', params: { projectName: route.params.projectName } }"
-              class="text-sm font-medium text-amber-700 dark:text-amber-300 hover:text-amber-900 dark:hover:text-amber-200 transition-colors duration-200"
+              class="rounded-md text-sm font-medium text-blue-950/70 dark:text-blue-100/70 hover:text-blue-950 dark:hover:text-white underline decoration-blue-950/20 dark:decoration-blue-100/25 hover:decoration-blue-950/50 dark:hover:decoration-blue-100/60 underline-offset-4 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]"
             >
               Open Sell
             </router-link>
             <router-link
               :to="{ name: 'marketing-overview', params: { projectName: route.params.projectName } }"
-              class="text-sm font-medium text-amber-700 dark:text-amber-300 hover:text-amber-900 dark:hover:text-amber-200 transition-colors duration-200"
+              class="rounded-md text-sm font-medium text-blue-950/70 dark:text-blue-100/70 hover:text-blue-950 dark:hover:text-white underline decoration-blue-950/20 dark:decoration-blue-100/25 hover:decoration-blue-950/50 dark:hover:decoration-blue-100/60 underline-offset-4 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]"
             >
               Open Market
             </router-link>

--- a/frontend/vuejs/src/apps/imagi/operate/views/OperateFinance.vue
+++ b/frontend/vuejs/src/apps/imagi/operate/views/OperateFinance.vue
@@ -23,7 +23,7 @@
     <!-- Toolbar -->
     <div class="flex flex-col sm:flex-row gap-3 mb-6">
       <div class="relative flex-1">
-        <i class="fas fa-magnifying-glass absolute left-3.5 top-1/2 -translate-y-1/2 text-xs text-blue-950/40 dark:text-white/30"></i>
+        <i class="fas fa-magnifying-glass absolute left-3.5 top-1/2 -translate-y-1/2 text-xs text-blue-950/40 dark:text-blue-100/30"></i>
         <input
           v-model="search"
           type="search"
@@ -48,7 +48,7 @@
 
     <!-- Loading -->
     <div v-if="store.transactionsLoading && !store.transactions.length" class="flex justify-center py-16">
-      <div class="w-6 h-6 border-2 border-amber-200 dark:border-amber-300/30 border-t-amber-600 dark:border-t-amber-300 rounded-full animate-spin"></div>
+      <div class="w-6 h-6 border-2 border-blue-200 dark:border-blue-300/30 border-t-blue-600 dark:border-t-blue-300 rounded-full animate-spin"></div>
     </div>
 
     <!-- Ledger -->
@@ -82,7 +82,7 @@
         <div class="flex items-center gap-1">
           <button
             type="button"
-            class="w-8 h-8 rounded-lg flex items-center justify-center text-blue-950/40 dark:text-white/40 hover:text-blue-950 dark:hover:text-white hover:bg-blue-50 dark:hover:bg-white/[0.08] transition-colors duration-200"
+            class="w-8 h-8 rounded-lg flex items-center justify-center text-blue-950/40 dark:text-blue-100/40 hover:text-blue-950 dark:hover:text-white hover:bg-blue-50 dark:hover:bg-white/[0.08] transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]"
             aria-label="Edit transaction"
             @click="openEdit(transaction)"
           >
@@ -90,7 +90,7 @@
           </button>
           <button
             type="button"
-            class="w-8 h-8 rounded-lg flex items-center justify-center text-blue-950/40 dark:text-white/40 hover:text-red-600 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-500/10 transition-colors duration-200"
+            class="w-8 h-8 rounded-lg flex items-center justify-center text-blue-950/40 dark:text-blue-100/40 hover:text-red-600 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-500/10 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]"
             aria-label="Delete transaction"
             @click="confirmDelete(transaction)"
           >

--- a/frontend/vuejs/src/apps/imagi/operate/views/OperateInvoices.vue
+++ b/frontend/vuejs/src/apps/imagi/operate/views/OperateInvoices.vue
@@ -7,7 +7,7 @@
     <!-- Toolbar -->
     <div class="flex flex-col sm:flex-row gap-3 mb-6">
       <div class="relative flex-1">
-        <i class="fas fa-magnifying-glass absolute left-3.5 top-1/2 -translate-y-1/2 text-xs text-blue-950/40 dark:text-white/30"></i>
+        <i class="fas fa-magnifying-glass absolute left-3.5 top-1/2 -translate-y-1/2 text-xs text-blue-950/40 dark:text-blue-100/30"></i>
         <input
           v-model="search"
           type="search"
@@ -36,7 +36,7 @@
 
     <!-- Loading -->
     <div v-if="store.invoicesLoading && !store.invoices.length" class="flex justify-center py-16">
-      <div class="w-6 h-6 border-2 border-amber-200 dark:border-amber-300/30 border-t-amber-600 dark:border-t-amber-300 rounded-full animate-spin"></div>
+      <div class="w-6 h-6 border-2 border-blue-200 dark:border-blue-300/30 border-t-blue-600 dark:border-t-blue-300 rounded-full animate-spin"></div>
     </div>
 
     <!-- List -->
@@ -86,7 +86,7 @@
             <button
               v-if="invoice.status === 'draft' || invoice.status === 'sent'"
               type="button"
-              class="w-9 h-9 rounded-xl flex items-center justify-center border border-blue-200/70 dark:border-white/[0.12] text-blue-950/40 dark:text-white/40 hover:text-red-600 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-500/10 transition-colors duration-200"
+              class="w-9 h-9 rounded-full flex items-center justify-center border border-blue-950/[0.14] dark:border-white/[0.16] text-blue-950/40 dark:text-blue-100/40 hover:text-red-600 dark:hover:text-red-300 hover:border-red-300 dark:hover:border-red-400/40 hover:bg-red-50 dark:hover:bg-red-500/10 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]"
               :disabled="busyId === invoice.id"
               aria-label="Void invoice"
               title="Void invoice"
@@ -97,7 +97,7 @@
             <button
               v-if="invoice.status === 'draft' || invoice.status === 'void'"
               type="button"
-              class="w-9 h-9 rounded-xl flex items-center justify-center border border-blue-200/70 dark:border-white/[0.12] text-blue-950/40 dark:text-white/40 hover:text-red-600 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-500/10 transition-colors duration-200"
+              class="w-9 h-9 rounded-full flex items-center justify-center border border-blue-950/[0.14] dark:border-white/[0.16] text-blue-950/40 dark:text-blue-100/40 hover:text-red-600 dark:hover:text-red-300 hover:border-red-300 dark:hover:border-red-400/40 hover:bg-red-50 dark:hover:bg-red-500/10 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]"
               aria-label="Delete invoice"
               title="Delete invoice"
               @click="confirmDelete(invoice)"
@@ -109,7 +109,7 @@
 
         <!-- Line items -->
         <details v-if="invoice.line_items.length" class="mt-3">
-          <summary class="text-xs font-medium text-blue-950/50 dark:text-blue-100/50 cursor-pointer hover:text-blue-950 dark:hover:text-white transition-colors duration-200">
+          <summary class="rounded-md text-xs font-medium text-blue-950/50 dark:text-blue-100/50 cursor-pointer hover:text-blue-950 dark:hover:text-white transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]">
             {{ invoice.line_items.length }} line item{{ invoice.line_items.length === 1 ? '' : 's' }}
           </summary>
           <div class="mt-2 rounded-xl border border-blue-200/60 dark:border-white/[0.08] divide-y divide-blue-200/60 dark:divide-white/[0.08]">

--- a/frontend/vuejs/src/apps/imagi/operate/views/OperateTasks.vue
+++ b/frontend/vuejs/src/apps/imagi/operate/views/OperateTasks.vue
@@ -11,9 +11,9 @@
           v-for="option in filterOptions"
           :key="option.value"
           type="button"
-          class="px-3.5 py-2 rounded-xl text-sm font-medium whitespace-nowrap border transition-colors duration-200"
+          class="px-3.5 py-2 rounded-full text-sm font-medium whitespace-nowrap border transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
           :class="statusFilter === option.value
-            ? 'border-amber-300 dark:border-amber-400/40 bg-amber-50 dark:bg-amber-400/10 text-amber-700 dark:text-amber-300'
+            ? 'border-orange-200/70 dark:border-orange-400/25 bg-orange-50/80 dark:bg-orange-400/10 text-orange-700 dark:text-orange-300'
             : 'border-transparent text-blue-950/60 dark:text-blue-100/60 hover:text-blue-950 dark:hover:text-white'"
           @click="setFilter(option.value)"
         >
@@ -32,7 +32,7 @@
 
     <!-- Loading -->
     <div v-if="store.tasksLoading && !store.tasks.length" class="flex justify-center py-16">
-      <div class="w-6 h-6 border-2 border-amber-200 dark:border-amber-300/30 border-t-amber-600 dark:border-t-amber-300 rounded-full animate-spin"></div>
+      <div class="w-6 h-6 border-2 border-blue-200 dark:border-blue-300/30 border-t-blue-600 dark:border-t-blue-300 rounded-full animate-spin"></div>
     </div>
 
     <!-- Task list -->
@@ -45,7 +45,7 @@
         <!-- Complete toggle -->
         <button
           type="button"
-          class="w-6 h-6 shrink-0 rounded-full border-2 flex items-center justify-center transition-colors duration-200"
+          class="w-6 h-6 shrink-0 rounded-full border-2 flex items-center justify-center transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]"
           :class="task.status === 'done'
             ? 'border-emerald-500 bg-emerald-500 text-white'
             : 'border-blue-950/25 dark:border-white/25 text-transparent hover:border-emerald-500'"
@@ -59,7 +59,7 @@
         <div class="flex-1 min-w-0">
           <p
             class="text-sm font-medium truncate transition-colors duration-200"
-            :class="task.status === 'done' ? 'text-blue-950/40 dark:text-white/40 line-through' : 'text-blue-950 dark:text-white'"
+            :class="task.status === 'done' ? 'text-blue-950/40 dark:text-blue-100/40 line-through' : 'text-blue-950 dark:text-white'"
           >
             {{ task.title }}
           </p>
@@ -88,7 +88,7 @@
         <div class="flex items-center gap-1">
           <button
             type="button"
-            class="w-8 h-8 rounded-lg flex items-center justify-center text-blue-950/40 dark:text-white/40 hover:text-blue-950 dark:hover:text-white hover:bg-blue-50 dark:hover:bg-white/[0.08] transition-colors duration-200"
+            class="w-8 h-8 rounded-lg flex items-center justify-center text-blue-950/40 dark:text-blue-100/40 hover:text-blue-950 dark:hover:text-white hover:bg-blue-50 dark:hover:bg-white/[0.08] transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]"
             aria-label="Edit task"
             @click="openEdit(task)"
           >
@@ -96,7 +96,7 @@
           </button>
           <button
             type="button"
-            class="w-8 h-8 rounded-lg flex items-center justify-center text-blue-950/40 dark:text-white/40 hover:text-red-600 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-500/10 transition-colors duration-200"
+            class="w-8 h-8 rounded-lg flex items-center justify-center text-blue-950/40 dark:text-blue-100/40 hover:text-red-600 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-500/10 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]"
             aria-label="Delete task"
             @click="confirmDelete(task)"
           >

--- a/frontend/vuejs/src/apps/imagi/operate/views/OperateWorkspace.vue
+++ b/frontend/vuejs/src/apps/imagi/operate/views/OperateWorkspace.vue
@@ -10,20 +10,14 @@
 -->
 <template>
   <DefaultLayout :isHomeNav="true">
-    <div class="bg-orange-50 dark:bg-[#16120e] relative transition-colors duration-500 min-h-screen overflow-hidden">
-      <!-- Subtle background matching home page -->
-      <div class="absolute inset-0 pointer-events-none">
-        <div class="absolute inset-0 opacity-[0.015] dark:opacity-[0.02]"
-             style="background-image: linear-gradient(rgba(128,128,128,0.1) 1px, transparent 1px), linear-gradient(90deg, rgba(128,128,128,0.1) 1px, transparent 1px); background-size: 64px 64px;"></div>
-      </div>
-
+    <div class="relative min-h-screen overflow-hidden bg-[linear-gradient(180deg,#fdf9f2_0%,#faf7f1_60%,#ffffff_100%)] dark:bg-[linear-gradient(180deg,#0c0c0e_0%,#0a0b0f_60%,#0a0a0a_100%)] transition-colors duration-500">
       <main class="relative z-10 flex flex-col px-6 sm:px-8 lg:px-12 pt-20 pb-16 min-h-screen">
         <div class="max-w-6xl mx-auto w-full">
 
           <!-- Back link -->
           <router-link
             :to="{ name: 'project-hub', params: { projectName } }"
-            class="inline-flex items-center gap-2 text-sm font-medium text-blue-950/60 dark:text-blue-100/60 hover:text-blue-950 dark:hover:text-white transition-colors duration-200 mb-6"
+            class="inline-flex items-center gap-2 rounded-md text-sm font-medium text-blue-950/60 dark:text-blue-100/60 hover:text-blue-950 dark:hover:text-white transition-colors duration-200 mb-6 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
           >
             <i class="fas fa-arrow-left text-xs"></i>
             <span>Project workspace</span>
@@ -32,7 +26,7 @@
           <!-- Loading -->
           <div v-if="isLoading" class="flex flex-col items-center justify-center py-24">
             <div class="w-12 h-12 bg-blue-50 dark:bg-white/[0.06] border border-blue-200/60 dark:border-white/[0.12] rounded-full flex items-center justify-center mb-4">
-              <div class="w-6 h-6 border-2 border-amber-200 dark:border-amber-300/30 border-t-amber-600 dark:border-t-amber-300 rounded-full animate-spin"></div>
+              <div class="w-6 h-6 border-2 border-blue-200 dark:border-blue-300/30 border-t-blue-600 dark:border-t-blue-300 rounded-full animate-spin"></div>
             </div>
             <p class="text-blue-950/70 dark:text-blue-100/70 text-sm transition-colors duration-300">Loading operate workspace...</p>
           </div>
@@ -40,7 +34,7 @@
           <!-- Not found -->
           <div v-else-if="!project" class="flex flex-col items-center justify-center py-24 text-center">
             <div class="w-16 h-16 bg-blue-50 dark:bg-white/[0.06] border border-blue-200/60 dark:border-white/[0.12] rounded-full flex items-center justify-center mb-6">
-              <i class="fas fa-folder-open text-2xl text-blue-950/40 dark:text-white/40"></i>
+              <i class="fas fa-folder-open text-2xl text-blue-950/40 dark:text-blue-100/40"></i>
             </div>
             <h2 class="text-2xl font-semibold text-blue-950 dark:text-white mb-3 transition-colors duration-300">Project not found</h2>
             <p class="text-blue-950/70 dark:text-blue-100/70 mb-8 max-w-md transition-colors duration-300">We couldn't find this project. It may have been deleted.</p>
@@ -58,7 +52,7 @@
               </div>
               <div class="min-w-0">
                 <div class="flex flex-wrap items-center gap-3 mb-1.5">
-                  <h1 class="text-3xl font-semibold text-blue-950 dark:text-white tracking-tight transition-colors duration-300">Operate</h1>
+                  <h1 class="font-display text-3xl font-semibold text-blue-950 dark:text-white tracking-[-0.02em] leading-[1.05] transition-colors duration-300">Operate</h1>
                   <span :class="ui.sectionBadge">{{ project.name }}</span>
                 </div>
                 <p class="text-base text-blue-950/70 dark:text-blue-100/70 max-w-2xl transition-colors duration-300">
@@ -73,9 +67,9 @@
                 v-for="tab in tabs"
                 :key="tab.name"
                 :to="{ name: tab.name, params: { projectName } }"
-                class="inline-flex items-center gap-2 px-4 py-2.5 rounded-t-xl text-sm font-medium whitespace-nowrap border-b-2 -mb-px transition-colors duration-200"
+                class="inline-flex items-center gap-2 px-4 py-2.5 rounded-t-xl text-sm font-medium whitespace-nowrap border-b-2 -mb-px transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-inset"
                 :class="route.name === tab.name
-                  ? 'border-amber-500 dark:border-amber-400 text-blue-950 dark:text-white'
+                  ? 'border-orange-500 dark:border-orange-400 text-blue-950 dark:text-white'
                   : 'border-transparent text-blue-950/60 dark:text-blue-100/60 hover:text-blue-950 dark:hover:text-white'"
               >
                 <i :class="['fas', tab.icon]" class="text-xs"></i>

--- a/frontend/vuejs/src/apps/imagi/project-manager/components/molecules/cards/ProjectCard.vue
+++ b/frontend/vuejs/src/apps/imagi/project-manager/components/molecules/cards/ProjectCard.vue
@@ -2,10 +2,10 @@
   <router-link
     v-if="project"
     :to="{ name: 'project-hub', params: { projectName: toSlug(project.name) }}"
-    class="crisp-card group relative block px-5 py-4 rounded-2xl bg-white dark:bg-white/[0.05] border transition-colors duration-300"
+    class="crisp-card group relative block px-5 py-4 rounded-2xl bg-white/85 dark:bg-white/[0.045] backdrop-blur-sm border transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
     :class="isOrange
-      ? 'border-orange-200/70 dark:border-orange-300/[0.16] hover:border-orange-300 dark:hover:border-orange-300/30'
-      : 'border-blue-200/70 dark:border-blue-300/[0.16] hover:border-blue-300 dark:hover:border-blue-300/30'"
+      ? 'border-orange-200/70 dark:border-orange-300/[0.14] hover:border-orange-300 dark:hover:border-orange-300/30'
+      : 'border-blue-200/70 dark:border-blue-300/[0.14] hover:border-blue-300 dark:hover:border-blue-300/30'"
     :title="`Open ${project.name}`"
   >
     <div class="flex items-center gap-3 sm:gap-4">
@@ -14,7 +14,7 @@
         <h3 class="text-base font-semibold tracking-tight text-blue-950 dark:text-white truncate leading-tight transition-colors duration-300">
           {{ project.name }}
         </h3>
-        <p v-if="project.description" class="text-xs text-blue-950/70 dark:text-blue-100/70 truncate leading-snug mt-1 transition-colors duration-300">
+        <p v-if="project.description" class="text-xs text-blue-950/65 dark:text-blue-100/65 truncate leading-snug mt-1 transition-colors duration-300">
           {{ project.description }}
         </p>
       </div>
@@ -23,7 +23,7 @@
       <div class="flex items-center gap-1.5 flex-shrink-0">
         <button
           @click.stop.prevent="confirmDelete"
-          class="w-8 h-8 rounded-lg flex items-center justify-center text-blue-950/40 dark:text-white/40 hover:text-red-600 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-500/10 transition-all duration-200"
+          class="w-8 h-8 rounded-lg flex items-center justify-center text-blue-950/40 dark:text-blue-100/40 hover:text-red-600 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-500/10 transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
           aria-label="Delete project"
         >
           <i class="fas fa-trash-alt text-xs"></i>
@@ -75,11 +75,35 @@ function confirmDelete() {
     0 12px 28px -10px rgba(15, 23, 42, 0.10);
 }
 
+/* Gentle lift on hover, matching the home value pills */
+.crisp-card:hover {
+  transform: translateY(-2px);
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.04),
+    0 2px 4px rgba(15, 23, 42, 0.06),
+    0 8px 18px -4px rgba(15, 23, 42, 0.09),
+    0 20px 40px -12px rgba(15, 23, 42, 0.14);
+}
+
 :global(.dark) .crisp-card {
   box-shadow:
     0 0 0 1px rgba(255, 255, 255, 0.04),
     0 1px 2px rgba(0, 0, 0, 0.5),
     0 4px 10px -2px rgba(0, 0, 0, 0.45),
     0 12px 28px -10px rgba(0, 0, 0, 0.55);
+}
+
+:global(.dark) .crisp-card:hover {
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.06),
+    0 2px 4px rgba(0, 0, 0, 0.55),
+    0 8px 18px -4px rgba(0, 0, 0, 0.5),
+    0 20px 40px -12px rgba(0, 0, 0, 0.6);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .crisp-card:hover {
+    transform: none;
+  }
 }
 </style>

--- a/frontend/vuejs/src/apps/imagi/project-manager/components/organisms/hub/ToolCategoryCard.vue
+++ b/frontend/vuejs/src/apps/imagi/project-manager/components/organisms/hub/ToolCategoryCard.vue
@@ -8,11 +8,11 @@
   <component
     :is="isBuildLocked ? 'div' : 'router-link'"
     :to="isBuildLocked ? undefined : target"
-    class="crisp-card group relative flex flex-col items-center text-center h-full px-6 pt-8 pb-6 rounded-2xl border transition-all duration-300"
+    class="crisp-card group relative flex flex-col items-center text-center h-full px-6 pt-8 pb-6 rounded-2xl border backdrop-blur-sm transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
     :class="[
       isBuildLocked
-        ? 'building-card cursor-progress bg-white dark:bg-white/[0.05] border-blue-300/70 dark:border-blue-300/25'
-        : ['bg-white dark:bg-white/[0.05] hover:-translate-y-1', accent.cardBorder],
+        ? 'building-card cursor-progress bg-white/85 dark:bg-white/[0.045] border-blue-300/70 dark:border-blue-300/25'
+        : ['bg-white/85 dark:bg-white/[0.045] hover:-translate-y-1', accent.cardBorder],
     ]"
     :title="isBuildLocked ? 'Imagi is building your app — this card unlocks the moment the build finishes' : tool.name"
     :aria-disabled="isBuildLocked ? 'true' : undefined"
@@ -43,7 +43,7 @@
         <h3 class="text-lg font-semibold text-blue-950 dark:text-white mb-1.5 tracking-tight">
           Building your app
         </h3>
-        <p class="text-sm text-blue-950/70 dark:text-blue-100/70 leading-relaxed">
+        <p class="text-sm text-blue-950/65 dark:text-blue-100/65 leading-relaxed">
           Imagi is turning your business description into a tailored first version. This usually takes a moment.
         </p>
         <!-- Indeterminate progress track -->
@@ -73,7 +73,7 @@
         <h3 class="text-lg font-semibold text-blue-950 dark:text-white mb-1.5 tracking-tight transition-colors duration-300">
           {{ tool.name }}
         </h3>
-        <p class="text-sm text-blue-950/70 dark:text-blue-100/70 leading-relaxed transition-colors duration-300">
+        <p class="text-sm text-blue-950/65 dark:text-blue-100/65 leading-relaxed transition-colors duration-300">
           {{ tool.tagline }}
         </p>
       </div>
@@ -231,8 +231,14 @@ const target = computed<RouteLocationRaw>(() => {
 @media (prefers-reduced-motion: reduce) {
   .building-card,
   .building-sheen::before,
-  .building-bar {
+  .building-bar,
+  .animate-ping {
     animation: none;
+  }
+
+  /* No hover lift for users who prefer reduced motion */
+  .crisp-card:hover {
+    transform: none;
   }
 }
 </style>

--- a/frontend/vuejs/src/apps/imagi/project-manager/components/organisms/projects/ProjectList.vue
+++ b/frontend/vuejs/src/apps/imagi/project-manager/components/organisms/projects/ProjectList.vue
@@ -1,62 +1,50 @@
 <template>
-  <div class="relative rounded-2xl border border-gray-800/60 bg-dark-900/40 backdrop-blur-sm transition-all duration-500 hover:shadow-[0_0_25px_-5px_rgba(99,102,241,0.5)] overflow-hidden p-8">
-    <!-- Background gradient -->
-    <div class="absolute inset-0 bg-gradient-to-br opacity-10 -z-10 transition-opacity duration-300 group-hover:opacity-20 from-indigo-900 to-violet-900"></div>
-    
-    <!-- Glowing orb effect -->
-    <div class="absolute -bottom-20 -right-20 w-40 h-40 rounded-full opacity-10 blur-3xl transition-opacity duration-500 group-hover:opacity-20 bg-indigo-500"></div>
-    
-    <!-- Enhanced Header with badge styling to match project card -->
-    <div class="relative z-10 mb-8">
+  <div class="crisp-card relative rounded-2xl bg-white/85 dark:bg-white/[0.045] backdrop-blur-sm border border-orange-200/70 dark:border-orange-300/[0.14] transition-colors duration-300 overflow-hidden p-8">
+    <!-- Header -->
+    <div class="relative mb-8">
       <div class="flex items-center justify-between mb-4">
-        <div class="inline-block px-4 py-1.5 bg-indigo-500/10 rounded-full">
-          <span class="text-indigo-400 font-semibold text-sm tracking-wider">YOUR PROJECTS</span>
-        </div>
+        <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-orange-200/70 dark:border-orange-400/25 bg-orange-50/80 dark:bg-orange-400/10 text-xs font-semibold text-orange-700 dark:text-orange-300 uppercase tracking-[0.18em] transition-colors duration-300">YOUR PROJECTS</p>
       </div>
-      
+
       <!-- Title section -->
       <div class="mb-6">
         <div class="flex items-center justify-between mb-2">
-          <h2 class="text-2xl font-bold text-white">Project Library</h2>
-          
-          <!-- Enhanced combined project icon with count -->
-          <div class="group relative">
-            <!-- Glow effect on hover -->
-            <div class="absolute -inset-1 rounded-xl bg-gradient-to-r from-indigo-500/30 to-violet-500/30 opacity-0 group-hover:opacity-100 blur-sm transition-all duration-300"></div>
-            
-            <!-- Icon container -->
-            <div class="relative bg-dark-800/60 backdrop-blur-sm rounded-xl border border-gray-800/60 px-4 py-2 hover:border-indigo-500/30 transition-all duration-300 flex items-center gap-3">
-              <div class="w-10 h-10 rounded-lg bg-indigo-500/15 flex items-center justify-center group-hover:scale-110 transition-all duration-300 border border-indigo-500/20 shadow-md shadow-indigo-500/5">
-                <i class="fas fa-folder-open text-indigo-400 text-lg"></i>
-              </div>
-              <div>
-                <p class="text-xs text-gray-400 uppercase">Total</p>
-                <p class="text-xl font-bold text-white">{{ projects.length || 0 }}</p>
-              </div>
+          <h2 class="text-2xl font-semibold tracking-tight text-blue-950 dark:text-white transition-colors duration-300">Project Library</h2>
+
+          <!-- Project count -->
+          <div class="flex items-center gap-3 px-4 py-2 rounded-xl bg-white/85 dark:bg-white/[0.04] border border-blue-200/70 dark:border-white/[0.14] transition-colors duration-300">
+            <div class="w-10 h-10 rounded-xl bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] dark:from-blue-400/[0.18] dark:to-blue-500/[0.22] ring-1 ring-blue-900/[0.08] dark:ring-blue-300/[0.18] flex items-center justify-center">
+              <i class="fas fa-folder-open text-blue-600 dark:text-blue-300 text-lg"></i>
+            </div>
+            <div>
+              <p class="text-xs font-medium uppercase tracking-[0.14em] text-blue-950/70 dark:text-blue-100/55 transition-colors duration-300">Total</p>
+              <p class="text-xl font-semibold tabular-nums text-blue-950 dark:text-white transition-colors duration-300">{{ projects.length || 0 }}</p>
             </div>
           </div>
         </div>
-        
-        <p class="text-gray-300">Continue working on your existing web applications</p>
-        
-        <!-- Decorative element matching new project card -->
-        <div class="w-16 h-1 bg-gradient-to-r from-indigo-500 to-violet-500 rounded-full mt-4"></div>
+
+        <p class="text-blue-950/65 dark:text-blue-100/65 transition-colors duration-300">Continue working on your existing web applications</p>
+
+        <!-- Hairline accent divider -->
+        <div class="mt-4 h-px w-16 bg-gradient-to-r from-transparent via-orange-300/70 dark:via-orange-300/30 to-transparent" aria-hidden="true"></div>
       </div>
     </div>
 
     <template v-if="!isLoading && !error && projects?.length">
-      <!-- Recent Projects with Enhanced Styling -->
+      <!-- Recent Projects -->
       <div v-if="recentProjects.length" class="mb-10">
-        <div class="flex items-center bg-indigo-500/5 rounded-lg px-4 py-2 mb-5">
-          <i class="fas fa-clock text-indigo-400 mr-3"></i>
-          <h3 class="text-sm font-medium text-white uppercase tracking-wider">Recently Opened</h3>
+        <div class="flex items-center gap-2.5 mb-5">
+          <i class="fas fa-clock text-blue-600 dark:text-blue-300 text-sm"></i>
+          <h3 class="text-xs font-semibold text-blue-950/70 dark:text-blue-100/55 uppercase tracking-[0.18em] transition-colors duration-300">Recently Opened</h3>
+          <span class="flex-1 h-px bg-blue-950/[0.08] dark:bg-white/[0.14]" aria-hidden="true"></span>
         </div>
-        
+
         <div class="space-y-4">
           <ProjectCard
-            v-for="project in recentProjects"
+            v-for="(project, index) in recentProjects"
             :key="project.id"
             :project="project"
+            :accent="index % 2 === 1 ? 'orange' : 'blue'"
             @delete="$emit('delete', project.id, project.name)"
           />
         </div>
@@ -64,60 +52,64 @@
 
       <!-- All Projects Section -->
       <div class="space-y-5">
-        <div class="flex items-center bg-indigo-500/5 rounded-lg px-4 py-2 mb-4">
-          <i class="fas fa-folder text-indigo-400 mr-3"></i>
-          <h3 class="text-sm font-medium text-white uppercase tracking-wider">All Projects</h3>
+        <div class="flex items-center gap-2.5 mb-4">
+          <i class="fas fa-folder text-orange-600 dark:text-orange-300 text-sm"></i>
+          <h3 class="text-xs font-semibold text-blue-950/70 dark:text-blue-100/55 uppercase tracking-[0.18em] transition-colors duration-300">All Projects</h3>
+          <span class="flex-1 h-px bg-blue-950/[0.08] dark:bg-white/[0.14]" aria-hidden="true"></span>
         </div>
 
-        <!-- Projects List with Enhanced Scrollbar -->
-        <div class="space-y-4 max-h-[350px] overflow-y-auto pr-2 custom-scrollbar">
+        <!-- Projects List -->
+        <div class="space-y-4 max-h-[350px] overflow-y-auto pr-2 pl-0.5 pt-1 pb-2 custom-scrollbar">
           <template v-if="props.projects.length > 3">
             <ProjectCard
-              v-for="project in otherProjects"
+              v-for="(project, index) in otherProjects"
               :key="project.id"
               :project="project"
+              :accent="index % 2 === 1 ? 'orange' : 'blue'"
               @delete="$emit('delete', project.id, project.name)"
             />
           </template>
           <div v-else-if="recentProjects.length === 0" class="flex flex-col items-center justify-center py-12">
-            <i class="fas fa-folder-open text-3xl text-indigo-400 mb-3 opacity-70"></i>
-            <p class="text-gray-300">No additional projects</p>
+            <i class="fas fa-folder-open text-3xl text-blue-950/30 dark:text-blue-100/30 mb-3"></i>
+            <p class="text-blue-950/65 dark:text-blue-100/65 transition-colors duration-300">No additional projects</p>
           </div>
         </div>
       </div>
     </template>
 
-    <!-- Enhanced Loading, Error, Empty States -->
+    <!-- Loading, Error, Empty States -->
     <div v-else>
       <div v-if="isLoading" class="flex flex-col items-center justify-center py-16">
-        <div class="w-16 h-16 bg-indigo-500/10 rounded-full flex items-center justify-center mb-5 animate-pulse">
-          <i class="fas fa-spinner fa-spin text-2xl text-indigo-400"></i>
+        <div class="w-16 h-16 rounded-2xl bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] dark:from-blue-400/[0.18] dark:to-blue-500/[0.22] ring-1 ring-blue-900/[0.08] dark:ring-blue-300/[0.18] flex items-center justify-center mb-5">
+          <div class="w-7 h-7 border-2 border-blue-200 dark:border-blue-300/30 border-t-blue-600 dark:border-t-blue-300 rounded-full animate-spin"></div>
         </div>
-        <p class="text-gray-300 text-lg">Loading your projects...</p>
+        <p class="text-blue-950/65 dark:text-blue-100/65 text-lg transition-colors duration-300">Loading your projects...</p>
       </div>
 
       <div v-else-if="error" class="flex flex-col items-center justify-center py-16">
-        <div class="w-16 h-16 bg-red-500/10 rounded-full flex items-center justify-center mb-5">
-          <i class="fas fa-exclamation-circle text-2xl text-red-400"></i>
+        <div class="w-16 h-16 rounded-2xl bg-red-50 dark:bg-red-500/10 ring-1 ring-red-900/[0.08] dark:ring-red-400/30 flex items-center justify-center mb-5">
+          <i class="fas fa-exclamation-circle text-2xl text-red-500 dark:text-red-300"></i>
         </div>
-        <p class="text-gray-300 mb-6 text-center max-w-md">{{ error }}</p>
-        <GradientButton
+        <p class="text-blue-950/65 dark:text-blue-100/65 mb-6 text-center max-w-md transition-colors duration-300">{{ error }}</p>
+        <button
+          type="button"
           @click="$emit('retry')"
+          class="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-full font-medium text-sm bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white transition-colors duration-200 shadow-[0_1px_2px_rgba(23,37,84,0.2),0_3px_8px_-2px_rgba(23,37,84,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
         >
-          <i class="fas fa-sync-alt mr-2"></i>
-          Try Again
-        </GradientButton>
+          <i class="fas fa-sync-alt"></i>
+          <span>Try Again</span>
+        </button>
       </div>
 
       <div v-else class="flex flex-col items-center justify-center py-16">
-        <div class="w-16 h-16 bg-indigo-500/10 rounded-full flex items-center justify-center mb-5">
-          <i class="fas fa-folder-open text-2xl text-indigo-400"></i>
+        <div class="w-16 h-16 rounded-2xl bg-orange-100 dark:bg-orange-400/[0.14] ring-1 ring-orange-900/[0.08] dark:ring-orange-300/[0.18] flex items-center justify-center mb-5">
+          <i class="fas fa-folder-open text-2xl text-orange-600 dark:text-orange-300"></i>
         </div>
-        <h3 class="text-xl font-semibold text-white mb-2">No projects yet</h3>
-        <p class="text-gray-300 text-center max-w-md mb-6">Create your first project to start building with Imagi</p>
-        
+        <h3 class="text-xl font-semibold tracking-tight text-blue-950 dark:text-white mb-2 transition-colors duration-300">No projects yet</h3>
+        <p class="text-blue-950/65 dark:text-blue-100/65 text-center max-w-md mb-6 transition-colors duration-300">Create your first project to start building with Imagi</p>
+
         <!-- Directional hint -->
-        <div class="flex items-center text-indigo-400 animate-pulse-slow">
+        <div class="flex items-center text-blue-700 dark:text-blue-300 transition-colors duration-300">
           <i class="fas fa-long-arrow-alt-left text-lg mr-2"></i>
           <span>Get started with a new project</span>
         </div>
@@ -129,7 +121,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import ProjectCard from '../../molecules/cards/ProjectCard.vue'
-import { GradientButton } from '@/shared/components/atoms'
 import type { Project } from '@/apps/imagi/build/types/components'
 import type { ProjectListProps } from '@/apps/imagi/build/types/components'
 
@@ -138,13 +129,13 @@ const props = defineProps<ProjectListProps>()
 // Get 3 most recently updated projects for display
 const recentProjects = computed(() => {
   if (!props.projects?.length) return []
-  
+
   return [...props.projects]
     .sort((a, b) => {
       // Handle cases where updated_at might be undefined
       if (!a.updated_at) return 1;  // If a's date is missing, b comes first
       if (!b.updated_at) return -1; // If b's date is missing, a comes first
-      
+
       const dateA = new Date(a.updated_at).getTime()
       const dateB = new Date(b.updated_at).getTime()
       return dateB - dateA
@@ -155,16 +146,16 @@ const recentProjects = computed(() => {
 // Get all projects except the recent ones
 const otherProjects = computed(() => {
   if (!props.projects?.length) return []
-  
+
   const recentIds = new Set(recentProjects.value.map(p => p.id))
-  
+
   return [...props.projects]
     .filter(project => !recentIds.has(project.id))
     .sort((a, b) => {
       // Handle cases where updated_at might be undefined
       if (!a.updated_at) return 1;  // If a's date is missing, b comes first
       if (!b.updated_at) return -1; // If b's date is missing, a comes first
-      
+
       const dateA = new Date(a.updated_at).getTime()
       const dateB = new Date(b.updated_at).getTime()
       return dateB - dateA
@@ -173,6 +164,29 @@ const otherProjects = computed(() => {
 </script>
 
 <style scoped>
+/* Crisp, sharply-defined panel matching Home/About - hairline edge + tight layered shadow */
+.crisp-card {
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.03),
+    0 1px 2px rgba(15, 23, 42, 0.06),
+    0 4px 10px -2px rgba(15, 23, 42, 0.07),
+    0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
+
+:global(.dark) .crisp-card {
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 12px 28px -10px rgba(0, 0, 0, 0.55);
+}
+
+/* Refined minimal scrollbar */
+.custom-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(0, 0, 0, 0.12) transparent;
+}
+
 .custom-scrollbar::-webkit-scrollbar {
   width: 6px;
 }
@@ -182,25 +196,23 @@ const otherProjects = computed(() => {
 }
 
 .custom-scrollbar::-webkit-scrollbar-thumb {
-  background: theme('colors.gray.700');
+  background: rgba(0, 0, 0, 0.12);
   border-radius: 8px;
 }
 
 .custom-scrollbar::-webkit-scrollbar-thumb:hover {
-  background: theme('colors.gray.600');
+  background: rgba(0, 0, 0, 0.2);
 }
 
-/* Add subtle animation for loading state */
-@keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.7; }
+:global(.dark) .custom-scrollbar {
+  scrollbar-color: rgba(255, 255, 255, 0.12) transparent;
 }
 
-.animate-pulse {
-  animation: pulse 1.5s ease-in-out infinite;
+:global(.dark) .custom-scrollbar::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.12);
 }
 
-.animate-pulse-slow {
-  animation: pulse 3s ease-in-out infinite;
+:global(.dark) .custom-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.2);
 }
 </style>

--- a/frontend/vuejs/src/apps/imagi/project-manager/views/ProjectHub.vue
+++ b/frontend/vuejs/src/apps/imagi/project-manager/views/ProjectHub.vue
@@ -13,11 +13,13 @@
 -->
 <template>
   <DefaultLayout :isHomeNav="true">
-    <div class="bg-orange-50 dark:bg-[#16120e] relative transition-colors duration-500 min-h-screen overflow-hidden">
-      <!-- Subtle background matching home page -->
-      <div class="absolute inset-0 pointer-events-none">
-        <div class="absolute inset-0 opacity-[0.015] dark:opacity-[0.02]"
-             style="background-image: linear-gradient(rgba(128,128,128,0.1) 1px, transparent 1px), linear-gradient(90deg, rgba(128,128,128,0.1) 1px, transparent 1px); background-size: 64px 64px;"></div>
+    <div class="hub-page relative transition-colors duration-500 min-h-screen overflow-hidden font-body">
+      <!-- Grain texture over the porcelain canvas -->
+      <div class="grain-overlay absolute inset-0 z-[1] pointer-events-none" aria-hidden="true"></div>
+
+      <!-- Atmosphere: one soft baby-blue wash behind the header -->
+      <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
+        <div class="page-glow-cool absolute -top-40 left-1/2 -translate-x-1/2 w-[760px] h-[440px]"></div>
       </div>
 
       <main class="relative z-10 flex flex-col px-6 sm:px-8 lg:px-12 pt-20 pb-12 min-h-screen">
@@ -26,7 +28,7 @@
           <!-- Back link -->
           <router-link
             :to="{ name: 'projects' }"
-            class="inline-flex items-center gap-2 text-sm font-medium text-blue-950/60 dark:text-blue-100/60 hover:text-blue-950 dark:hover:text-white transition-colors duration-200 mb-6"
+            class="inline-flex items-center gap-2 rounded-full text-sm font-medium text-blue-950/70 dark:text-blue-100/55 hover:text-blue-950 dark:hover:text-white transition-colors duration-200 mb-6 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
           >
             <i class="fas fa-arrow-left text-xs"></i>
             <span>All projects</span>
@@ -34,7 +36,7 @@
 
           <!-- Loading -->
           <div v-if="isLoading" class="flex flex-col items-center justify-center py-24">
-            <div class="w-12 h-12 bg-blue-50 dark:bg-white/[0.06] border border-blue-200/60 dark:border-white/[0.12] rounded-full flex items-center justify-center mb-4">
+            <div class="w-12 h-12 bg-blue-50 dark:bg-white/[0.06] border border-blue-200/60 dark:border-white/[0.14] rounded-full flex items-center justify-center mb-4">
               <div class="w-6 h-6 border-2 border-blue-200 dark:border-blue-300/30 border-t-blue-600 dark:border-t-blue-300 rounded-full animate-spin"></div>
             </div>
             <p class="text-blue-950/70 dark:text-blue-100/70 text-sm transition-colors duration-300">Loading project...</p>
@@ -42,14 +44,14 @@
 
           <!-- Not found -->
           <div v-else-if="!project" class="flex flex-col items-center justify-center py-24 text-center">
-            <div class="w-16 h-16 bg-blue-50 dark:bg-white/[0.06] border border-blue-200/60 dark:border-white/[0.12] rounded-full flex items-center justify-center mb-6">
-              <i class="fas fa-folder-open text-2xl text-blue-950/40 dark:text-white/40"></i>
+            <div class="w-16 h-16 bg-blue-50 dark:bg-white/[0.06] border border-blue-200/60 dark:border-white/[0.14] rounded-full flex items-center justify-center mb-6">
+              <i class="fas fa-folder-open text-2xl text-blue-950/40 dark:text-blue-100/40"></i>
             </div>
-            <h2 class="text-2xl font-semibold text-blue-950 dark:text-white mb-3 transition-colors duration-300">Project not found</h2>
-            <p class="text-blue-950/70 dark:text-blue-100/70 mb-8 max-w-md transition-colors duration-300">We couldn't find this project. It may have been deleted.</p>
+            <h2 class="text-2xl font-semibold tracking-tight text-blue-950 dark:text-white mb-3 transition-colors duration-300">Project not found</h2>
+            <p class="text-blue-950/65 dark:text-blue-100/65 mb-8 max-w-md transition-colors duration-300">We couldn't find this project. It may have been deleted.</p>
             <router-link
               :to="{ name: 'projects' }"
-              class="inline-flex items-center gap-2 px-5 py-2.5 bg-white dark:bg-white/[0.06] hover:bg-blue-50 dark:hover:bg-white/[0.1] border border-blue-200/70 dark:border-white/[0.12] rounded-xl text-blue-950 dark:text-white font-medium text-sm transition-all duration-300"
+              class="inline-flex items-center gap-2 px-5 py-2.5 rounded-full border border-blue-950/[0.14] text-blue-950/80 hover:text-blue-950 hover:border-blue-950/30 hover:bg-blue-950/[0.03] dark:border-white/[0.16] dark:text-blue-100/80 dark:hover:text-white dark:hover:border-white/30 dark:hover:bg-white/[0.06] font-medium text-sm transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
             >
               <i class="fas fa-arrow-left text-sm"></i>
               <span>Back to projects</span>
@@ -59,19 +61,19 @@
           <!-- Hub -->
           <template v-else>
             <!-- Project header -->
-            <section class="flex flex-col items-center text-center mb-10 md:mb-14">
+            <section class="rise-item flex flex-col items-center text-center mb-10 md:mb-14" style="animation-delay: 0ms">
               <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-blue-200/70 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 text-xs font-semibold text-blue-700 dark:text-blue-300 uppercase tracking-[0.18em] mb-5 transition-colors duration-300">Project workspace</p>
-              <h1 class="text-3xl sm:text-4xl lg:text-5xl font-semibold text-blue-950 dark:text-white mb-3 tracking-tight transition-colors duration-300">
+              <h1 class="font-display text-4xl sm:text-5xl lg:text-6xl font-semibold text-blue-950 dark:text-white mb-4 tracking-[-0.02em] leading-[1.05] text-balance transition-colors duration-300">
                 {{ project.name }}
               </h1>
-              <p class="text-base sm:text-lg text-blue-950/70 dark:text-blue-100/70 max-w-2xl leading-relaxed transition-colors duration-300">
+              <p class="text-base sm:text-lg text-blue-950/65 dark:text-blue-100/65 max-w-2xl leading-relaxed text-pretty transition-colors duration-300">
                 {{ project.description || 'Build your product and run your business — all in one place. Choose a workspace to get started.' }}
               </p>
-              <div class="mt-7 h-px w-16 bg-gradient-to-r from-transparent via-blue-300/60 dark:via-blue-300/25 to-transparent"></div>
+              <div class="mt-7 h-px w-16 bg-gradient-to-r from-transparent via-blue-300/60 dark:via-blue-300/25 to-transparent" aria-hidden="true"></div>
             </section>
 
             <!-- Category grid -->
-            <section>
+            <section class="rise-item" style="animation-delay: 90ms">
               <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5 sm:gap-6">
                 <ToolCategoryCard
                   v-for="tool in businessTools"
@@ -191,3 +193,76 @@ watch(
 
 onBeforeUnmount(stopBuildStatusPolling)
 </script>
+
+<style scoped>
+/* Warm porcelain canvas fading to white so the page hands off to the footer
+   (footer is bg-white / dark #0a0a0a) — matches Home.vue */
+.hub-page {
+  background: linear-gradient(180deg, #fdf9f2 0%, #faf7f1 45%, #ffffff 100%);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+.dark .hub-page {
+  background: linear-gradient(180deg, #0c0c0e 0%, #0a0b0f 50%, #0a0a0a 100%);
+}
+
+/* Fine film grain keeps large soft gradients from banding and adds texture */
+.grain-overlay {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)' opacity='0.5'/%3E%3C/svg%3E");
+  background-size: 160px 160px;
+  opacity: 0.035;
+  mix-blend-mode: multiply;
+}
+
+.dark .grain-overlay {
+  opacity: 0.05;
+  mix-blend-mode: overlay;
+}
+
+/* Soft baby-blue wash behind the page header */
+.page-glow-cool {
+  background: radial-gradient(closest-side, rgba(158, 205, 243, 0.2), rgba(158, 205, 243, 0.06) 55%, transparent 75%);
+  filter: blur(48px);
+}
+
+.dark .page-glow-cool {
+  background: radial-gradient(closest-side, rgba(96, 165, 250, 0.08), rgba(96, 165, 250, 0.02) 55%, transparent 75%);
+}
+
+/* Page-load rise: header and grid fade up in sequence */
+.rise-item {
+  animation: rise-up 0.7s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@keyframes rise-up {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rise-item {
+    animation: none;
+  }
+}
+</style>
+
+<!-- Unscoped: brand-tinted text selection on the hub page -->
+<style>
+.hub-page ::selection {
+  background: rgba(158, 205, 243, 0.55);
+  color: #172554;
+}
+
+.dark .hub-page ::selection {
+  background: rgba(96, 165, 250, 0.4);
+  color: #eff6ff;
+}
+</style>

--- a/frontend/vuejs/src/apps/imagi/project-manager/views/Projects.vue
+++ b/frontend/vuejs/src/apps/imagi/project-manager/views/Projects.vue
@@ -21,38 +21,40 @@
     />
     
     <DefaultLayout :isHomeNav="true">
-    <div class="bg-orange-50 dark:bg-[#16120e] relative transition-colors duration-500 min-h-screen overflow-hidden">
-      <!-- Subtle background matching home page -->
-      <div class="absolute inset-0 pointer-events-none">
-        <div class="absolute inset-0 opacity-[0.015] dark:opacity-[0.02]"
-             style="background-image: linear-gradient(rgba(128,128,128,0.1) 1px, transparent 1px), linear-gradient(90deg, rgba(128,128,128,0.1) 1px, transparent 1px); background-size: 64px 64px;"></div>
+    <div class="projects-page relative transition-colors duration-500 min-h-screen overflow-hidden font-body">
+      <!-- Grain texture over the porcelain canvas -->
+      <div class="grain-overlay absolute inset-0 z-[1] pointer-events-none" aria-hidden="true"></div>
+
+      <!-- Atmosphere: one soft apricot wash behind the header -->
+      <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
+        <div class="page-glow-warm absolute -top-40 left-1/2 -translate-x-1/2 w-[760px] h-[440px]"></div>
       </div>
 
       <!-- Main Content (pt-20 clears the fixed h-14 navbar) -->
       <main class="relative z-10 flex flex-col px-6 sm:px-8 lg:px-12 pt-20 pb-8 min-h-screen">
         <!-- Compact Hero -->
-        <section class="flex-shrink-0 max-w-6xl mx-auto w-full text-center mb-6 md:mb-8">
+        <section class="rise-item flex-shrink-0 max-w-6xl mx-auto w-full text-center mb-6 md:mb-8" style="animation-delay: 0ms">
           <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-blue-200/70 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 text-xs font-semibold text-blue-700 dark:text-blue-300 uppercase tracking-[0.18em] mb-4 transition-colors duration-300">Workspace</p>
-          <h1 class="text-3xl sm:text-4xl font-semibold text-blue-950 dark:text-white mb-2 tracking-tight transition-colors duration-300">
-            Your Projects
+          <h1 class="font-display text-4xl sm:text-5xl font-semibold text-blue-950 dark:text-white mb-3 tracking-[-0.02em] leading-[1.05] text-balance transition-colors duration-300">
+            Your <em class="accent-ink not-italic">Projects</em>
           </h1>
-          <p class="text-base text-blue-950/70 dark:text-blue-100/70 transition-colors duration-300">
+          <p class="text-base sm:text-lg text-blue-950/65 dark:text-blue-100/65 leading-relaxed transition-colors duration-300">
             Start a new business or keep building and running an existing one.
           </p>
         </section>
 
         <!-- Authentication Error -->
-        <div v-if="showAuthError" class="flex-1 flex items-center justify-center">
+        <div v-if="showAuthError" class="rise-item flex-1 flex items-center justify-center" style="animation-delay: 90ms">
           <div class="max-w-2xl mx-auto w-full">
-            <div class="crisp-card relative p-10 rounded-2xl bg-white dark:bg-white/[0.05] border border-blue-200/70 dark:border-blue-300/[0.16] text-center transition-colors duration-300">
-              <div class="w-16 h-16 bg-blue-50 dark:bg-white/[0.06] border border-blue-200/60 dark:border-white/[0.12] rounded-full flex items-center justify-center mx-auto mb-6">
+            <div class="crisp-card relative p-10 rounded-2xl bg-white/85 dark:bg-white/[0.045] backdrop-blur-sm border border-blue-200/70 dark:border-blue-300/[0.14] text-center transition-colors duration-300">
+              <div class="w-16 h-16 bg-blue-50 dark:bg-white/[0.06] border border-blue-200/60 dark:border-white/[0.14] rounded-full flex items-center justify-center mx-auto mb-6">
                 <i class="fas fa-lock text-2xl text-blue-700 dark:text-blue-300"></i>
               </div>
-              <h2 class="text-2xl font-semibold text-blue-950 dark:text-white mb-3 transition-colors duration-300">Authentication Required</h2>
+              <h2 class="text-2xl font-semibold tracking-tight text-blue-950 dark:text-white mb-3 transition-colors duration-300">Authentication Required</h2>
               <p class="text-blue-950/70 dark:text-blue-100/70 mb-8 max-w-md mx-auto transition-colors duration-300">Please log in to view and manage your projects.</p>
               <router-link
                 to="/auth/signin"
-                class="group inline-flex items-center justify-center gap-3 px-8 py-4 rounded-full font-medium text-lg bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white transition-all duration-200 hover:-translate-y-0.5 active:translate-y-0 shadow-[0_1px_2px_rgba(23,37,84,0.25),0_8px_20px_-6px_rgba(23,37,84,0.35),inset_0_1px_0_rgba(255,255,255,0.12)] hover:shadow-[0_2px_3px_rgba(23,37,84,0.22),0_14px_28px_-8px_rgba(23,37,84,0.4),inset_0_1px_0_rgba(255,255,255,0.12)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.5),0_10px_24px_-8px_rgba(0,0,0,0.55)] dark:hover:shadow-[0_2px_3px_rgba(0,0,0,0.5),0_14px_30px_-8px_rgba(0,0,0,0.6)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#16120e]"
+                class="group inline-flex items-center justify-center gap-3 px-8 py-4 rounded-full font-medium text-lg bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white transition-all duration-200 hover:-translate-y-0.5 active:translate-y-0 shadow-[0_1px_2px_rgba(23,37,84,0.25),0_8px_20px_-6px_rgba(23,37,84,0.35),inset_0_1px_0_rgba(255,255,255,0.12)] hover:shadow-[0_2px_3px_rgba(23,37,84,0.22),0_14px_28px_-8px_rgba(23,37,84,0.4),inset_0_1px_0_rgba(255,255,255,0.12)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.5),0_10px_24px_-8px_rgba(0,0,0,0.55)] dark:hover:shadow-[0_2px_3px_rgba(0,0,0,0.5),0_14px_30px_-8px_rgba(0,0,0,0.6)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
               >
                 <i class="fas fa-sign-in-alt"></i>
                 <span>Log In</span>
@@ -66,14 +68,14 @@
           <div class="h-full grid grid-cols-1 lg:grid-cols-2 gap-6">
 
             <!-- Section A: Create a Project -->
-            <section class="min-h-0">
-              <div class="crisp-card h-full p-6 md:p-8 rounded-2xl bg-white dark:bg-white/[0.05] border border-blue-200/70 dark:border-blue-300/[0.16] transition-colors duration-300 flex flex-col">
+            <section class="rise-item min-h-0" style="animation-delay: 90ms">
+              <div class="crisp-card h-full p-6 md:p-8 rounded-2xl bg-white/85 dark:bg-white/[0.045] backdrop-blur-sm border border-blue-200/70 dark:border-blue-300/[0.14] transition-colors duration-300 flex flex-col">
 
                 <!-- Section header -->
                 <div class="mb-5 flex-shrink-0">
                   <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-blue-200/70 dark:border-blue-400/25 bg-blue-50/80 dark:bg-blue-400/10 text-xs font-semibold text-blue-700 dark:text-blue-300 uppercase tracking-[0.18em] mb-3 transition-colors duration-300">New Project</p>
-                  <h2 class="text-2xl font-semibold text-blue-950 dark:text-white mb-2 transition-colors duration-300">Create a Project</h2>
-                  <p class="text-sm text-blue-950/70 dark:text-blue-100/70 transition-colors duration-300">Start a new business — describe it, and Imagi builds the first version of your app.</p>
+                  <h2 class="text-2xl font-semibold tracking-tight text-blue-950 dark:text-white mb-2 transition-colors duration-300">Create a Project</h2>
+                  <p class="text-sm text-blue-950/65 dark:text-blue-100/65 leading-relaxed transition-colors duration-300">Start a new business — describe it, and Imagi builds the first version of your app.</p>
                 </div>
 
                 <!-- Create Form -->
@@ -85,8 +87,7 @@
                       v-model="newProjectName"
                       type="text"
                       placeholder="Enter your business name..."
-                      class="w-full px-4 py-3 bg-white dark:bg-white/[0.04] border border-blue-200/70 dark:border-white/[0.12] focus:border-blue-400 dark:focus:border-blue-300/50 rounded-xl text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-white/40 transition-all duration-300 disabled:opacity-50 disabled:cursor-not-allowed"
-                      style="outline: none !important;"
+                      class="w-full px-4 py-3 bg-white dark:bg-white/[0.04] border border-blue-200/70 dark:border-white/[0.14] focus:border-blue-400 dark:focus:border-blue-300/50 rounded-xl text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-blue-100/40 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e] disabled:opacity-50 disabled:cursor-not-allowed"
                       :disabled="isCreating"
                     >
                   </div>
@@ -96,14 +97,13 @@
                     <label class="block text-sm font-medium text-blue-950/80 dark:text-blue-100/80 mb-1 flex-shrink-0 transition-colors duration-300">
                       Business Description
                     </label>
-                    <p class="text-xs text-blue-950/50 dark:text-blue-100/50 mb-2 flex-shrink-0 transition-colors duration-300">
+                    <p class="text-xs text-blue-950/70 dark:text-blue-100/55 mb-2 flex-shrink-0 transition-colors duration-300">
                       Imagi's AI uses this to build the first version of your app.
                     </p>
                     <textarea
                       v-model="newProjectDescription"
                       placeholder="What does your business do? Who are its customers? What does the market look like, and how will you sell?"
-                      class="w-full flex-1 min-h-[80px] px-4 py-3 bg-white dark:bg-white/[0.04] border border-blue-200/70 dark:border-white/[0.12] focus:border-blue-400 dark:focus:border-blue-300/50 rounded-xl text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-white/40 transition-all duration-300 resize-none disabled:opacity-50 disabled:cursor-not-allowed"
-                      style="outline: none !important;"
+                      class="w-full flex-1 min-h-[80px] px-4 py-3 bg-white dark:bg-white/[0.04] border border-blue-200/70 dark:border-white/[0.14] focus:border-blue-400 dark:focus:border-blue-300/50 rounded-xl text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-blue-100/40 transition-all duration-300 resize-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e] disabled:opacity-50 disabled:cursor-not-allowed"
                       :disabled="isCreating"
                     ></textarea>
                   </div>
@@ -113,7 +113,7 @@
                     <button
                       @click="createProject"
                       :disabled="!canCreate || isCreating"
-                      class="group w-full inline-flex items-center justify-center gap-3 px-8 py-3.5 rounded-full font-medium text-base bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white transition-all duration-200 hover:-translate-y-0.5 active:translate-y-0 shadow-[0_1px_2px_rgba(23,37,84,0.25),0_8px_20px_-6px_rgba(23,37,84,0.35),inset_0_1px_0_rgba(255,255,255,0.12)] hover:shadow-[0_2px_3px_rgba(23,37,84,0.22),0_14px_28px_-8px_rgba(23,37,84,0.4),inset_0_1px_0_rgba(255,255,255,0.12)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.5),0_10px_24px_-8px_rgba(0,0,0,0.55)] dark:hover:shadow-[0_2px_3px_rgba(0,0,0,0.5),0_14px_30px_-8px_rgba(0,0,0,0.6)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#16120e] disabled:opacity-50 disabled:cursor-not-allowed"
+                      class="group w-full inline-flex items-center justify-center gap-3 px-8 py-3.5 rounded-full font-medium text-base bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white transition-all duration-200 hover:-translate-y-0.5 active:translate-y-0 shadow-[0_1px_2px_rgba(23,37,84,0.25),0_8px_20px_-6px_rgba(23,37,84,0.35),inset_0_1px_0_rgba(255,255,255,0.12)] hover:shadow-[0_2px_3px_rgba(23,37,84,0.22),0_14px_28px_-8px_rgba(23,37,84,0.4),inset_0_1px_0_rgba(255,255,255,0.12)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.5),0_10px_24px_-8px_rgba(0,0,0,0.55)] dark:hover:shadow-[0_2px_3px_rgba(0,0,0,0.5),0_14px_30px_-8px_rgba(0,0,0,0.6)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e] disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                       <template v-if="isCreating">
                         <div class="w-5 h-5 border-2 border-[#fdf9f2]/30 border-t-[#fdf9f2] dark:border-blue-950/30 dark:border-t-blue-950 rounded-full animate-spin"></div>
@@ -132,34 +132,33 @@
             </section>
 
             <!-- Section B: Project Library -->
-            <section class="min-h-0">
-              <div class="crisp-card h-full p-6 md:p-8 rounded-2xl bg-white dark:bg-white/[0.05] border border-orange-200/70 dark:border-orange-300/[0.16] transition-colors duration-300 flex flex-col">
+            <section class="rise-item min-h-0" style="animation-delay: 180ms">
+              <div class="crisp-card h-full p-6 md:p-8 rounded-2xl bg-white/85 dark:bg-white/[0.045] backdrop-blur-sm border border-orange-200/70 dark:border-orange-300/[0.14] transition-colors duration-300 flex flex-col">
 
                 <!-- Section header -->
                 <div class="mb-5 flex-shrink-0">
                   <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-orange-200/70 dark:border-orange-400/25 bg-orange-50/80 dark:bg-orange-400/10 text-xs font-semibold text-orange-700 dark:text-orange-300 uppercase tracking-[0.18em] mb-3 transition-colors duration-300">Your Projects</p>
                   <div class="flex items-end justify-between gap-3 mb-2">
-                    <h2 class="text-2xl font-semibold text-blue-950 dark:text-white transition-colors duration-300">Project Library</h2>
+                    <h2 class="text-2xl font-semibold tracking-tight text-blue-950 dark:text-white transition-colors duration-300">Project Library</h2>
                     <span
                       v-if="!isLoading && !error && displayedProjects.length > 0"
-                      class="inline-flex items-center px-2.5 py-1 mb-0.5 rounded-full border border-blue-200/60 dark:border-white/[0.12] bg-white dark:bg-white/[0.04] text-xs font-medium text-blue-950/60 dark:text-blue-100/60 transition-colors duration-300"
+                      class="inline-flex items-center px-2.5 py-1 mb-0.5 rounded-full border border-blue-200/60 dark:border-white/[0.14] bg-white/85 dark:bg-white/[0.04] text-xs font-medium text-blue-950/70 dark:text-blue-100/55 transition-colors duration-300"
                     >
                       {{ searchQuery ? `${displayedProjects.length} Results` : `${projects.length || 0} Projects` }}
                     </span>
                   </div>
-                  <p class="text-sm text-blue-950/70 dark:text-blue-100/70 transition-colors duration-300">Continue working on your existing applications.</p>
+                  <p class="text-sm text-blue-950/65 dark:text-blue-100/65 leading-relaxed transition-colors duration-300">Continue working on your existing applications.</p>
                 </div>
 
                 <!-- Search Input -->
                 <div class="mb-4 flex-shrink-0">
                   <div class="relative">
-                    <i class="fas fa-search absolute left-4 top-1/2 -translate-y-1/2 text-blue-950/40 dark:text-white/40 text-sm"></i>
+                    <i class="fas fa-search absolute left-4 top-1/2 -translate-y-1/2 text-blue-950/40 dark:text-blue-100/40 text-sm"></i>
                     <input
                       v-model="searchQuery"
                       type="text"
                       placeholder="Search projects..."
-                      class="w-full pl-11 pr-4 py-2.5 bg-white dark:bg-white/[0.04] border border-blue-200/70 dark:border-white/[0.12] focus:border-blue-400 dark:focus:border-blue-300/50 rounded-xl text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-white/40 text-sm transition-all duration-300"
-                      style="outline: none !important;"
+                      class="w-full pl-11 pr-4 py-2.5 bg-white dark:bg-white/[0.04] border border-blue-200/70 dark:border-white/[0.14] focus:border-blue-400 dark:focus:border-blue-300/50 rounded-xl text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-blue-100/40 text-sm transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
                     >
                   </div>
                 </div>
@@ -182,7 +181,7 @@
                     <p class="text-blue-950/70 dark:text-blue-100/70 mb-4 text-center max-w-md text-sm transition-colors duration-300">{{ error }}</p>
                     <button
                       @click="retryFetch"
-                      class="inline-flex items-center gap-2 px-5 py-2.5 bg-white dark:bg-white/[0.06] hover:bg-blue-50 dark:hover:bg-white/[0.1] border border-blue-200/70 dark:border-white/[0.12] rounded-xl text-blue-950 dark:text-white font-medium text-sm transition-all duration-300"
+                      class="inline-flex items-center gap-2 px-5 py-2.5 rounded-full border border-blue-950/[0.14] text-blue-950/80 hover:text-blue-950 hover:border-blue-950/30 hover:bg-blue-950/[0.03] dark:border-white/[0.16] dark:text-blue-100/80 dark:hover:text-white dark:hover:border-white/30 dark:hover:bg-white/[0.06] font-medium text-sm transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
                     >
                       <i class="fas fa-redo text-sm"></i>
                       <span>Try Again</span>
@@ -556,18 +555,87 @@ watch(
 </script>
 
 <style scoped>
-/* Remove browser default styling for form inputs */
-input, textarea {
-  outline: none !important;
-  box-shadow: none !important;
-  -webkit-appearance: none !important;
-  -moz-appearance: none !important;
-  appearance: none !important;
+/* Warm porcelain canvas fading to white so the page hands off to the footer
+   (footer is bg-white / dark #0a0a0a) — matches Home.vue */
+.projects-page {
+  background: linear-gradient(180deg, #fdf9f2 0%, #faf7f1 45%, #ffffff 100%);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
 }
 
-input:focus, textarea:focus {
-  outline: none !important;
-  box-shadow: none !important;
+.dark .projects-page {
+  background: linear-gradient(180deg, #0c0c0e 0%, #0a0b0f 50%, #0a0a0a 100%);
+}
+
+/* Fine film grain keeps large soft gradients from banding and adds texture */
+.grain-overlay {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)' opacity='0.5'/%3E%3C/svg%3E");
+  background-size: 160px 160px;
+  opacity: 0.035;
+  mix-blend-mode: multiply;
+}
+
+.dark .grain-overlay {
+  opacity: 0.05;
+  mix-blend-mode: overlay;
+}
+
+/* Soft apricot wash behind the page header */
+.page-glow-warm {
+  background: radial-gradient(closest-side, rgba(251, 146, 60, 0.13), rgba(251, 146, 60, 0.04) 55%, transparent 75%);
+  filter: blur(48px);
+}
+
+.dark .page-glow-warm {
+  background: radial-gradient(closest-side, rgba(251, 146, 60, 0.07), rgba(251, 146, 60, 0.02) 55%, transparent 75%);
+}
+
+/* Italic serif accent with the hero's warm gradient ink */
+.accent-ink {
+  font-style: italic;
+  font-variation-settings: 'SOFT' 30, 'WONK' 1;
+  background: linear-gradient(115deg, #c2410c 5%, #ea580c 55%, #b45309 95%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  padding-right: 0.06em;
+}
+
+.dark .accent-ink {
+  background: linear-gradient(115deg, #fb923c 5%, #fcd34d 60%, #f59e0b 95%);
+  -webkit-background-clip: text;
+  background-clip: text;
+}
+
+/* Page-load rise: header and panels fade up in sequence */
+.rise-item {
+  animation: rise-up 0.7s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@keyframes rise-up {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rise-item {
+    animation: none;
+  }
+}
+
+/* Quiet native input decorations (rings are applied via focus-visible classes) */
+input, textarea {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
 }
 
 /* Custom scrollbar for project list */
@@ -622,4 +690,17 @@ input:focus, textarea:focus {
     0 12px 28px -10px rgba(0, 0, 0, 0.55);
 }
 
+</style>
+
+<!-- Unscoped: brand-tinted text selection on the projects page -->
+<style>
+.projects-page ::selection {
+  background: rgba(158, 205, 243, 0.55);
+  color: #172554;
+}
+
+.dark .projects-page ::selection {
+  background: rgba(96, 165, 250, 0.4);
+  color: #eff6ff;
+}
 </style>

--- a/frontend/vuejs/src/apps/imagi/project-manager/views/ToolCategory.vue
+++ b/frontend/vuejs/src/apps/imagi/project-manager/views/ToolCategory.vue
@@ -10,11 +10,13 @@
 -->
 <template>
   <DefaultLayout :isHomeNav="true">
-    <div class="bg-orange-50 dark:bg-[#16120e] relative transition-colors duration-500 min-h-screen overflow-hidden">
-      <!-- Subtle background matching home page -->
-      <div class="absolute inset-0 pointer-events-none">
-        <div class="absolute inset-0 opacity-[0.015] dark:opacity-[0.02]"
-             style="background-image: linear-gradient(rgba(128,128,128,0.1) 1px, transparent 1px), linear-gradient(90deg, rgba(128,128,128,0.1) 1px, transparent 1px); background-size: 64px 64px;"></div>
+    <div class="tool-page relative transition-colors duration-500 min-h-screen overflow-hidden font-body">
+      <!-- Grain texture over the porcelain canvas -->
+      <div class="grain-overlay absolute inset-0 z-[1] pointer-events-none" aria-hidden="true"></div>
+
+      <!-- Atmosphere: one soft apricot wash behind the header -->
+      <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
+        <div class="page-glow-warm absolute -top-40 left-1/2 -translate-x-1/2 w-[760px] h-[440px]"></div>
       </div>
 
       <main class="relative z-10 flex flex-col px-6 sm:px-8 lg:px-12 pt-20 pb-12 min-h-screen">
@@ -23,7 +25,7 @@
           <!-- Back link -->
           <router-link
             :to="{ name: 'project-hub', params: { projectName } }"
-            class="inline-flex items-center gap-2 text-sm font-medium text-blue-950/60 dark:text-blue-100/60 hover:text-blue-950 dark:hover:text-white transition-colors duration-200 mb-6"
+            class="inline-flex items-center gap-2 rounded-full text-sm font-medium text-blue-950/70 dark:text-blue-100/55 hover:text-blue-950 dark:hover:text-white transition-colors duration-200 mb-6 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
           >
             <i class="fas fa-arrow-left text-xs"></i>
             <span>Project workspace</span>
@@ -31,13 +33,13 @@
 
           <!-- Unknown category -->
           <div v-if="!tool" class="flex flex-col items-center justify-center py-24 text-center">
-            <div class="w-16 h-16 bg-blue-50 dark:bg-white/[0.06] border border-blue-200/60 dark:border-white/[0.12] rounded-full flex items-center justify-center mb-6">
-              <i class="fas fa-circle-question text-2xl text-blue-950/40 dark:text-white/40"></i>
+            <div class="w-16 h-16 bg-blue-50 dark:bg-white/[0.06] border border-blue-200/60 dark:border-white/[0.14] rounded-full flex items-center justify-center mb-6">
+              <i class="fas fa-circle-question text-2xl text-blue-950/40 dark:text-blue-100/40"></i>
             </div>
-            <h2 class="text-2xl font-semibold text-blue-950 dark:text-white mb-3 transition-colors duration-300">Tool not found</h2>
+            <h2 class="text-2xl font-semibold tracking-tight text-blue-950 dark:text-white mb-3 transition-colors duration-300">Tool not found</h2>
             <router-link
               :to="{ name: 'project-hub', params: { projectName } }"
-              class="inline-flex items-center gap-2 px-5 py-2.5 bg-white dark:bg-white/[0.06] hover:bg-blue-50 dark:hover:bg-white/[0.1] border border-blue-200/70 dark:border-white/[0.12] rounded-xl text-blue-950 dark:text-white font-medium text-sm transition-all duration-300"
+              class="inline-flex items-center gap-2 px-5 py-2.5 rounded-full border border-blue-950/[0.14] text-blue-950/80 hover:text-blue-950 hover:border-blue-950/30 hover:bg-blue-950/[0.03] dark:border-white/[0.16] dark:text-blue-100/80 dark:hover:text-white dark:hover:border-white/30 dark:hover:bg-white/[0.06] font-medium text-sm transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
             >
               <i class="fas fa-arrow-left text-sm"></i>
               <span>Back to workspace</span>
@@ -46,7 +48,7 @@
 
           <template v-else>
             <!-- Header -->
-            <section class="flex flex-col sm:flex-row sm:items-center gap-5 mb-8">
+            <section class="rise-item flex flex-col sm:flex-row sm:items-center gap-5 mb-8" style="animation-delay: 0ms">
               <div
                 class="w-16 h-16 rounded-2xl flex items-center justify-center border flex-shrink-0 transition-colors duration-300"
                 :class="accent.iconWrap"
@@ -55,44 +57,44 @@
               </div>
               <div>
                 <div class="flex items-center gap-3 mb-1.5">
-                  <h1 class="text-3xl font-semibold text-blue-950 dark:text-white tracking-tight transition-colors duration-300">{{ tool.name }}</h1>
-                  <span class="inline-flex items-center px-2.5 py-1 rounded-full border border-blue-950/10 dark:border-white/15 bg-blue-950/[0.03] dark:bg-white/[0.04] text-[11px] font-semibold uppercase tracking-[0.14em] text-blue-950/50 dark:text-white/50 transition-colors duration-300">Coming soon</span>
+                  <h1 class="font-display text-3xl sm:text-4xl font-semibold text-blue-950 dark:text-white tracking-[-0.02em] leading-[1.05] transition-colors duration-300">{{ tool.name }}</h1>
+                  <span class="inline-flex items-center px-2.5 py-1 rounded-full border border-blue-950/10 dark:border-white/15 bg-blue-950/[0.03] dark:bg-white/[0.04] text-[11px] font-semibold uppercase tracking-[0.14em] text-blue-950/70 dark:text-blue-100/55 transition-colors duration-300">Coming soon</span>
                 </div>
-                <p class="text-base text-blue-950/70 dark:text-blue-100/70 max-w-2xl transition-colors duration-300">{{ tool.description }}</p>
+                <p class="text-base text-blue-950/65 dark:text-blue-100/65 max-w-2xl leading-relaxed transition-colors duration-300">{{ tool.description }}</p>
               </div>
             </section>
 
             <!-- Planned capabilities -->
-            <section class="mb-8">
-              <p class="inline-flex items-center px-3 py-1 rounded-full border text-xs font-semibold uppercase tracking-[0.18em] mb-4 transition-colors duration-300" :class="accent.badge">What's coming</p>
+            <section class="rise-item mb-8" style="animation-delay: 90ms">
+              <p class="inline-flex items-center px-3.5 py-1.5 rounded-full border text-xs font-semibold uppercase tracking-[0.18em] mb-4 transition-colors duration-300" :class="accent.badge">What's coming</p>
               <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
                 <div
                   v-for="feature in tool.features"
                   :key="feature.name"
-                  class="crisp-card p-5 rounded-2xl bg-white dark:bg-white/[0.05] border border-blue-200/70 dark:border-blue-300/[0.16] transition-colors duration-300"
+                  class="crisp-card p-5 rounded-2xl bg-white/85 dark:bg-white/[0.045] backdrop-blur-sm border border-blue-200/70 dark:border-blue-300/[0.14] transition-colors duration-300"
                 >
                   <div class="w-10 h-10 rounded-xl flex items-center justify-center border mb-3 transition-colors duration-300" :class="accent.iconWrap">
                     <i :class="['fas', feature.icon, accent.iconText]"></i>
                   </div>
-                  <h3 class="text-base font-semibold text-blue-950 dark:text-white mb-1 transition-colors duration-300">{{ feature.name }}</h3>
-                  <p class="text-sm text-blue-950/70 dark:text-blue-100/70 leading-snug transition-colors duration-300">{{ feature.description }}</p>
+                  <h3 class="text-base font-semibold tracking-tight text-blue-950 dark:text-white mb-1 transition-colors duration-300">{{ feature.name }}</h3>
+                  <p class="text-sm text-blue-950/65 dark:text-blue-100/65 leading-snug transition-colors duration-300">{{ feature.description }}</p>
                 </div>
               </div>
             </section>
 
             <!-- Placeholder notice -->
-            <section>
-              <div class="crisp-card p-6 md:p-8 rounded-2xl bg-white dark:bg-white/[0.05] border border-blue-200/70 dark:border-blue-300/[0.16] text-center transition-colors duration-300">
-                <div class="w-12 h-12 bg-blue-50 dark:bg-white/[0.06] border border-blue-200/60 dark:border-white/[0.12] rounded-full flex items-center justify-center mx-auto mb-4">
-                  <i class="fas fa-screwdriver-wrench text-xl text-blue-950/40 dark:text-white/40"></i>
+            <section class="rise-item" style="animation-delay: 180ms">
+              <div class="crisp-card p-6 md:p-8 rounded-2xl bg-white/85 dark:bg-white/[0.045] backdrop-blur-sm border border-blue-200/70 dark:border-blue-300/[0.14] text-center transition-colors duration-300">
+                <div class="w-12 h-12 bg-blue-50 dark:bg-white/[0.06] border border-blue-200/60 dark:border-white/[0.14] rounded-full flex items-center justify-center mx-auto mb-4">
+                  <i class="fas fa-screwdriver-wrench text-xl text-blue-950/40 dark:text-blue-100/40"></i>
                 </div>
-                <h3 class="text-lg font-semibold text-blue-950 dark:text-white mb-2 transition-colors duration-300">We're building this workspace</h3>
-                <p class="text-sm text-blue-950/70 dark:text-blue-100/70 max-w-md mx-auto mb-6 transition-colors duration-300">
+                <h3 class="text-lg font-semibold tracking-tight text-blue-950 dark:text-white mb-2 transition-colors duration-300">We're building this workspace</h3>
+                <p class="text-sm text-blue-950/65 dark:text-blue-100/65 max-w-md mx-auto mb-6 transition-colors duration-300">
                   {{ tool.name }} tools aren't available yet. In the meantime, you can start building your product with the app builder.
                 </p>
                 <router-link
                   :to="{ name: 'builder-workspace', params: { projectName } }"
-                  class="group inline-flex items-center justify-center gap-3 px-7 py-3 rounded-full font-medium text-base bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white transition-colors duration-200 shadow-[0_1px_2px_rgba(23,37,84,0.2),0_3px_8px_-2px_rgba(23,37,84,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#16120e]"
+                  class="group inline-flex items-center justify-center gap-3 px-7 py-3 rounded-full font-medium text-base bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white transition-colors duration-200 shadow-[0_1px_2px_rgba(23,37,84,0.2),0_3px_8px_-2px_rgba(23,37,84,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
                 >
                   <i class="fas fa-wand-magic-sparkles"></i>
                   <span>Open the app builder</span>
@@ -121,6 +123,64 @@ const accent = computed(() => accentClasses[tool.value?.accent ?? 'blue'])
 </script>
 
 <style scoped>
+/* Warm porcelain canvas fading to white so the page hands off to the footer
+   (footer is bg-white / dark #0a0a0a) — matches Home.vue */
+.tool-page {
+  background: linear-gradient(180deg, #fdf9f2 0%, #faf7f1 45%, #ffffff 100%);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+.dark .tool-page {
+  background: linear-gradient(180deg, #0c0c0e 0%, #0a0b0f 50%, #0a0a0a 100%);
+}
+
+/* Fine film grain keeps large soft gradients from banding and adds texture */
+.grain-overlay {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)' opacity='0.5'/%3E%3C/svg%3E");
+  background-size: 160px 160px;
+  opacity: 0.035;
+  mix-blend-mode: multiply;
+}
+
+.dark .grain-overlay {
+  opacity: 0.05;
+  mix-blend-mode: overlay;
+}
+
+/* Soft apricot wash behind the page header */
+.page-glow-warm {
+  background: radial-gradient(closest-side, rgba(251, 146, 60, 0.13), rgba(251, 146, 60, 0.04) 55%, transparent 75%);
+  filter: blur(48px);
+}
+
+.dark .page-glow-warm {
+  background: radial-gradient(closest-side, rgba(251, 146, 60, 0.07), rgba(251, 146, 60, 0.02) 55%, transparent 75%);
+}
+
+/* Page-load rise: header and sections fade up in sequence */
+.rise-item {
+  animation: rise-up 0.7s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@keyframes rise-up {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .rise-item {
+    animation: none;
+  }
+}
+
 /* Crisp, sharply-defined card matching Home/About - hairline edge + tight layered shadow */
 .crisp-card {
   box-shadow:
@@ -137,5 +197,17 @@ const accent = computed(() => accentClasses[tool.value?.accent ?? 'blue'])
     0 4px 10px -2px rgba(0, 0, 0, 0.45),
     0 12px 28px -10px rgba(0, 0, 0, 0.55);
 }
+</style>
 
+<!-- Unscoped: brand-tinted text selection on the tool page -->
+<style>
+.tool-page ::selection {
+  background: rgba(158, 205, 243, 0.55);
+  color: #172554;
+}
+
+.dark .tool-page ::selection {
+  background: rgba(96, 165, 250, 0.4);
+  color: #eff6ff;
+}
 </style>

--- a/frontend/vuejs/src/apps/imagi/sell/components/OrderStatusBadge.vue
+++ b/frontend/vuejs/src/apps/imagi/sell/components/OrderStatusBadge.vue
@@ -30,7 +30,7 @@ const colorClasses = computed(() => {
       return 'border-red-200/80 dark:border-red-400/25 bg-red-50/80 dark:bg-red-500/10 text-red-600 dark:text-red-300'
     default:
       // canceled, unknown
-      return 'border-blue-950/10 dark:border-white/15 bg-blue-950/[0.03] dark:bg-white/[0.04] text-blue-950/60 dark:text-white/60'
+      return 'border-blue-950/10 dark:border-white/15 bg-blue-950/[0.03] dark:bg-white/[0.04] text-blue-950/60 dark:text-blue-100/60'
   }
 })
 </script>

--- a/frontend/vuejs/src/apps/imagi/sell/components/ProductForm.vue
+++ b/frontend/vuejs/src/apps/imagi/sell/components/ProductForm.vue
@@ -35,10 +35,10 @@
           v-for="option in billingOptions"
           :key="option.value"
           type="button"
-          class="px-3 py-2.5 rounded-xl border text-sm font-medium transition-colors duration-150"
+          class="px-3 py-2.5 rounded-xl border text-sm font-medium transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#141418]"
           :class="form.billing_interval === option.value
             ? 'border-emerald-400 dark:border-emerald-400/60 bg-emerald-50 dark:bg-emerald-400/10 text-emerald-800 dark:text-emerald-200'
-            : 'border-blue-200/70 dark:border-white/[0.12] bg-white dark:bg-white/[0.06] text-blue-950/70 dark:text-blue-100/70 hover:border-blue-300 dark:hover:border-white/25'"
+            : 'border-blue-950/[0.14] dark:border-white/[0.14] bg-white dark:bg-white/[0.06] text-blue-950/70 dark:text-blue-100/70 hover:border-blue-950/30 dark:hover:border-white/25'"
           @click="form.billing_interval = option.value"
         >
           {{ option.label }}
@@ -82,7 +82,7 @@
     </div>
 
     <label class="flex items-center gap-2.5 text-sm text-blue-950/80 dark:text-blue-100/80 cursor-pointer">
-      <input v-model="form.is_active" type="checkbox" class="rounded border-blue-300 text-emerald-600 focus:ring-emerald-400/40" />
+      <input v-model="form.is_active" type="checkbox" class="rounded border-blue-950/30 dark:border-white/30 text-blue-950 dark:text-blue-400 focus:ring-blue-500/40 dark:focus:ring-blue-300/50" />
       Available for purchase
     </label>
 

--- a/frontend/vuejs/src/apps/imagi/sell/components/SellModal.vue
+++ b/frontend/vuejs/src/apps/imagi/sell/components/SellModal.vue
@@ -12,7 +12,7 @@
 
       <!-- Panel -->
       <div
-        class="relative w-full max-h-[88vh] overflow-y-auto crisp-card rounded-2xl bg-white dark:bg-[#211b16] border border-blue-200/70 dark:border-blue-300/[0.16] p-6"
+        class="relative w-full max-h-[88vh] overflow-y-auto crisp-card rounded-2xl bg-white dark:bg-[#141418] border border-blue-200/70 dark:border-blue-300/[0.14] p-6"
         :class="wide ? 'max-w-2xl' : 'max-w-lg'"
         role="dialog"
         aria-modal="true"
@@ -21,7 +21,7 @@
           <h3 class="text-lg font-semibold text-blue-950 dark:text-white transition-colors duration-300">{{ title }}</h3>
           <button
             type="button"
-            class="w-8 h-8 -mt-1 -mr-1 rounded-lg flex items-center justify-center text-blue-950/50 dark:text-white/50 hover:text-blue-950 dark:hover:text-white hover:bg-blue-50 dark:hover:bg-white/[0.08] transition-colors duration-200"
+            class="w-8 h-8 -mt-1 -mr-1 rounded-lg flex items-center justify-center text-blue-950/50 dark:text-blue-100/50 hover:text-blue-950 dark:hover:text-white hover:bg-blue-50 dark:hover:bg-white/[0.08] transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#141418]"
             aria-label="Close"
             @click="$emit('close')"
           >

--- a/frontend/vuejs/src/apps/imagi/sell/utils/ui.ts
+++ b/frontend/vuejs/src/apps/imagi/sell/utils/ui.ts
@@ -1,26 +1,28 @@
 /**
- * Shared Tailwind class strings for the Sell workspace, so every view uses
- * the same design language as the project hub (crisp cards, blue-950 ink,
- * emerald accent — the Sell tool's color in businessTools.ts). Keep these
- * as full static strings for the JIT compiler.
+ * Shared Tailwind class strings for the Sell workspace, aligned to the
+ * warm-porcelain editorial system defined by the home page: blue-950 ink,
+ * navy pill buttons, hairline borders, crisp-card panels. Emerald stays
+ * reserved for the Sell tool's identity accents (icon tiles, section badge,
+ * selected states — its color in businessTools.ts) and semantic statuses.
+ * Keep these as full static strings for the JIT compiler.
  */
 
 export const ui = {
-  card: 'crisp-card rounded-2xl bg-white dark:bg-white/[0.05] border border-blue-200/70 dark:border-blue-300/[0.16] transition-colors duration-300',
+  card: 'crisp-card rounded-2xl bg-white/85 dark:bg-white/[0.045] backdrop-blur-sm border border-blue-200/70 dark:border-blue-300/[0.14] transition-colors duration-300',
 
-  label: 'block text-xs font-semibold uppercase tracking-[0.14em] text-blue-950/60 dark:text-blue-100/60 mb-1.5 transition-colors duration-300',
+  label: 'block text-xs font-semibold uppercase tracking-[0.14em] text-blue-950/70 dark:text-blue-100/55 mb-1.5 transition-colors duration-300',
 
-  input: 'w-full px-3.5 py-2.5 rounded-xl bg-white dark:bg-white/[0.06] border border-blue-200/70 dark:border-white/[0.12] text-blue-950 dark:text-white text-sm placeholder-blue-950/40 dark:placeholder-white/30 focus:outline-none focus:ring-2 focus:ring-emerald-400/40 focus:border-emerald-300 dark:focus:border-emerald-400/40 transition-colors duration-200',
+  input: 'w-full px-3.5 py-2.5 rounded-xl bg-white dark:bg-white/[0.06] border border-blue-950/[0.14] dark:border-white/[0.14] text-blue-950 dark:text-white text-sm placeholder-blue-950/40 dark:placeholder-blue-100/30 focus:outline-none focus:ring-2 focus:ring-blue-500/40 dark:focus:ring-blue-300/50 focus:border-blue-300 dark:focus:border-blue-400/40 transition-colors duration-200',
 
-  primaryBtn: 'inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl bg-emerald-600 hover:bg-emerald-500 text-white text-sm font-medium transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed',
+  primaryBtn: 'inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-full bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white text-sm font-medium transition-colors duration-200 shadow-[0_1px_2px_rgba(23,37,84,0.2),0_3px_8px_-2px_rgba(23,37,84,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e] disabled:opacity-50 disabled:cursor-not-allowed',
 
-  secondaryBtn: 'inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl bg-white dark:bg-white/[0.06] hover:bg-blue-50 dark:hover:bg-white/[0.1] border border-blue-200/70 dark:border-white/[0.12] text-blue-950 dark:text-white text-sm font-medium transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed',
+  secondaryBtn: 'inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-full border border-blue-950/[0.14] text-blue-950/80 hover:text-blue-950 hover:border-blue-950/30 hover:bg-blue-950/[0.03] dark:border-white/[0.16] dark:text-blue-100/80 dark:hover:text-white dark:hover:border-white/30 dark:hover:bg-white/[0.06] text-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e] disabled:opacity-50 disabled:cursor-not-allowed',
 
-  dangerBtn: 'inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl bg-white dark:bg-white/[0.06] hover:bg-red-50 dark:hover:bg-red-500/10 border border-red-200/80 dark:border-red-400/25 text-red-600 dark:text-red-300 text-sm font-medium transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed',
+  dangerBtn: 'inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-full border border-red-200/80 dark:border-red-400/25 text-red-600 dark:text-red-300 hover:bg-red-50 dark:hover:bg-red-500/10 hover:border-red-300 dark:hover:border-red-400/40 text-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e] disabled:opacity-50 disabled:cursor-not-allowed',
 
   iconTile: 'rounded-xl flex items-center justify-center border bg-emerald-50 dark:bg-emerald-400/10 border-emerald-200/60 dark:border-emerald-400/25 text-emerald-600 dark:text-emerald-300 transition-colors duration-300',
 
-  sectionBadge: 'inline-flex items-center px-3 py-1 rounded-full border border-emerald-200/70 dark:border-emerald-400/25 bg-emerald-50/80 dark:bg-emerald-400/10 text-xs font-semibold uppercase tracking-[0.18em] text-emerald-700 dark:text-emerald-300 transition-colors duration-300',
+  sectionBadge: 'inline-flex items-center px-3.5 py-1.5 rounded-full border border-emerald-200/70 dark:border-emerald-400/25 bg-emerald-50/80 dark:bg-emerald-400/10 text-xs font-semibold uppercase tracking-[0.18em] text-emerald-700 dark:text-emerald-300 transition-colors duration-300',
 
   errorBox: 'p-3.5 rounded-xl border border-red-200/80 dark:border-red-400/25 bg-red-50/80 dark:bg-red-500/10 text-sm text-red-700 dark:text-red-300',
 

--- a/frontend/vuejs/src/apps/imagi/sell/views/CheckoutReturn.vue
+++ b/frontend/vuejs/src/apps/imagi/sell/views/CheckoutReturn.vue
@@ -7,14 +7,14 @@
   Cancel route:  /checkout/:projectId/cancel
 -->
 <template>
-  <div class="min-h-screen flex items-center justify-center px-6 bg-orange-50 dark:bg-[#16120e] transition-colors duration-500">
-    <div class="w-full max-w-md p-8 text-center crisp-card rounded-2xl bg-white dark:bg-white/[0.05] border border-blue-200/70 dark:border-blue-300/[0.16]">
+  <div class="min-h-screen flex items-center justify-center px-6 bg-[linear-gradient(180deg,#fdf9f2_0%,#faf7f1_60%,#ffffff_100%)] dark:bg-[linear-gradient(180deg,#0c0c0e_0%,#0a0b0f_60%,#0a0a0a_100%)] transition-colors duration-500">
+    <div class="w-full max-w-md p-8 text-center crisp-card rounded-2xl bg-white/85 dark:bg-white/[0.045] backdrop-blur-sm border border-blue-200/70 dark:border-blue-300/[0.14]">
       <!-- Canceled -->
       <template v-if="canceled">
-        <div class="w-14 h-14 mx-auto mb-5 rounded-full flex items-center justify-center border bg-blue-950/[0.03] dark:bg-white/[0.04] border-blue-950/10 dark:border-white/15 text-blue-950/50 dark:text-white/50">
+        <div class="w-14 h-14 mx-auto mb-5 rounded-full flex items-center justify-center border bg-blue-950/[0.03] dark:bg-white/[0.04] border-blue-950/10 dark:border-white/15 text-blue-950/50 dark:text-blue-100/50">
           <i class="fas fa-arrow-rotate-left text-xl"></i>
         </div>
-        <h1 class="text-2xl font-semibold text-blue-950 dark:text-white mb-2">Checkout canceled</h1>
+        <h1 class="font-display text-2xl font-semibold tracking-[-0.02em] leading-[1.05] text-blue-950 dark:text-white mb-2">Checkout canceled</h1>
         <p class="text-sm text-blue-950/60 dark:text-blue-100/60">
           No charge was made. You can close this page, or go back and try again.
         </p>
@@ -25,7 +25,7 @@
         <div class="w-14 h-14 mx-auto mb-5 rounded-full flex items-center justify-center border bg-emerald-50 dark:bg-emerald-400/10 border-emerald-200/60 dark:border-emerald-400/25">
           <div class="w-6 h-6 border-2 border-emerald-200 dark:border-emerald-300/30 border-t-emerald-600 dark:border-t-emerald-300 rounded-full animate-spin"></div>
         </div>
-        <h1 class="text-2xl font-semibold text-blue-950 dark:text-white mb-2">Confirming your payment…</h1>
+        <h1 class="font-display text-2xl font-semibold tracking-[-0.02em] leading-[1.05] text-blue-950 dark:text-white mb-2">Confirming your payment…</h1>
         <p class="text-sm text-blue-950/60 dark:text-blue-100/60">This usually takes a moment.</p>
       </template>
 
@@ -34,7 +34,7 @@
         <div class="w-14 h-14 mx-auto mb-5 rounded-full flex items-center justify-center border bg-emerald-50 dark:bg-emerald-400/10 border-emerald-200/60 dark:border-emerald-400/25 text-emerald-600 dark:text-emerald-300">
           <i class="fas fa-check text-xl"></i>
         </div>
-        <h1 class="text-2xl font-semibold text-blue-950 dark:text-white mb-2">Payment received</h1>
+        <h1 class="font-display text-2xl font-semibold tracking-[-0.02em] leading-[1.05] text-blue-950 dark:text-white mb-2">Payment received</h1>
         <p class="text-sm text-blue-950/60 dark:text-blue-100/60">
           Thanks! Your payment of
           <span class="font-semibold text-blue-950 dark:text-white">{{ formatMoney(amount, currency) }}</span>
@@ -47,7 +47,7 @@
         <div class="w-14 h-14 mx-auto mb-5 rounded-full flex items-center justify-center border bg-amber-50 dark:bg-amber-400/10 border-amber-200/60 dark:border-amber-400/25 text-amber-600 dark:text-amber-300">
           <i class="fas fa-hourglass-half text-xl"></i>
         </div>
-        <h1 class="text-2xl font-semibold text-blue-950 dark:text-white mb-2">Payment processing</h1>
+        <h1 class="font-display text-2xl font-semibold tracking-[-0.02em] leading-[1.05] text-blue-950 dark:text-white mb-2">Payment processing</h1>
         <p class="text-sm text-blue-950/60 dark:text-blue-100/60 mb-6">
           We haven't seen the confirmation yet. If you completed the payment, it will be
           recorded shortly.

--- a/frontend/vuejs/src/apps/imagi/sell/views/SellCustomers.vue
+++ b/frontend/vuejs/src/apps/imagi/sell/views/SellCustomers.vue
@@ -7,7 +7,7 @@
     <!-- Toolbar -->
     <div class="flex flex-col sm:flex-row sm:items-center gap-3 mb-6">
       <div class="relative flex-1 max-w-sm">
-        <i class="fas fa-magnifying-glass absolute left-3.5 top-1/2 -translate-y-1/2 text-xs text-blue-950/40 dark:text-white/30"></i>
+        <i class="fas fa-magnifying-glass absolute left-3.5 top-1/2 -translate-y-1/2 text-xs text-blue-950/40 dark:text-blue-100/30"></i>
         <input
           v-model="search"
           type="search"

--- a/frontend/vuejs/src/apps/imagi/sell/views/SellOrders.vue
+++ b/frontend/vuejs/src/apps/imagi/sell/views/SellOrders.vue
@@ -10,10 +10,10 @@
         v-for="option in statusFilters"
         :key="option.value"
         type="button"
-        class="px-3.5 py-1.5 rounded-full text-xs font-semibold uppercase tracking-[0.1em] border transition-colors duration-150"
+        class="px-3.5 py-1.5 rounded-full text-xs font-semibold uppercase tracking-[0.1em] border transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
         :class="statusFilter === option.value
           ? 'border-emerald-300 dark:border-emerald-400/40 bg-emerald-50 dark:bg-emerald-400/10 text-emerald-700 dark:text-emerald-300'
-          : 'border-blue-200/70 dark:border-white/[0.12] text-blue-950/60 dark:text-blue-100/60 hover:text-blue-950 dark:hover:text-white'"
+          : 'border-blue-950/[0.14] dark:border-white/[0.16] text-blue-950/60 dark:text-blue-100/60 hover:text-blue-950 dark:hover:text-white hover:border-blue-950/30 dark:hover:border-white/30'"
         @click="setFilter(option.value)"
       >
         {{ option.label }}
@@ -52,7 +52,7 @@
             <button
               v-if="order.status === 'paid'"
               type="button"
-              class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-blue-700 dark:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-400/10 border border-blue-200/70 dark:border-blue-400/25 transition-colors duration-150"
+              class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium text-blue-950/80 dark:text-blue-100/80 hover:text-blue-950 dark:hover:text-white hover:bg-blue-950/[0.03] dark:hover:bg-white/[0.06] border border-blue-950/[0.14] dark:border-white/[0.16] hover:border-blue-950/30 dark:hover:border-white/30 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
               :disabled="busyOrderId === order.id"
               @click="fulfill(order.id)"
             >
@@ -62,7 +62,7 @@
             <button
               v-if="order.status === 'pending' && order.stripe_checkout_session_id"
               type="button"
-              class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-blue-950/70 dark:text-blue-100/70 hover:bg-blue-50 dark:hover:bg-white/[0.08] border border-blue-200/70 dark:border-white/[0.12] transition-colors duration-150"
+              class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium text-blue-950/80 dark:text-blue-100/80 hover:text-blue-950 dark:hover:text-white hover:bg-blue-950/[0.03] dark:hover:bg-white/[0.06] border border-blue-950/[0.14] dark:border-white/[0.16] hover:border-blue-950/30 dark:hover:border-white/30 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
               title="Check the payment status with Stripe"
               :disabled="busyOrderId === order.id"
               @click="sync(order.id)"
@@ -73,7 +73,7 @@
           </div>
         </div>
         <!-- Items -->
-        <div v-if="order.items.length" class="mt-3 pl-13 sm:pl-[52px]">
+        <div v-if="order.items.length" class="mt-3 pl-[52px]">
           <p v-for="item in order.items" :key="item.id" class="text-xs text-blue-950/60 dark:text-blue-100/60">
             {{ item.quantity }} × {{ item.product_name }} — {{ formatMoney(item.unit_price_cents * item.quantity, order.currency) }}
           </p>

--- a/frontend/vuejs/src/apps/imagi/sell/views/SellOverview.vue
+++ b/frontend/vuejs/src/apps/imagi/sell/views/SellOverview.vue
@@ -59,7 +59,7 @@
           <h2 class="text-base font-semibold text-blue-950 dark:text-white">Recent orders</h2>
           <router-link
             :to="{ name: 'sell-orders', params: { projectName: route.params.projectName } }"
-            class="text-sm font-medium text-emerald-700 dark:text-emerald-300 hover:text-emerald-900 dark:hover:text-emerald-200 transition-colors duration-200"
+            class="rounded-sm text-sm font-medium text-blue-950/70 dark:text-blue-100/70 hover:text-blue-950 dark:hover:text-white underline underline-offset-4 decoration-blue-950/25 dark:decoration-blue-100/30 hover:decoration-blue-950/60 dark:hover:decoration-blue-100/70 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
           >
             View all
           </router-link>

--- a/frontend/vuejs/src/apps/imagi/sell/views/SellPayments.vue
+++ b/frontend/vuejs/src/apps/imagi/sell/views/SellPayments.vue
@@ -50,7 +50,7 @@
             It's live at the <code class="font-mono">{{ installedNotice.route }}</code> page of your app.
             <router-link
               :to="{ name: 'builder-workspace', params: { projectName: route.params.projectName } }"
-              class="underline hover:no-underline"
+              class="rounded-sm underline hover:no-underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50"
             >
               Open the Build workspace
             </router-link>
@@ -115,7 +115,7 @@
           <div class="w-11 h-11 text-lg" :class="ui.iconTile">
             <i class="fas fa-link"></i>
           </div>
-          <span class="inline-flex items-center px-2.5 py-0.5 rounded-full border border-blue-950/10 dark:border-white/15 bg-blue-950/[0.03] dark:bg-white/[0.04] text-[11px] font-semibold uppercase tracking-[0.1em] text-blue-950/60 dark:text-white/60">
+          <span class="inline-flex items-center px-2.5 py-0.5 rounded-full border border-blue-950/10 dark:border-white/15 bg-blue-950/[0.03] dark:bg-white/[0.04] text-[11px] font-semibold uppercase tracking-[0.1em] text-blue-950/60 dark:text-blue-100/60">
             No code
           </span>
         </div>

--- a/frontend/vuejs/src/apps/imagi/sell/views/SellProducts.vue
+++ b/frontend/vuejs/src/apps/imagi/sell/views/SellProducts.vue
@@ -7,7 +7,7 @@
     <!-- Toolbar -->
     <div class="flex flex-col sm:flex-row sm:items-center gap-3 mb-6">
       <div class="relative flex-1 max-w-sm">
-        <i class="fas fa-magnifying-glass absolute left-3.5 top-1/2 -translate-y-1/2 text-xs text-blue-950/40 dark:text-white/30"></i>
+        <i class="fas fa-magnifying-glass absolute left-3.5 top-1/2 -translate-y-1/2 text-xs text-blue-950/40 dark:text-blue-100/30"></i>
         <input
           v-model="search"
           type="search"
@@ -59,7 +59,7 @@
                 class="inline-flex items-center px-2.5 py-0.5 rounded-full border text-[11px] font-semibold uppercase tracking-[0.1em] whitespace-nowrap"
                 :class="product.is_active
                   ? 'border-emerald-200/80 dark:border-emerald-400/25 bg-emerald-50/80 dark:bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
-                  : 'border-blue-950/10 dark:border-white/15 bg-blue-950/[0.03] dark:bg-white/[0.04] text-blue-950/60 dark:text-white/60'"
+                  : 'border-blue-950/10 dark:border-white/15 bg-blue-950/[0.03] dark:bg-white/[0.04] text-blue-950/60 dark:text-blue-100/60'"
               >
                 {{ product.is_active ? 'Active' : 'Hidden' }}
               </span>
@@ -69,7 +69,7 @@
           <div class="flex flex-wrap items-center gap-2 mt-3">
             <button
               type="button"
-              class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-emerald-700 dark:text-emerald-300 hover:bg-emerald-50 dark:hover:bg-emerald-400/10 border border-emerald-200/70 dark:border-emerald-400/25 transition-colors duration-150 disabled:opacity-50"
+              class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium text-blue-950/80 dark:text-blue-100/80 hover:text-blue-950 dark:hover:text-white hover:bg-blue-950/[0.03] dark:hover:bg-white/[0.06] border border-blue-950/[0.14] dark:border-white/[0.16] hover:border-blue-950/30 dark:hover:border-white/30 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e] disabled:opacity-50"
               :disabled="!product.is_active || linkLoadingId === product.id || !store.isConfigured"
               :title="store.isConfigured ? 'Create a Stripe Checkout link and copy it' : 'Connect Stripe in Settings first'"
               @click="copyPaymentLink(product.id)"
@@ -79,7 +79,7 @@
             </button>
             <button
               type="button"
-              class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-blue-950/70 dark:text-blue-100/70 hover:bg-blue-50 dark:hover:bg-white/[0.08] border border-blue-200/70 dark:border-white/[0.12] transition-colors duration-150"
+              class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium text-blue-950/80 dark:text-blue-100/80 hover:text-blue-950 dark:hover:text-white hover:bg-blue-950/[0.03] dark:hover:bg-white/[0.06] border border-blue-950/[0.14] dark:border-white/[0.16] hover:border-blue-950/30 dark:hover:border-white/30 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
               @click="openEdit(product)"
             >
               <i class="fas fa-pen"></i>
@@ -87,7 +87,7 @@
             </button>
             <button
               type="button"
-              class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-red-600 dark:text-red-300 hover:bg-red-50 dark:hover:bg-red-500/10 border border-red-200/80 dark:border-red-400/25 transition-colors duration-150"
+              class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium text-red-600 dark:text-red-300 hover:bg-red-50 dark:hover:bg-red-500/10 border border-red-200/80 dark:border-red-400/25 hover:border-red-300 dark:hover:border-red-400/40 transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
               @click="confirmDelete(product)"
             >
               <i class="fas fa-trash"></i>

--- a/frontend/vuejs/src/apps/imagi/sell/views/SellSettings.vue
+++ b/frontend/vuejs/src/apps/imagi/sell/views/SellSettings.vue
@@ -18,7 +18,7 @@
       </div>
       <p class="text-sm text-blue-950/60 dark:text-blue-100/60 mb-6">
         Find these under
-        <a href="https://dashboard.stripe.com/apikeys" target="_blank" rel="noopener noreferrer" class="text-emerald-700 dark:text-emerald-300 hover:underline">Developers → API keys</a>
+        <a href="https://dashboard.stripe.com/apikeys" target="_blank" rel="noopener noreferrer" class="rounded-sm font-medium text-blue-950/80 dark:text-blue-100/80 hover:text-blue-950 dark:hover:text-white underline underline-offset-2 decoration-blue-950/30 dark:decoration-blue-100/30 hover:decoration-blue-950/60 dark:hover:decoration-blue-100/70 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]">Developers → API keys</a>
         in your Stripe dashboard. Payments go directly to your own Stripe account.
       </p>
 
@@ -125,7 +125,7 @@
             <code class="flex-1 px-3 py-2 rounded-lg bg-blue-950/[0.04] dark:bg-white/[0.06] border border-blue-200/60 dark:border-white/[0.08] font-mono text-[11px] text-blue-950/80 dark:text-blue-100/80 break-all">{{ settings.stripe_webhook_url }}</code>
             <button
               type="button"
-              class="w-8 h-8 shrink-0 rounded-lg flex items-center justify-center text-blue-950/50 dark:text-white/50 hover:text-blue-950 dark:hover:text-white hover:bg-blue-50 dark:hover:bg-white/[0.08] transition-colors duration-150"
+              class="w-8 h-8 shrink-0 rounded-lg flex items-center justify-center text-blue-950/50 dark:text-blue-100/50 hover:text-blue-950 dark:hover:text-white hover:bg-blue-50 dark:hover:bg-white/[0.08] transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
               title="Copy"
               @click="copy(settings.stripe_webhook_url)"
             >

--- a/frontend/vuejs/src/apps/imagi/sell/views/SellWorkspace.vue
+++ b/frontend/vuejs/src/apps/imagi/sell/views/SellWorkspace.vue
@@ -9,20 +9,14 @@
 -->
 <template>
   <DefaultLayout :isHomeNav="true">
-    <div class="bg-orange-50 dark:bg-[#16120e] relative transition-colors duration-500 min-h-screen overflow-hidden">
-      <!-- Subtle background matching home page -->
-      <div class="absolute inset-0 pointer-events-none">
-        <div class="absolute inset-0 opacity-[0.015] dark:opacity-[0.02]"
-             style="background-image: linear-gradient(rgba(128,128,128,0.1) 1px, transparent 1px), linear-gradient(90deg, rgba(128,128,128,0.1) 1px, transparent 1px); background-size: 64px 64px;"></div>
-      </div>
-
+    <div class="relative min-h-screen overflow-hidden bg-[linear-gradient(180deg,#fdf9f2_0%,#faf7f1_60%,#ffffff_100%)] dark:bg-[linear-gradient(180deg,#0c0c0e_0%,#0a0b0f_60%,#0a0a0a_100%)] transition-colors duration-500">
       <main class="relative z-10 flex flex-col px-6 sm:px-8 lg:px-12 pt-20 pb-16 min-h-screen">
         <div class="max-w-6xl mx-auto w-full">
 
           <!-- Back link -->
           <router-link
             :to="{ name: 'project-hub', params: { projectName } }"
-            class="inline-flex items-center gap-2 text-sm font-medium text-blue-950/60 dark:text-blue-100/60 hover:text-blue-950 dark:hover:text-white transition-colors duration-200 mb-6"
+            class="inline-flex items-center gap-2 rounded-full text-sm font-medium text-blue-950/60 dark:text-blue-100/60 hover:text-blue-950 dark:hover:text-white transition-colors duration-200 mb-6 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
           >
             <i class="fas fa-arrow-left text-xs"></i>
             <span>Project workspace</span>
@@ -39,7 +33,7 @@
           <!-- Not found -->
           <div v-else-if="!project" class="flex flex-col items-center justify-center py-24 text-center">
             <div class="w-16 h-16 bg-blue-50 dark:bg-white/[0.06] border border-blue-200/60 dark:border-white/[0.12] rounded-full flex items-center justify-center mb-6">
-              <i class="fas fa-folder-open text-2xl text-blue-950/40 dark:text-white/40"></i>
+              <i class="fas fa-folder-open text-2xl text-blue-950/40 dark:text-blue-100/40"></i>
             </div>
             <h2 class="text-2xl font-semibold text-blue-950 dark:text-white mb-3 transition-colors duration-300">Project not found</h2>
             <p class="text-blue-950/70 dark:text-blue-100/70 mb-8 max-w-md transition-colors duration-300">We couldn't find this project. It may have been deleted.</p>
@@ -57,7 +51,7 @@
               </div>
               <div class="min-w-0">
                 <div class="flex flex-wrap items-center gap-3 mb-1.5">
-                  <h1 class="text-3xl font-semibold text-blue-950 dark:text-white tracking-tight transition-colors duration-300">Sell</h1>
+                  <h1 class="font-display text-3xl font-semibold text-blue-950 dark:text-white tracking-[-0.02em] leading-[1.05] transition-colors duration-300">Sell</h1>
                   <span :class="ui.sectionBadge">{{ project.name }}</span>
                 </div>
                 <p class="text-base text-blue-950/70 dark:text-blue-100/70 max-w-2xl transition-colors duration-300">
@@ -87,12 +81,12 @@
             </div>
 
             <!-- Tabs -->
-            <nav class="flex items-center gap-1.5 overflow-x-auto pb-px mb-6 border-b border-blue-200/60 dark:border-white/[0.1]">
+            <nav class="flex items-center gap-1.5 overflow-x-auto pb-px mb-6 border-b border-blue-950/[0.08] dark:border-white/[0.14]">
               <router-link
                 v-for="tab in tabs"
                 :key="tab.name"
                 :to="{ name: tab.name, params: { projectName } }"
-                class="inline-flex items-center gap-2 px-4 py-2.5 rounded-t-xl text-sm font-medium whitespace-nowrap border-b-2 -mb-px transition-colors duration-200"
+                class="inline-flex items-center gap-2 px-4 py-2.5 rounded-t-xl text-sm font-medium whitespace-nowrap border-b-2 -mb-px transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-inset"
                 :class="isActiveTab(tab)
                   ? 'border-emerald-500 dark:border-emerald-400 text-blue-950 dark:text-white'
                   : 'border-transparent text-blue-950/60 dark:text-blue-100/60 hover:text-blue-950 dark:hover:text-white'"

--- a/frontend/vuejs/src/apps/payments/components/atoms/buttons/Button/Button.vue
+++ b/frontend/vuejs/src/apps/payments/components/atoms/buttons/Button/Button.vue
@@ -1,15 +1,15 @@
 <template>
-  <button 
+  <button
     :type="type"
-    :disabled="disabled" 
+    :disabled="disabled"
     :class="[
-      'px-6 py-3 rounded-xl transition-all duration-300 transform font-medium',
-      variant === 'primary' ? 'bg-gradient-to-r from-primary-600 to-primary-500 hover:from-primary-500 hover:to-primary-400 text-white shadow-lg shadow-primary-500/20 hover:shadow-xl hover:shadow-primary-500/30 hover:scale-[1.02]' : '',
-      variant === 'secondary' ? 'bg-white/5 backdrop-blur-sm border border-white/20 text-white hover:bg-white/10 hover:scale-[1.02]' : '',
-      variant === 'danger' ? 'bg-gradient-to-r from-red-600 to-red-500 hover:from-red-500 hover:to-red-400 text-white shadow-lg shadow-red-500/20 hover:shadow-xl hover:shadow-red-500/30 hover:scale-[1.02]' : '',
-      variant === 'outline' ? 'bg-transparent border border-primary-500 text-primary-400 hover:bg-primary-500/10 hover:scale-[1.02]' : '',
-      variant === 'success' ? 'bg-gradient-to-r from-green-600 to-green-500 hover:from-green-500 hover:to-green-400 text-white shadow-lg shadow-green-500/20 hover:shadow-xl hover:shadow-green-500/30 hover:scale-[1.02]' : '',
-      disabled ? 'opacity-50 cursor-not-allowed transform-none hover:scale-100' : '',
+      'inline-flex items-center justify-center px-6 py-3 rounded-full transition-colors duration-200 font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]',
+      variant === 'primary' ? 'bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white shadow-[0_1px_2px_rgba(23,37,84,0.2),0_3px_8px_-2px_rgba(23,37,84,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)]' : '',
+      variant === 'secondary' ? 'border border-blue-950/[0.14] text-blue-950/80 hover:text-blue-950 hover:border-blue-950/30 hover:bg-blue-950/[0.03] dark:border-white/[0.16] dark:text-blue-100/80 dark:hover:text-white dark:hover:border-white/30 dark:hover:bg-white/[0.06]' : '',
+      variant === 'danger' ? 'bg-red-600 text-white hover:bg-red-500 dark:bg-red-500 dark:text-white dark:hover:bg-red-400 shadow-[0_1px_2px_rgba(127,29,29,0.2),0_3px_8px_-2px_rgba(127,29,29,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)]' : '',
+      variant === 'outline' ? 'bg-transparent border border-blue-950/[0.14] text-blue-950/80 hover:text-blue-950 hover:border-blue-950/30 hover:bg-blue-950/[0.03] dark:border-white/[0.16] dark:text-blue-100/80 dark:hover:text-white dark:hover:border-white/30 dark:hover:bg-white/[0.06]' : '',
+      variant === 'success' ? 'bg-emerald-600 text-white hover:bg-emerald-500 dark:bg-emerald-500 dark:text-white dark:hover:bg-emerald-400 shadow-[0_1px_2px_rgba(6,78,59,0.2),0_3px_8px_-2px_rgba(6,78,59,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)]' : '',
+      disabled ? 'opacity-50 cursor-not-allowed' : '',
       fullWidth ? 'w-full' : '',
       loading ? 'relative' : '',
       customClass
@@ -62,10 +62,11 @@ export default defineComponent({
 </script>
 
 <style scoped>
+/* Spinner inherits the button's ink color so it reads in both themes */
 .spinner-sm {
-  border: 2px solid rgba(255, 255, 255, 0.3);
+  border: 2px solid rgba(128, 128, 128, 0.25);
   border-radius: 50%;
-  border-top: 2px solid #fff;
+  border-top: 2px solid currentColor;
   width: 16px;
   height: 16px;
   animation: spin 1s linear infinite;
@@ -74,17 +75,5 @@ export default defineComponent({
 @keyframes spin {
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
-}
-
-/* Gradient animation for buttons */
-@keyframes gradient-shift {
-  0% { background-position: 0% 50%; }
-  50% { background-position: 100% 50%; }
-  100% { background-position: 0% 50%; }
-}
-
-.bg-gradient-to-r {
-  background-size: 200% auto;
-  animation: gradient-shift 8s ease infinite;
 }
 </style> 

--- a/frontend/vuejs/src/apps/payments/components/atoms/cards/BalanceDisplay/BalanceDisplay.vue
+++ b/frontend/vuejs/src/apps/payments/components/atoms/cards/BalanceDisplay/BalanceDisplay.vue
@@ -1,13 +1,13 @@
 <template>
   <div class="balance-display">
-    <div class="text-sm text-white/70 mb-2">{{ label }}</div>
+    <div class="text-sm text-blue-950/70 dark:text-blue-100/55 mb-2 transition-colors duration-300">{{ label }}</div>
     <div v-if="loading" class="animate-pulse-slow py-1">
-      <div class="h-10 w-32 bg-dark-800/80 rounded-lg"></div>
+      <div class="h-10 w-32 bg-blue-950/10 dark:bg-white/10 rounded-lg"></div>
     </div>
-    <div v-else class="font-bold text-3xl bg-gradient-to-r from-primary-300 to-primary-500 bg-clip-text text-transparent">
+    <div v-else class="font-display font-semibold text-3xl tracking-tight tabular-nums text-blue-950 dark:text-white transition-colors duration-300">
       {{ formattedBalance }}
     </div>
-    <div v-if="showLastUpdated && lastUpdated" class="text-sm text-white/60 mt-2">
+    <div v-if="showLastUpdated && lastUpdated" class="text-sm text-blue-950/60 dark:text-blue-100/55 mt-2 transition-colors duration-300">
       Last updated: {{ formatDate(lastUpdated) }}
     </div>
   </div>
@@ -70,18 +70,6 @@ const formatDate = (dateStr: string | Date) => {
   transition: all 0.3s ease;
 }
 
-/* Gradient animation for text */
-@keyframes gradient-shift {
-  0% { background-position: 0% 50%; }
-  50% { background-position: 100% 50%; }
-  100% { background-position: 0% 50%; }
-}
-
-.bg-gradient-to-r {
-  background-size: 200% auto;
-  animation: gradient-shift 8s ease infinite;
-}
-
 /* Pulsing animation for loading state */
 @keyframes pulse-slow {
   0%, 100% { opacity: 0.6; }
@@ -90,5 +78,11 @@ const formatDate = (dateStr: string | Date) => {
 
 .animate-pulse-slow {
   animation: pulse-slow 1.5s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-pulse-slow {
+    animation: none;
+  }
 }
 </style> 

--- a/frontend/vuejs/src/apps/payments/components/atoms/cards/Card/Card.vue
+++ b/frontend/vuejs/src/apps/payments/components/atoms/cards/Card/Card.vue
@@ -1,27 +1,21 @@
 <template>
-  <div 
+  <div
     :class="[
-      'group relative backdrop-blur-sm bg-dark-800/40 border border-gray-800/60 shadow-xl rounded-2xl overflow-hidden transition-all duration-500',
-      hoverable ? 'transform hover:-translate-y-1 hover:shadow-[0_0_20px_-5px_rgba(99,102,241,0.4)]' : '',
+      'payment-card group relative backdrop-blur-sm bg-white/85 dark:bg-white/[0.045] border border-blue-950/[0.08] dark:border-white/[0.1] rounded-2xl overflow-hidden transition-all duration-300',
+      hoverable ? 'hoverable' : '',
       customClass
     ]"
   >
-    <!-- Card top highlight -->
-    <div class="absolute top-0 inset-x-0 h-px bg-gradient-to-r from-primary-500/0 via-primary-500/60 to-primary-500/0"></div>
-    
-    <!-- Background gradient -->
-    <div class="absolute inset-0 bg-gradient-to-br opacity-10 -z-10 from-primary-900 to-violet-900 transition-opacity duration-300 group-hover:opacity-20"></div>
-    
-    <!-- Glowing orb decoration -->
-    <div v-if="showDecoration" class="absolute -bottom-20 -right-20 w-40 h-40 rounded-full opacity-10 blur-3xl transition-opacity duration-500 group-hover:opacity-20 bg-primary-500"></div>
-    
-    <div v-if="$slots.header" :class="['p-6 border-b border-white/10', headerClass]">
+    <!-- Soft baby-blue orb decoration -->
+    <div v-if="showDecoration" class="absolute -bottom-20 -right-20 w-40 h-40 rounded-full blur-3xl pointer-events-none bg-[#9ecdf3]/25 dark:bg-blue-400/10 transition-opacity duration-500" aria-hidden="true"></div>
+
+    <div v-if="$slots.header" :class="['p-6 border-b border-blue-950/[0.08] dark:border-white/[0.1]', headerClass]">
       <slot name="header"></slot>
     </div>
     <div :class="['p-6', contentClass]">
       <slot></slot>
     </div>
-    <div v-if="$slots.footer" :class="['p-6 border-t border-white/10', footerClass]">
+    <div v-if="$slots.footer" :class="['p-6 border-t border-blue-950/[0.08] dark:border-white/[0.1]', footerClass]">
       <slot name="footer"></slot>
     </div>
   </div>
@@ -62,31 +56,44 @@ export default defineComponent({
 </script>
 
 <style scoped>
-/* Subtle glow effect for cards */
-.backdrop-blur-sm {
-  position: relative;
+/* Crisp, sharply-defined card: hairline edge + tight layered shadow */
+.payment-card {
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.03),
+    0 1px 2px rgba(15, 23, 42, 0.06),
+    0 4px 10px -2px rgba(15, 23, 42, 0.07),
+    0 12px 28px -10px rgba(15, 23, 42, 0.10);
 }
 
-.backdrop-blur-sm::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: -1;
-  filter: blur(20px);
-  opacity: 0.1;
-  background: radial-gradient(circle at top right, var(--tw-gradient-stops));
-  --tw-gradient-from: theme('colors.primary.500');
-  --tw-gradient-stops: var(--tw-gradient-from), transparent 70%;
-  border-radius: inherit;
-  transform: translate(0, 0) scale(0.95);
-  pointer-events: none;
-  transition: opacity 0.3s ease-in-out;
+.dark .payment-card {
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 12px 28px -10px rgba(0, 0, 0, 0.55);
 }
 
-.backdrop-blur-sm:hover::after {
-  opacity: 0.15;
+/* Gentle lift on hover for hoverable cards */
+.payment-card.hoverable:hover {
+  transform: translateY(-4px);
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.04),
+    0 2px 4px rgba(15, 23, 42, 0.06),
+    0 10px 20px -4px rgba(15, 23, 42, 0.1),
+    0 24px 44px -12px rgba(15, 23, 42, 0.14);
+}
+
+.dark .payment-card.hoverable:hover {
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.06),
+    0 2px 4px rgba(0, 0, 0, 0.5),
+    0 12px 24px -4px rgba(0, 0, 0, 0.5),
+    0 28px 48px -12px rgba(0, 0, 0, 0.6);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .payment-card.hoverable:hover {
+    transform: none;
+  }
 }
 </style> 

--- a/frontend/vuejs/src/apps/payments/components/atoms/indicators/Spinner/Spinner.vue
+++ b/frontend/vuejs/src/apps/payments/components/atoms/indicators/Spinner/Spinner.vue
@@ -30,35 +30,53 @@ export default defineComponent({
 </script>
 
 <style scoped>
+/* Navy-ink spinner: dual-theme, no neon */
 .spinner {
   position: relative;
   border-radius: 50%;
-  border-top-color: #00ffc6;
   animation: spin 1.2s cubic-bezier(0.65, 0, 0.35, 1) infinite;
 }
 
 .spinner-sm {
   width: 16px;
   height: 16px;
-  border: 2px solid rgba(0, 255, 198, 0.05);
-  border-top: 2px solid #00ffc6;
-  border-right: 2px solid rgba(0, 255, 198, 0.2);
+  border: 2px solid rgba(23, 37, 84, 0.08);
+  border-top: 2px solid #172554;
+  border-right: 2px solid rgba(23, 37, 84, 0.25);
 }
 
 .spinner-md {
   width: 24px;
   height: 24px;
-  border: 3px solid rgba(0, 255, 198, 0.05);
-  border-top: 3px solid #00ffc6;
-  border-right: 3px solid rgba(0, 255, 198, 0.2);
+  border: 3px solid rgba(23, 37, 84, 0.08);
+  border-top: 3px solid #172554;
+  border-right: 3px solid rgba(23, 37, 84, 0.25);
 }
 
 .spinner-lg {
   width: 48px;
   height: 48px;
-  border: 4px solid rgba(0, 255, 198, 0.05);
-  border-top: 4px solid #00ffc6;
-  border-right: 4px solid rgba(0, 255, 198, 0.2);
+  border: 4px solid rgba(23, 37, 84, 0.08);
+  border-top: 4px solid #172554;
+  border-right: 4px solid rgba(23, 37, 84, 0.25);
+}
+
+.dark .spinner-sm {
+  border: 2px solid rgba(255, 255, 255, 0.08);
+  border-top: 2px solid #f3ede2;
+  border-right: 2px solid rgba(255, 255, 255, 0.25);
+}
+
+.dark .spinner-md {
+  border: 3px solid rgba(255, 255, 255, 0.08);
+  border-top: 3px solid #f3ede2;
+  border-right: 3px solid rgba(255, 255, 255, 0.25);
+}
+
+.dark .spinner-lg {
+  border: 4px solid rgba(255, 255, 255, 0.08);
+  border-top: 4px solid #f3ede2;
+  border-right: 4px solid rgba(255, 255, 255, 0.25);
 }
 
 .spinner-glow {
@@ -68,10 +86,14 @@ export default defineComponent({
   transform: translate(-50%, -50%);
   width: 150%;
   height: 150%;
-  background: radial-gradient(circle, rgba(0, 255, 198, 0.2) 0%, rgba(0, 255, 198, 0) 70%);
+  background: radial-gradient(circle, rgba(158, 205, 243, 0.25) 0%, rgba(158, 205, 243, 0) 70%);
   border-radius: 50%;
   z-index: -1;
   animation: pulse 2s ease-in-out infinite;
+}
+
+.dark .spinner-glow {
+  background: radial-gradient(circle, rgba(96, 165, 250, 0.15) 0%, rgba(96, 165, 250, 0) 70%);
 }
 
 @keyframes spin {
@@ -82,5 +104,11 @@ export default defineComponent({
 @keyframes pulse {
   0%, 100% { opacity: 0.3; transform: translate(-50%, -50%) scale(0.8); }
   50% { opacity: 0.7; transform: translate(-50%, -50%) scale(1.2); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner-glow {
+    animation: none;
+  }
 }
 </style> 

--- a/frontend/vuejs/src/apps/payments/components/atoms/inputs/Input.vue
+++ b/frontend/vuejs/src/apps/payments/components/atoms/inputs/Input.vue
@@ -1,10 +1,10 @@
 <template>
   <div>
-    <label v-if="label" :for="id" class="block text-sm font-medium text-white/80 mb-2">
+    <label v-if="label" :for="id" class="block text-sm font-medium text-blue-950/80 dark:text-blue-100/80 mb-2 transition-colors duration-300">
       {{ label }}
     </label>
     <div class="relative" :class="{ 'mt-2': !!label }">
-      <span v-if="prefix" class="absolute left-4 top-1/2 transform -translate-y-1/2 text-white/60">
+      <span v-if="prefix" class="absolute left-4 top-1/2 transform -translate-y-1/2 text-blue-950/60 dark:text-blue-100/55">
         {{ prefix }}
       </span>
       <input
@@ -19,11 +19,11 @@
         :disabled="disabled"
         :readonly="readonly"
         :class="[
-          'w-full px-4 py-3 bg-white/5 backdrop-blur-sm border border-white/20 rounded-xl text-white',
-          'focus:ring-2 focus:ring-primary-500/50 focus:border-primary-500/50 transition-all duration-300',
-          'disabled:opacity-50 disabled:cursor-not-allowed placeholder:text-white/40',
+          'w-full px-4 py-3 bg-white dark:bg-white/[0.05] backdrop-blur-sm border border-blue-950/[0.12] dark:border-white/[0.14] rounded-xl text-blue-950 dark:text-white',
+          'transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:border-blue-500/50 dark:focus-visible:border-blue-300/50',
+          'disabled:opacity-50 disabled:cursor-not-allowed placeholder:text-blue-950/40 dark:placeholder:text-blue-100/30',
           prefix ? 'pl-8' : '',
-          error ? 'border-red-500/50 focus:border-red-500/50 focus:ring-red-500/50' : '',
+          error ? 'border-red-500/50 dark:border-red-400/50 focus-visible:border-red-500/50 dark:focus-visible:border-red-400/50 focus-visible:ring-red-500/40 dark:focus-visible:ring-red-400/40' : '',
           customClass,
         ]"
         @input="$emit('update:modelValue', ($event.target as HTMLInputElement).value)"
@@ -31,10 +31,10 @@
         @focus="$emit('focus', $event)"
       >
     </div>
-    <p v-if="helpText" class="mt-2 text-sm text-white/60">
+    <p v-if="helpText" class="mt-2 text-sm text-blue-950/60 dark:text-blue-100/55 transition-colors duration-300">
       {{ helpText }}
     </p>
-    <p v-if="error" class="mt-2 text-sm text-red-400">
+    <p v-if="error" class="mt-2 text-sm text-red-600 dark:text-red-400">
       {{ error }}
     </p>
   </div>
@@ -122,14 +122,5 @@ input[type="number"]::-webkit-outer-spin-button {
 
 input[type="number"] {
   -moz-appearance: textfield;
-}
-
-/* Input focus glow effect */
-input:focus {
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1), 0 0 10px 2px rgba(59, 130, 246, 0.1);
-}
-
-input.border-red-500\/50:focus {
-  box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.1), 0 0 10px 2px rgba(239, 68, 68, 0.1);
 }
 </style> 

--- a/frontend/vuejs/src/apps/payments/components/molecules/cards/BalanceDisplay/BalanceDisplay.vue
+++ b/frontend/vuejs/src/apps/payments/components/molecules/cards/BalanceDisplay/BalanceDisplay.vue
@@ -1,14 +1,14 @@
 <template>
-  <div class="bg-dark-900 rounded-lg p-4">
+  <div class="rounded-2xl bg-white/85 dark:bg-white/[0.045] border border-blue-950/[0.08] dark:border-white/[0.1] backdrop-blur-sm p-4 transition-colors duration-300">
     <div v-if="loading" class="flex justify-center py-4">
       <PaymentSpinner />
     </div>
     <div v-else class="flex justify-between items-center">
       <div>
-        <p class="text-white font-medium">{{ title }}</p>
-        <p class="text-sm text-gray-400">{{ subtitle }}</p>
+        <p class="text-blue-950 dark:text-white font-medium transition-colors duration-300">{{ title }}</p>
+        <p class="text-sm text-blue-950/60 dark:text-blue-100/55 transition-colors duration-300">{{ subtitle }}</p>
       </div>
-      <div class="text-2xl font-bold text-primary-400">
+      <div class="text-2xl font-semibold tabular-nums text-blue-700 dark:text-blue-300 transition-colors duration-300">
         {{ formatCurrency(amount) }}
       </div>
     </div>

--- a/frontend/vuejs/src/apps/payments/components/molecules/cards/CreditBalance/CreditBalance.vue
+++ b/frontend/vuejs/src/apps/payments/components/molecules/cards/CreditBalance/CreditBalance.vue
@@ -22,10 +22,10 @@
         >
           ${{ balance.toLocaleString() }}
         </span>
-        <button 
-          v-if="showRefresh" 
-          @click="refreshBalance" 
-          class="refresh-btn ml-2 text-gray-400 hover:text-gray-600"
+        <button
+          v-if="showRefresh"
+          @click="refreshBalance"
+          class="refresh-btn ml-2 rounded-full text-blue-950/50 hover:text-blue-950 dark:text-blue-100/50 dark:hover:text-white transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
           :class="{ 'refresh-small': size === 'small' }"
         >
           <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -37,9 +37,9 @@
       <!-- "Add Credits" button removed as requested -->
     </div>
     
-    <div v-else class="text-red-500 text-sm">
+    <div v-else class="text-red-600 dark:text-red-400 text-sm">
       <span>Failed to load balance</span>
-      <button @click="refreshBalance" class="ml-2 text-indigo-600">Retry</button>
+      <button @click="refreshBalance" class="ml-2 rounded text-blue-700 hover:text-blue-800 dark:text-blue-300 dark:hover:text-blue-200 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]">Retry</button>
     </div>
   </div>
 </template>
@@ -107,7 +107,13 @@ defineEmits<{
   padding: 0;
 }
 
+/* Blue ink balance figure, dual theme */
 .balance-value {
-  color: #4f46e5; /* indigo-600 */
+  color: #1d4ed8; /* blue-700 */
+}
+
+:root.dark .balance-value,
+.dark .balance-value {
+  color: #93c5fd; /* blue-300 */
 }
 </style> 

--- a/frontend/vuejs/src/apps/payments/components/molecules/cards/ModelPriceCard/ModelPriceCard.vue
+++ b/frontend/vuejs/src/apps/payments/components/molecules/cards/ModelPriceCard/ModelPriceCard.vue
@@ -1,18 +1,18 @@
 <template>
-  <div 
-    class="group flex items-center justify-between backdrop-blur-sm border border-white/10 hover:border-primary-500/30 rounded-xl px-6 py-4 transition-all duration-300 hover:shadow-[0_0_15px_-5px_rgba(59,130,246,0.5)] bg-dark-800/30"
+  <div
+    class="model-price-card group flex items-center justify-between backdrop-blur-sm bg-white/85 dark:bg-white/[0.045] border border-blue-200/70 dark:border-blue-300/[0.14] hover:border-blue-300/80 dark:hover:border-blue-300/[0.24] rounded-2xl px-6 py-4 transition-all duration-300"
   >
     <!-- Model Name -->
-    <div class="font-medium text-white">
+    <div class="font-medium tracking-tight text-blue-950 dark:text-white transition-colors duration-300">
       {{ modelName }}
     </div>
-    
+
     <!-- Price -->
     <div class="flex items-center">
-      <div class="text-lg font-semibold text-primary-300 mr-2">
+      <div class="text-lg font-semibold tabular-nums text-blue-700 dark:text-blue-300 mr-2 transition-colors duration-300">
         ${{ formattedPrice }}
       </div>
-      <span class="text-xs text-white/60">{{ unit }}</span>
+      <span class="text-xs text-blue-950/60 dark:text-blue-100/55 transition-colors duration-300">{{ unit }}</span>
     </div>
   </div>
 </template>
@@ -38,4 +38,19 @@ const props = defineProps({
 const formattedPrice = computed(() => {
   return props.price.toFixed(props.price < 0.01 ? 3 : 2);
 });
-</script> 
+</script>
+
+<style scoped>
+/* Crisp hairline row with a whisper of depth */
+.model-price-card {
+  box-shadow:
+    0 1px 2px rgba(15, 23, 42, 0.05),
+    0 2px 6px -2px rgba(15, 23, 42, 0.06);
+}
+
+.dark .model-price-card {
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.4),
+    0 2px 6px -2px rgba(0, 0, 0, 0.35);
+}
+</style> 

--- a/frontend/vuejs/src/apps/payments/components/molecules/cards/OnDemandCard/OnDemandCard.vue
+++ b/frontend/vuejs/src/apps/payments/components/molecules/cards/OnDemandCard/OnDemandCard.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="rounded-2xl bg-white/50 dark:bg-white/[0.03] border border-gray-200 dark:border-white/[0.08] backdrop-blur-sm p-8 transition-all duration-300 hover:border-gray-300 dark:hover:border-white/[0.12] hover:shadow-lg hover:shadow-gray-200/30 dark:hover:shadow-none">
+  <div class="ondemand-card rounded-2xl bg-white/85 dark:bg-white/[0.045] border border-orange-200/70 dark:border-orange-300/[0.14] backdrop-blur-sm p-8 transition-all duration-300">
     <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-8">
       <!-- Left: Description -->
       <div class="flex-1">
-        <h3 class="text-xl font-semibold text-gray-900 dark:text-white mb-2 transition-colors duration-300">
+        <h3 class="text-xl font-semibold tracking-tight text-blue-950 dark:text-white mb-2 transition-colors duration-300">
           On-Demand Credits
         </h3>
-        <p class="text-gray-500 dark:text-white/60 text-sm leading-relaxed transition-colors duration-300">
+        <p class="text-blue-950/65 dark:text-blue-100/65 text-sm leading-relaxed text-pretty transition-colors duration-300">
           Need extra API usage beyond your plan? Purchase additional credits anytime. Credits are added to your account instantly and never expire.
         </p>
       </div>
@@ -19,11 +19,11 @@
             v-for="preset in presets"
             :key="preset"
             @click="selectPreset(preset)"
-            class="py-2.5 px-3 rounded-xl text-sm font-medium transition-all duration-200 active:scale-[0.97]"
+            class="py-2.5 px-3 rounded-full text-sm font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
             :class="[
               selectedAmount === preset && !isCustom
-                ? 'bg-gray-900 dark:bg-white text-white dark:text-gray-900'
-                : 'bg-gray-100 dark:bg-white/[0.06] text-gray-700 dark:text-white/70 hover:bg-gray-200 dark:hover:bg-white/[0.1] border border-gray-200 dark:border-white/[0.08]'
+                ? 'bg-blue-950 text-[#fdf9f2] dark:bg-[#f3ede2] dark:text-blue-950 shadow-[0_1px_2px_rgba(23,37,84,0.2),0_3px_8px_-2px_rgba(23,37,84,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)]'
+                : 'border border-blue-950/[0.14] text-blue-950/80 hover:text-blue-950 hover:border-blue-950/30 hover:bg-blue-950/[0.03] dark:border-white/[0.16] dark:text-blue-100/80 dark:hover:text-white dark:hover:border-white/30 dark:hover:bg-white/[0.06]'
             ]"
           >
             ${{ preset }}
@@ -33,7 +33,7 @@
         <!-- Custom Amount Input -->
         <div class="relative mb-4">
           <div class="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
-            <span class="text-gray-500 dark:text-white/50 text-sm font-medium">$</span>
+            <span class="text-blue-950/60 dark:text-blue-100/55 text-sm font-medium">$</span>
           </div>
           <input
             v-model.number="customInput"
@@ -44,7 +44,7 @@
             placeholder="Custom amount (5-1000)"
             @focus="isCustom = true"
             @input="handleCustomInput"
-            class="w-full pl-8 pr-4 py-3 rounded-xl bg-gray-50 dark:bg-white/[0.04] border border-gray-200 dark:border-white/[0.08] text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-white/30 text-sm transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-500 dark:focus:border-blue-400"
+            class="w-full pl-8 pr-4 py-3 rounded-xl bg-white dark:bg-white/[0.05] border border-blue-950/[0.12] dark:border-white/[0.14] text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-blue-100/30 text-sm transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:border-blue-500/50 dark:focus-visible:border-blue-300/50"
           />
         </div>
 
@@ -52,7 +52,7 @@
         <button
           @click="handlePurchase"
           :disabled="!isValidAmount || loading"
-          class="w-full py-3 px-6 rounded-xl bg-gray-900 dark:bg-white text-white dark:text-gray-900 font-medium text-sm transition-all duration-200 active:scale-[0.98] hover:bg-gray-800 dark:hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed"
+          class="w-full inline-flex items-center justify-center py-3 px-6 rounded-full bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white font-medium text-sm transition-colors duration-200 shadow-[0_1px_2px_rgba(23,37,84,0.2),0_3px_8px_-2px_rgba(23,37,84,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)] disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
         >
           <span v-if="loading" class="flex items-center justify-center gap-2">
             <svg class="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24">
@@ -108,3 +108,22 @@ const handlePurchase = () => {
   }
 }
 </script>
+
+<style scoped>
+/* Crisp, sharply-defined card: hairline edge + tight layered shadow */
+.ondemand-card {
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.03),
+    0 1px 2px rgba(15, 23, 42, 0.06),
+    0 4px 10px -2px rgba(15, 23, 42, 0.07),
+    0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
+
+.dark .ondemand-card {
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 12px 28px -10px rgba(0, 0, 0, 0.55);
+}
+</style>

--- a/frontend/vuejs/src/apps/payments/components/molecules/cards/SubscriptionTierCard/SubscriptionTierCard.vue
+++ b/frontend/vuejs/src/apps/payments/components/molecules/cards/SubscriptionTierCard/SubscriptionTierCard.vue
@@ -1,42 +1,42 @@
 <template>
   <div
-    class="relative rounded-2xl p-8 transition-all duration-300 hover:shadow-xl"
+    class="tier-card relative rounded-2xl p-8 bg-white/85 dark:bg-white/[0.045] backdrop-blur-sm border transition-all duration-300"
     :class="[
       isPopular
-        ? 'bg-white dark:bg-white/[0.05] border-2 border-blue-500 dark:border-blue-400 hover:shadow-blue-100/50 dark:hover:shadow-none'
-        : 'bg-white/50 dark:bg-white/[0.03] border border-gray-200 dark:border-white/[0.08] hover:shadow-gray-200/30 dark:hover:shadow-none hover:border-gray-300 dark:hover:border-white/[0.12]'
+        ? 'border-orange-300/80 dark:border-orange-300/[0.25]'
+        : 'border-blue-200/70 dark:border-blue-300/[0.14]'
     ]"
   >
     <!-- Popular Badge -->
     <div v-if="isPopular" class="absolute -top-3.5 left-1/2 -translate-x-1/2">
-      <span class="inline-flex items-center px-4 py-1 rounded-full text-xs font-semibold bg-blue-500 text-white tracking-wide uppercase">
+      <span class="inline-flex items-center px-3.5 py-1.5 rounded-full border border-orange-200/70 dark:border-orange-400/25 bg-[#fdf9f2] dark:bg-[#0c0c0e] text-xs font-semibold text-orange-700 dark:text-orange-300 uppercase tracking-[0.18em] transition-colors duration-300">
         Most Popular
       </span>
     </div>
 
     <!-- Tier Name -->
-    <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-2 transition-colors duration-300">
+    <h3 class="text-lg font-semibold tracking-tight text-blue-950 dark:text-white mb-2 transition-colors duration-300">
       {{ name }}
     </h3>
 
     <!-- Price -->
     <div class="flex items-baseline gap-1 mb-6">
-      <span class="text-4xl font-semibold text-gray-900 dark:text-white tracking-tight transition-colors duration-300">
+      <span class="font-display text-4xl font-semibold text-blue-950 dark:text-white tracking-tight tabular-nums transition-colors duration-300">
         ${{ price }}
       </span>
-      <span class="text-gray-500 dark:text-white/50 text-sm transition-colors duration-300">/month</span>
+      <span class="text-blue-950/60 dark:text-blue-100/55 text-sm transition-colors duration-300">/month</span>
     </div>
 
     <!-- Key Highlights -->
     <div class="mb-6 space-y-2">
-      <div class="flex items-center gap-2 text-sm text-gray-700 dark:text-white/70 transition-colors duration-300">
-        <svg class="w-4 h-4 text-blue-500 dark:text-blue-400 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+      <div class="flex items-center gap-2 text-sm text-blue-950/70 dark:text-blue-100/70 transition-colors duration-300">
+        <svg class="w-4 h-4 flex-shrink-0" :class="isPopular ? 'text-orange-600 dark:text-orange-300' : 'text-blue-600 dark:text-blue-300'" fill="currentColor" viewBox="0 0 20 20">
           <path d="M10.394 2.08a1 1 0 00-.788 0l-7 3a1 1 0 000 1.84L5.25 8.051a.999.999 0 01.356-.257l4-1.714a1 1 0 11.788 1.838l-3.14 1.346L10 11.25l6.606-2.83a1 1 0 000-1.84l-7-3zM3.31 9.397L5 10.12v4.102a8.969 8.969 0 00-1.05-.174 1 1 0 01-.89-.89 11.115 11.115 0 01.25-3.762zM9.3 16.573A9.026 9.026 0 007 14.935v-3.957l1.818.78a3 3 0 002.364 0l5.508-2.361a11.026 11.026 0 01.25 3.762 1 1 0 01-.89.89 8.968 8.968 0 00-5.35 2.524 1 1 0 01-1.4 0zM6 18a1 1 0 001-1v-2.065a8.935 8.935 0 00-2-.712V17a1 1 0 001 1z"/>
         </svg>
         <span>{{ deployments }}</span>
       </div>
-      <div class="flex items-center gap-2 text-sm text-gray-700 dark:text-white/70 transition-colors duration-300">
-        <svg class="w-4 h-4 text-blue-500 dark:text-blue-400 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+      <div class="flex items-center gap-2 text-sm text-blue-950/70 dark:text-blue-100/70 transition-colors duration-300">
+        <svg class="w-4 h-4 flex-shrink-0" :class="isPopular ? 'text-orange-600 dark:text-orange-300' : 'text-blue-600 dark:text-blue-300'" fill="currentColor" viewBox="0 0 20 20">
           <path fill-rule="evenodd" d="M4 4a2 2 0 00-2 2v4a2 2 0 002 2V6h10a2 2 0 00-2-2H4zm2 6a2 2 0 012-2h8a2 2 0 012 2v4a2 2 0 01-2 2H8a2 2 0 01-2-2v-4zm6 4a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd"/>
         </svg>
         <span>{{ apiUsage }}</span>
@@ -44,15 +44,20 @@
     </div>
 
     <!-- Feature List -->
-    <ul class="space-y-3 mb-8">
+    <ul class="space-y-3 mb-8 pt-5 border-t border-blue-950/[0.06] dark:border-white/[0.07]">
       <li
         v-for="(feature, index) in features"
         :key="index"
-        class="flex items-start gap-3 text-sm text-gray-600 dark:text-white/60 transition-colors duration-300"
+        class="flex items-start gap-3 text-sm text-blue-950/70 dark:text-blue-100/70 transition-colors duration-300"
       >
-        <svg class="w-4 h-4 text-emerald-500 dark:text-emerald-400 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-          <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
-        </svg>
+        <span
+          class="flex-shrink-0 w-[18px] h-[18px] rounded-full ring-1 flex items-center justify-center mt-0.5 transition-all duration-300"
+          :class="isPopular ? 'bg-orange-100 dark:bg-orange-400/[0.14] ring-orange-200/80 dark:ring-orange-300/[0.18]' : 'bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] dark:from-blue-400/[0.18] dark:to-blue-500/[0.22] ring-blue-200/80 dark:ring-blue-300/[0.18]'"
+        >
+          <svg class="w-2.5 h-2.5" :class="isPopular ? 'text-orange-600 dark:text-orange-300' : 'text-blue-600 dark:text-blue-300'" fill="currentColor" viewBox="0 0 20 20">
+            <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+          </svg>
+        </span>
         <span>{{ feature }}</span>
       </li>
     </ul>
@@ -61,11 +66,11 @@
     <button
       @click="$emit('subscribe')"
       :disabled="loading"
-      class="w-full py-3 px-6 rounded-xl font-medium text-sm transition-all duration-200 active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed"
+      class="w-full inline-flex items-center justify-center py-3 px-6 rounded-full font-medium text-sm transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
       :class="[
         isPopular
-          ? 'bg-blue-500 hover:bg-blue-600 text-white'
-          : 'bg-gray-900 dark:bg-white text-white dark:text-gray-900 hover:bg-gray-800 dark:hover:bg-gray-100'
+          ? 'bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white shadow-[0_1px_2px_rgba(23,37,84,0.2),0_3px_8px_-2px_rgba(23,37,84,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)]'
+          : 'border border-blue-950/[0.14] text-blue-950/80 hover:text-blue-950 hover:border-blue-950/30 hover:bg-blue-950/[0.03] dark:border-white/[0.16] dark:text-blue-100/80 dark:hover:text-white dark:hover:border-white/30 dark:hover:bg-white/[0.06]'
       ]"
     >
       <span v-if="loading" class="flex items-center justify-center gap-2">
@@ -95,3 +100,47 @@ defineEmits<{
   subscribe: []
 }>()
 </script>
+
+<style scoped>
+/* Crisp, sharply-defined card: hairline edge + tight layered shadow, gentle lift on hover */
+.tier-card {
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.03),
+    0 1px 2px rgba(15, 23, 42, 0.06),
+    0 4px 10px -2px rgba(15, 23, 42, 0.07),
+    0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
+
+.tier-card:hover {
+  transform: translateY(-4px);
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.04),
+    0 2px 4px rgba(15, 23, 42, 0.06),
+    0 10px 20px -4px rgba(15, 23, 42, 0.1),
+    0 24px 44px -12px rgba(15, 23, 42, 0.14);
+}
+
+.dark .tier-card {
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 12px 28px -10px rgba(0, 0, 0, 0.55);
+}
+
+.dark .tier-card:hover {
+  transform: translateY(-4px);
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.06),
+    0 2px 4px rgba(0, 0, 0, 0.5),
+    0 12px 24px -4px rgba(0, 0, 0, 0.5),
+    0 28px 48px -12px rgba(0, 0, 0, 0.6);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tier-card,
+  .tier-card:hover {
+    transform: none;
+  }
+}
+</style>

--- a/frontend/vuejs/src/apps/payments/components/molecules/forms/PaymentForm/PaymentForm.vue
+++ b/frontend/vuejs/src/apps/payments/components/molecules/forms/PaymentForm/PaymentForm.vue
@@ -22,14 +22,14 @@
     </div>
 
     <div class="mb-6">
-      <label class="block text-sm font-medium text-gray-300 mb-2">
+      <label class="block text-sm font-medium text-blue-950/80 dark:text-blue-100/80 mb-2 transition-colors duration-300">
         Card Information
       </label>
-      <div 
-        id="card-element" 
-        class="bg-dark-900 rounded-lg p-4 min-h-[40px] border border-dark-700"
+      <div
+        id="card-element"
+        class="bg-white dark:bg-white/[0.05] rounded-xl p-4 min-h-[40px] border border-blue-950/[0.12] dark:border-white/[0.14] transition-colors duration-200"
       ></div>
-      <div id="card-errors" class="mt-2 text-sm text-red-500"></div>
+      <div id="card-errors" class="mt-2 text-sm text-red-600 dark:text-red-400"></div>
     </div>
 
     <PaymentButton
@@ -108,28 +108,31 @@ export default defineComponent({
           throw new Error('Failed to load Stripe')
         }
 
+        // Match the Stripe iframe to the warm-porcelain theme (ink navy / dark)
+        const isDarkMode = document.documentElement.classList.contains('dark')
+
         // Create Elements instance with proper styling
         elements.value = stripe.value.elements({
           appearance: {
-            theme: 'night',
+            theme: isDarkMode ? 'night' : 'stripe',
             variables: {
-              colorPrimary: '#00ffc6',
-              colorBackground: '#1a1b23',
-              colorText: '#ffffff',
-              colorDanger: '#ff4d4d',
+              colorPrimary: isDarkMode ? '#93c5fd' : '#1d4ed8',
+              colorBackground: isDarkMode ? '#16161a' : '#ffffff',
+              colorText: isDarkMode ? '#ffffff' : '#172554',
+              colorDanger: isDarkMode ? '#f87171' : '#dc2626',
               fontFamily: 'system-ui, sans-serif',
-              borderRadius: '8px',
+              borderRadius: '12px',
             },
             rules: {
               '.Input': {
-                border: '1px solid #2d2d3b',
+                border: isDarkMode ? '1px solid rgba(255, 255, 255, 0.14)' : '1px solid rgba(23, 37, 84, 0.12)',
                 boxShadow: 'none',
               },
               '.Input:focus': {
-                border: '1px solid #00ffc6',
+                border: isDarkMode ? '1px solid rgba(147, 197, 253, 0.5)' : '1px solid rgba(59, 130, 246, 0.5)',
               },
               '.Label': {
-                color: '#ffffff',
+                color: isDarkMode ? '#ffffff' : '#172554',
               }
             }
           },
@@ -140,13 +143,13 @@ export default defineComponent({
         cardElement.value = elements.value.create('card', {
           style: {
             base: {
-              color: '#ffffff',
+              color: isDarkMode ? '#ffffff' : '#172554',
               fontFamily: 'system-ui, sans-serif',
               fontSize: '16px',
               '::placeholder': {
-                color: '#6b7280',
+                color: isDarkMode ? 'rgba(255, 255, 255, 0.4)' : 'rgba(23, 37, 84, 0.4)',
               },
-              backgroundColor: '#1a1b23',
+              backgroundColor: 'transparent',
             },
           },
           hidePostalCode: true
@@ -177,14 +180,14 @@ export default defineComponent({
         cardElement.value.on('focus', () => {
           const el = document.getElementById('card-element')
           if (el) {
-            el.classList.add('ring-2', 'ring-primary-500', 'border-primary-500')
+            el.classList.add('ring-2', 'ring-blue-500/40', 'dark:ring-blue-300/50', 'border-blue-500/50', 'dark:border-blue-300/50')
           }
         })
 
         cardElement.value.on('blur', () => {
           const el = document.getElementById('card-element')
           if (el) {
-            el.classList.remove('ring-2', 'ring-primary-500', 'border-primary-500')
+            el.classList.remove('ring-2', 'ring-blue-500/40', 'dark:ring-blue-300/50', 'border-blue-500/50', 'dark:border-blue-300/50')
           }
         })
 

--- a/frontend/vuejs/src/apps/payments/components/molecules/headers/PageHeader/PageHeader.vue
+++ b/frontend/vuejs/src/apps/payments/components/molecules/headers/PageHeader/PageHeader.vue
@@ -1,11 +1,11 @@
 <template>
   <div :class="['text-center mb-12', animationClass]">
-    <h1 class="text-4xl lg:text-5xl font-bold mb-6 text-center">
-      <span class="text-white block">{{ titlePrefix }}</span>
-      <span class="bg-gradient-to-r from-primary-400 to-primary-500 bg-clip-text text-transparent">{{ highlightedTitle }}</span>
+    <h1 class="font-display font-semibold text-4xl lg:text-5xl mb-6 text-center tracking-[-0.02em] leading-[1.05] text-balance">
+      <span class="text-blue-950 dark:text-white block transition-colors duration-300">{{ titlePrefix }}</span>
+      <em class="header-accent not-italic">{{ highlightedTitle }}</em>
     </h1>
-    <div class="w-24 h-1 bg-gradient-to-r from-primary-500 to-violet-500 rounded-full mx-auto mb-4"></div>
-    <p v-if="subtitle" class="text-lg text-white/70 max-w-2xl mx-auto">
+    <div class="w-24 h-px bg-gradient-to-r from-transparent via-blue-950/25 to-transparent dark:via-white/25 mx-auto mb-4" aria-hidden="true"></div>
+    <p v-if="subtitle" class="text-lg text-blue-950/65 dark:text-blue-100/65 leading-relaxed text-pretty max-w-2xl mx-auto transition-colors duration-300">
       {{ subtitle }}
     </p>
   </div>
@@ -67,5 +67,29 @@ const animationClass = computed(() => {
 
 .animation-delay-150 {
   animation-delay: 150ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-in-up {
+    animation: none;
+  }
+}
+
+/* Italic serif accent with the warm gradient ink */
+.header-accent {
+  font-style: italic;
+  font-variation-settings: 'SOFT' 30, 'WONK' 1;
+  background: linear-gradient(115deg, #c2410c 5%, #ea580c 55%, #b45309 95%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  padding-right: 0.06em;
+}
+
+.dark .header-accent {
+  background: linear-gradient(115deg, #fb923c 5%, #fcd34d 60%, #f59e0b 95%);
+  -webkit-background-clip: text;
+  background-clip: text;
 }
 </style> 

--- a/frontend/vuejs/src/apps/payments/components/molecules/messages/StatusMessage/StatusMessage.vue
+++ b/frontend/vuejs/src/apps/payments/components/molecules/messages/StatusMessage/StatusMessage.vue
@@ -48,35 +48,35 @@ const props = defineProps({
 const typeClasses = computed(() => {
   switch (props.type) {
     case 'success':
-      return 'bg-green-500/10 border-green-300/30 text-green-300 animate-pulse-slow';
+      return 'bg-emerald-50/80 border-emerald-200/70 dark:bg-emerald-400/[0.07] dark:border-emerald-300/[0.18]';
     case 'error':
-      return 'bg-red-500/10 border-red-300/30 text-red-300';
+      return 'bg-red-50/80 border-red-200/70 dark:bg-red-500/10 dark:border-red-400/25';
     case 'warning':
-      return 'bg-yellow-500/10 border-yellow-300/30 text-yellow-300';
+      return 'bg-amber-50/80 border-amber-200/70 dark:bg-amber-400/[0.08] dark:border-amber-300/[0.2]';
     case 'info':
-      return 'bg-blue-500/10 border-blue-300/30 text-blue-300';
+      return 'bg-blue-50/80 border-blue-200/70 dark:bg-blue-400/10 dark:border-blue-400/25';
     default:
-      return 'bg-green-500/10 border-green-300/30 text-green-300';
+      return 'bg-emerald-50/80 border-emerald-200/70 dark:bg-emerald-400/[0.07] dark:border-emerald-300/[0.18]';
   }
 });
 
 const glowClass = computed(() => {
   switch (props.type) {
-    case 'success': return 'bg-green-500/5';
+    case 'success': return 'bg-emerald-500/5';
     case 'error': return 'bg-red-500/5';
-    case 'warning': return 'bg-yellow-500/5';
+    case 'warning': return 'bg-amber-500/5';
     case 'info': return 'bg-blue-500/5';
-    default: return 'bg-green-500/5';
+    default: return 'bg-emerald-500/5';
   }
 });
 
 const borderGradientClass = computed(() => {
   switch (props.type) {
-    case 'success': return 'from-green-500/0 via-green-500/60 to-green-500/0';
-    case 'error': return 'from-red-500/0 via-red-500/60 to-red-500/0';
-    case 'warning': return 'from-yellow-500/0 via-yellow-500/60 to-yellow-500/0';
-    case 'info': return 'from-blue-500/0 via-blue-500/60 to-blue-500/0';
-    default: return 'from-green-500/0 via-green-500/60 to-green-500/0';
+    case 'success': return 'from-emerald-500/0 via-emerald-500/40 to-emerald-500/0 dark:via-emerald-400/40';
+    case 'error': return 'from-red-500/0 via-red-500/40 to-red-500/0 dark:via-red-400/40';
+    case 'warning': return 'from-amber-500/0 via-amber-500/40 to-amber-500/0 dark:via-amber-400/40';
+    case 'info': return 'from-blue-500/0 via-blue-500/40 to-blue-500/0 dark:via-blue-400/40';
+    default: return 'from-emerald-500/0 via-emerald-500/40 to-emerald-500/0 dark:via-emerald-400/40';
   }
 });
 
@@ -92,42 +92,33 @@ const iconClass = computed(() => {
 
 const iconBgClass = computed(() => {
   switch (props.type) {
-    case 'success': return 'bg-green-500/20';
-    case 'error': return 'bg-red-500/20';
-    case 'warning': return 'bg-yellow-500/20';
-    case 'info': return 'bg-blue-500/20';
-    default: return 'bg-green-500/20';
+    case 'success': return 'bg-emerald-100 dark:bg-emerald-400/[0.14] ring-1 ring-emerald-200/80 dark:ring-emerald-300/[0.18]';
+    case 'error': return 'bg-red-100 dark:bg-red-400/[0.14] ring-1 ring-red-200/80 dark:ring-red-300/[0.18]';
+    case 'warning': return 'bg-amber-100 dark:bg-amber-400/[0.14] ring-1 ring-amber-200/80 dark:ring-amber-300/[0.18]';
+    case 'info': return 'bg-blue-100 dark:bg-blue-400/[0.14] ring-1 ring-blue-200/80 dark:ring-blue-300/[0.18]';
+    default: return 'bg-emerald-100 dark:bg-emerald-400/[0.14] ring-1 ring-emerald-200/80 dark:ring-emerald-300/[0.18]';
   }
 });
 
 const iconColorClass = computed(() => {
   switch (props.type) {
-    case 'success': return 'text-green-400';
-    case 'error': return 'text-red-400';
-    case 'warning': return 'text-yellow-400';
-    case 'info': return 'text-blue-400';
-    default: return 'text-green-400';
+    case 'success': return 'text-emerald-600 dark:text-emerald-300';
+    case 'error': return 'text-red-600 dark:text-red-400';
+    case 'warning': return 'text-amber-600 dark:text-amber-300';
+    case 'info': return 'text-blue-600 dark:text-blue-300';
+    default: return 'text-emerald-600 dark:text-emerald-300';
   }
 });
 
 const textColorClass = computed(() => {
   switch (props.type) {
-    case 'success': return 'text-green-300';
-    case 'error': return 'text-red-300';
-    case 'warning': return 'text-yellow-300';
-    case 'info': return 'text-blue-300';
-    default: return 'text-green-300';
+    case 'success': return 'text-emerald-800 dark:text-emerald-200';
+    case 'error': return 'text-red-700 dark:text-red-300';
+    case 'warning': return 'text-amber-800 dark:text-amber-200';
+    case 'info': return 'text-blue-800 dark:text-blue-200';
+    default: return 'text-emerald-800 dark:text-emerald-200';
   }
 });
 </script>
 
-<style scoped>
-@keyframes pulse-slow {
-  0%, 100% { opacity: 0.9; }
-  50% { opacity: 1; }
-}
-
-.animate-pulse-slow {
-  animation: pulse-slow 4s ease-in-out infinite;
-}
-</style> 
+ 

--- a/frontend/vuejs/src/apps/payments/components/molecules/selectors/PaymentAmountSelector/PaymentAmountSelector.vue
+++ b/frontend/vuejs/src/apps/payments/components/molecules/selectors/PaymentAmountSelector/PaymentAmountSelector.vue
@@ -1,32 +1,32 @@
 <template>
   <div class="payment-amount-selector">
-    <h3 class="text-lg font-medium text-white mb-4">Select Amount</h3>
-    
+    <h3 class="text-lg font-medium tracking-tight text-blue-950 dark:text-white mb-4 transition-colors duration-300">Select Amount</h3>
+
     <div class="grid grid-cols-2 md:grid-cols-3 gap-3">
       <button
         v-for="amount in presetAmounts"
         :key="amount"
         @click="selectAmount(amount)"
-        class="amount-btn py-3 px-4 text-center rounded-lg border transition-all duration-200"
-        :class="{ 
-          'border-primary-500 bg-primary-500/10': selectedAmount === amount,
-          'border-gray-700 bg-dark-800 hover:border-gray-500': selectedAmount !== amount 
+        class="amount-btn py-3 px-4 text-center rounded-full border font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
+        :class="{
+          'border-blue-950 bg-blue-950 text-[#fdf9f2] dark:border-[#f3ede2] dark:bg-[#f3ede2] dark:text-blue-950': selectedAmount === amount,
+          'border-blue-950/[0.14] bg-white/85 text-blue-950/80 hover:text-blue-950 hover:border-blue-950/30 hover:bg-blue-950/[0.03] dark:border-white/[0.16] dark:bg-white/[0.05] dark:text-blue-100/80 dark:hover:text-white dark:hover:border-white/30 dark:hover:bg-white/[0.06]': selectedAmount !== amount
         }"
       >
         ${{ amount }}
       </button>
-      
+
       <div class="custom-amount col-span-2 md:col-span-3 mt-2">
-        <label class="block text-sm text-gray-400 mb-1">Custom Amount</label>
+        <label class="block text-sm text-blue-950/70 dark:text-blue-100/55 mb-1 transition-colors duration-300">Custom Amount</label>
         <div class="flex items-center">
-          <span class="text-gray-400 mr-2">$</span>
+          <span class="text-blue-950/60 dark:text-blue-100/55 mr-2">$</span>
           <input
             type="number"
             min="5"
             :value="customAmount"
             @input="onCustomAmountChange"
             @focus="selectCustomAmount"
-            class="bg-dark-800 border border-gray-700 rounded-lg px-3 py-2 w-full text-white focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            class="bg-white dark:bg-white/[0.05] border border-blue-950/[0.12] dark:border-white/[0.14] rounded-xl px-3 py-2 w-full text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-blue-100/30 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:border-blue-500/50 dark:focus-visible:border-blue-300/50"
             placeholder="Enter amount"
           />
         </div>

--- a/frontend/vuejs/src/apps/payments/components/molecules/summaries/OrderSummary/OrderSummary.vue
+++ b/frontend/vuejs/src/apps/payments/components/molecules/summaries/OrderSummary/OrderSummary.vue
@@ -1,19 +1,19 @@
 <template>
-  <div class="bg-dark-900 rounded-lg p-4">
+  <div class="rounded-2xl bg-white/85 dark:bg-white/[0.045] border border-blue-950/[0.08] dark:border-white/[0.1] backdrop-blur-sm p-4 transition-colors duration-300">
     <div class="flex justify-between items-center mb-4">
       <div>
-        <p class="text-white font-medium">{{ title }}</p>
-        <p class="text-sm text-gray-400">{{ subtitle }}</p>
+        <p class="text-blue-950 dark:text-white font-medium transition-colors duration-300">{{ title }}</p>
+        <p class="text-sm text-blue-950/60 dark:text-blue-100/55 transition-colors duration-300">{{ subtitle }}</p>
       </div>
-      <p class="text-xl font-bold text-primary-400">{{ formatCurrency(amount) }}</p>
+      <p class="text-xl font-semibold tabular-nums text-blue-700 dark:text-blue-300 transition-colors duration-300">{{ formatCurrency(amount) }}</p>
     </div>
     <div v-if="$slots.details" class="mb-4">
       <slot name="details"></slot>
     </div>
-    <div class="border-t border-dark-700 pt-4">
+    <div class="border-t border-blue-950/[0.08] dark:border-white/[0.1] pt-4">
       <div class="flex justify-between items-center">
-        <p class="text-gray-400">{{ totalLabel }}</p>
-        <p class="text-2xl font-bold text-primary-400">{{ formatCurrency(displayTotal) }}</p>
+        <p class="text-blue-950/60 dark:text-blue-100/55 transition-colors duration-300">{{ totalLabel }}</p>
+        <p class="text-2xl font-semibold tabular-nums text-blue-950 dark:text-white transition-colors duration-300">{{ formatCurrency(displayTotal) }}</p>
       </div>
     </div>
   </div>

--- a/frontend/vuejs/src/apps/payments/components/organisms/cards/AccountBalanceCard/AccountBalanceCard.vue
+++ b/frontend/vuejs/src/apps/payments/components/organisms/cards/AccountBalanceCard/AccountBalanceCard.vue
@@ -1,31 +1,31 @@
 <template>
-  <div class="rounded-2xl bg-white/50 dark:bg-white/[0.03] border border-gray-200 dark:border-white/[0.08] backdrop-blur-sm p-6 sm:p-8 transition-all duration-300 hover:border-gray-300 dark:hover:border-white/[0.12] hover:shadow-lg">
+  <div class="balance-card rounded-2xl bg-white/85 dark:bg-white/[0.045] border border-blue-200/70 dark:border-blue-300/[0.14] backdrop-blur-sm p-6 sm:p-8 transition-all duration-300">
     <div class="mb-6">
-      <span class="text-sm font-medium text-gray-600 dark:text-gray-400 uppercase tracking-wide">{{ title }}</span>
+      <span class="text-xs font-semibold uppercase tracking-[0.16em] text-blue-700 dark:text-blue-300/70 transition-colors duration-300">{{ title }}</span>
     </div>
-    
+
     <div class="flex flex-col md:flex-row justify-between items-start md:items-center gap-6">
       <div class="flex-grow">
         <!-- Balance display with clean styling -->
         <div>
-          <div class="text-sm text-gray-500 dark:text-gray-400 mb-2">{{ balanceLabel }}</div>
+          <div class="text-sm text-blue-950/60 dark:text-blue-100/55 mb-2 transition-colors duration-300">{{ balanceLabel }}</div>
           <div class="flex items-baseline gap-2">
             <div v-if="loading" class="animate-pulse">
-              <div class="h-9 w-20 bg-gray-200 dark:bg-white/10 rounded-lg"></div>
+              <div class="h-9 w-20 bg-blue-950/10 dark:bg-white/10 rounded-lg"></div>
             </div>
-            <div v-else class="text-3xl sm:text-4xl font-semibold text-gray-900 dark:text-white">
+            <div v-else class="font-display text-3xl sm:text-4xl font-semibold tracking-tight tabular-nums text-blue-950 dark:text-white transition-colors duration-300">
               ${{ credits.toLocaleString() }}
             </div>
-            <div class="text-sm text-gray-500 dark:text-gray-400">USD</div>
+            <div class="text-sm text-blue-950/60 dark:text-blue-100/55 transition-colors duration-300">USD</div>
           </div>
-          
+
           <!-- Last updated info -->
-          <div v-if="lastUpdated && showLastUpdated" class="text-xs text-gray-500 dark:text-gray-500 mt-2">
+          <div v-if="lastUpdated && showLastUpdated" class="text-xs text-blue-950/50 dark:text-blue-100/40 mt-2 transition-colors duration-300">
             Last updated: {{ formatDateTime(lastUpdated) }}
           </div>
         </div>
       </div>
-      
+
       <!-- Action buttons -->
       <div v-if="showActions" class="flex flex-col sm:flex-row gap-3">
         <slot name="actions">
@@ -85,5 +85,20 @@ const formatDateTime = (date: Date | string) => {
 </script>
 
 <style scoped>
-/* You can add component-specific styles here if needed */
+/* Crisp, sharply-defined card: hairline edge + tight layered shadow */
+.balance-card {
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.03),
+    0 1px 2px rgba(15, 23, 42, 0.06),
+    0 4px 10px -2px rgba(15, 23, 42, 0.07),
+    0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
+
+.dark .balance-card {
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 12px 28px -10px rgba(0, 0, 0, 0.55);
+}
 </style> 

--- a/frontend/vuejs/src/apps/payments/components/organisms/forms/AddCreditCard/AddCreditCard.vue
+++ b/frontend/vuejs/src/apps/payments/components/organisms/forms/AddCreditCard/AddCreditCard.vue
@@ -1,21 +1,21 @@
 <template>
   <div class="add-card-form">
-    <div v-if="error" class="error-message bg-red-50 text-red-600 p-3 rounded mb-4">
+    <div v-if="error" class="error-message bg-red-50/80 dark:bg-red-500/10 border border-red-200/70 dark:border-red-400/25 text-red-700 dark:text-red-300 p-3 rounded-xl mb-4 transition-colors duration-300">
       {{ error }}
     </div>
-    
+
     <div class="mb-4">
-      <div ref="cardElement" class="card-element p-3 border rounded"></div>
-      <div v-if="cardError" class="text-red-500 text-sm mt-1">{{ cardError }}</div>
+      <div ref="cardElement" class="card-element p-3 border border-blue-950/[0.12] dark:border-white/[0.14] rounded-xl"></div>
+      <div v-if="cardError" class="text-red-600 dark:text-red-400 text-sm mt-1">{{ cardError }}</div>
     </div>
-    
-    <button 
-      @click="handleSubmit" 
-      :disabled="isLoading || !stripe" 
-      class="w-full py-2 px-4 rounded bg-indigo-600 text-white font-medium hover:bg-indigo-700 disabled:opacity-50"
+
+    <button
+      @click="handleSubmit"
+      :disabled="isLoading || !stripe"
+      class="w-full inline-flex items-center justify-center py-2 px-4 rounded-full bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white font-medium transition-colors duration-200 shadow-[0_1px_2px_rgba(23,37,84,0.2),0_3px_8px_-2px_rgba(23,37,84,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)] disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
     >
       <span v-if="isLoading">
-        <svg class="animate-spin -ml-1 mr-2 h-4 w-4 text-white inline-block" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+        <svg class="animate-spin -ml-1 mr-2 h-4 w-4 inline-block" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
           <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
           <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
         </svg>
@@ -149,6 +149,7 @@ const emit = defineEmits<{
 </script>
 
 <style scoped>
+/* Kept white in both themes: the Stripe element renders dark slate text (#32325d) */
 .card-element {
   background-color: white;
   min-height: 40px;

--- a/frontend/vuejs/src/apps/payments/components/organisms/forms/AddCredits/AddCredits.vue
+++ b/frontend/vuejs/src/apps/payments/components/organisms/forms/AddCredits/AddCredits.vue
@@ -1,108 +1,108 @@
 <template>
   <div class="add-credits-container">
     <!-- Error message -->
-    <div v-if="error" class="error-message bg-red-50 text-red-600 p-3 rounded mb-4">
+    <div v-if="error" class="error-message bg-red-50/80 dark:bg-red-500/10 border border-red-200/70 dark:border-red-400/25 text-red-700 dark:text-red-300 p-3 rounded-xl mb-4 transition-colors duration-300">
       {{ error }}
     </div>
-    
+
     <!-- Success message -->
-    <div v-if="successMessage" class="success-message bg-green-50 text-green-600 p-3 rounded mb-4">
+    <div v-if="successMessage" class="success-message bg-emerald-50/80 dark:bg-emerald-400/[0.07] border border-emerald-200/70 dark:border-emerald-300/[0.18] text-emerald-700 dark:text-emerald-300 p-3 rounded-xl mb-4 transition-colors duration-300">
       {{ successMessage }}
     </div>
-    
+
     <!-- Credit packages section -->
     <div v-if="packages.length > 0" class="mb-6">
-      <h3 class="text-lg font-semibold mb-3">Credit Packages</h3>
+      <h3 class="text-lg font-semibold tracking-tight text-blue-950 dark:text-white mb-3 transition-colors duration-300">Credit Packages</h3>
       <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div 
-          v-for="pkg in packages" 
-          :key="pkg.id" 
+        <div
+          v-for="pkg in packages"
+          :key="pkg.id"
           @click="selectPackage(pkg)"
-          class="border rounded-lg p-4 hover:border-indigo-500 cursor-pointer transition-colors"
-          :class="{'border-indigo-500 bg-indigo-50': selectedPackage?.id === pkg.id}"
+          class="border rounded-xl p-4 bg-white/85 dark:bg-white/[0.045] backdrop-blur-sm hover:border-blue-400/60 dark:hover:border-blue-300/40 cursor-pointer transition-colors"
+          :class="selectedPackage?.id === pkg.id ? 'border-blue-500 bg-blue-50/80 dark:border-blue-300/60 dark:bg-blue-400/10' : 'border-blue-950/[0.1] dark:border-white/[0.12]'"
         >
-          <div class="font-semibold text-lg">{{ pkg.name }}</div>
-          <div class="text-gray-600 mb-2">{{ pkg.description || `${pkg.credits} credits` }}</div>
-          <div class="text-xl font-bold text-indigo-600">${{ pkg.price.toFixed(2) }}</div>
+          <div class="font-semibold text-lg text-blue-950 dark:text-white transition-colors duration-300">{{ pkg.name }}</div>
+          <div class="text-blue-950/60 dark:text-blue-100/55 mb-2 transition-colors duration-300">{{ pkg.description || `${pkg.credits} credits` }}</div>
+          <div class="text-xl font-semibold tabular-nums text-blue-700 dark:text-blue-300 transition-colors duration-300">${{ pkg.price.toFixed(2) }}</div>
         </div>
       </div>
     </div>
-    
+
     <!-- Custom amount section -->
     <div class="mb-6">
-      <h3 class="text-lg font-semibold mb-3">Custom Amount</h3>
+      <h3 class="text-lg font-semibold tracking-tight text-blue-950 dark:text-white mb-3 transition-colors duration-300">Custom Amount</h3>
       <div class="flex items-center">
-        <span class="text-gray-500 text-lg mr-2">$</span>
-        <input 
-          v-model.number="customAmount" 
-          type="number" 
-          min="5" 
-          max="1000" 
-          step="1" 
-          placeholder="Enter amount" 
-          class="flex-1 p-2 border rounded" 
-          :class="{'border-red-500': customAmountError}"
+        <span class="text-blue-950/60 dark:text-blue-100/55 text-lg mr-2">$</span>
+        <input
+          v-model.number="customAmount"
+          type="number"
+          min="5"
+          max="1000"
+          step="1"
+          placeholder="Enter amount"
+          class="flex-1 p-2 border rounded-xl bg-white dark:bg-white/[0.05] text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-blue-100/30 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:border-blue-500/50 dark:focus-visible:border-blue-300/50"
+          :class="customAmountError ? 'border-red-500/50 dark:border-red-400/50' : 'border-blue-950/[0.12] dark:border-white/[0.14]'"
         />
       </div>
-      <div v-if="customAmountError" class="text-red-500 text-sm mt-1">
+      <div v-if="customAmountError" class="text-red-600 dark:text-red-400 text-sm mt-1">
         {{ customAmountError }}
       </div>
-      <div class="text-sm text-gray-500 mt-1">
+      <div class="text-sm text-blue-950/60 dark:text-blue-100/55 mt-1 transition-colors duration-300">
         Minimum $5, Maximum $1,000
       </div>
     </div>
-    
+
     <!-- Payment methods section -->
     <div class="mb-6">
-      <h3 class="text-lg font-semibold mb-3">Payment Method</h3>
-      
+      <h3 class="text-lg font-semibold tracking-tight text-blue-950 dark:text-white mb-3 transition-colors duration-300">Payment Method</h3>
+
       <!-- Select saved payment method -->
       <div v-if="paymentMethods.length > 0" class="mb-4">
-        <div 
-          v-for="method in paymentMethods" 
-          :key="method.id" 
+        <div
+          v-for="method in paymentMethods"
+          :key="method.id"
           @click="selectedPaymentMethod = method"
-          class="border rounded p-3 mb-2 flex items-center cursor-pointer"
-          :class="{'border-indigo-500 bg-indigo-50': selectedPaymentMethod?.id === method.id}"
+          class="border rounded-xl p-3 mb-2 flex items-center bg-white/85 dark:bg-white/[0.045] backdrop-blur-sm hover:border-blue-400/60 dark:hover:border-blue-300/40 cursor-pointer transition-colors"
+          :class="selectedPaymentMethod?.id === method.id ? 'border-blue-500 bg-blue-50/80 dark:border-blue-300/60 dark:bg-blue-400/10' : 'border-blue-950/[0.1] dark:border-white/[0.12]'"
         >
           <div class="flex-1">
-            <div class="font-medium">{{ method.card_brand.charAt(0).toUpperCase() + method.card_brand.slice(1) }} •••• {{ method.last4 }}</div>
-            <div class="text-sm text-gray-500">Expires {{ method.exp_month }}/{{ method.exp_year }}</div>
+            <div class="font-medium text-blue-950 dark:text-white transition-colors duration-300">{{ method.card_brand.charAt(0).toUpperCase() + method.card_brand.slice(1) }} •••• {{ method.last4 }}</div>
+            <div class="text-sm text-blue-950/60 dark:text-blue-100/55 transition-colors duration-300">Expires {{ method.exp_month }}/{{ method.exp_year }}</div>
           </div>
-          <div v-if="method.is_default" class="text-sm text-indigo-600 font-medium">Default</div>
+          <div v-if="method.is_default" class="text-sm text-blue-700 dark:text-blue-300 font-medium transition-colors duration-300">Default</div>
         </div>
       </div>
-      
+
       <!-- Add new card if no saved cards -->
       <div v-else>
-        <p class="text-gray-600 mb-3">No saved payment methods. Please add a card to continue.</p>
+        <p class="text-blue-950/65 dark:text-blue-100/65 mb-3 transition-colors duration-300">No saved payment methods. Please add a card to continue.</p>
       </div>
-      
+
       <!-- Toggle add new card form -->
-      <button 
-        @click="showAddCard = !showAddCard" 
-        class="text-indigo-600 hover:text-indigo-800 text-sm font-medium flex items-center"
+      <button
+        @click="showAddCard = !showAddCard"
+        class="text-blue-700 hover:text-blue-800 dark:text-blue-300 dark:hover:text-blue-200 text-sm font-medium flex items-center rounded transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
       >
         <span v-if="!showAddCard">+ Add a new card</span>
         <span v-else>Cancel</span>
       </button>
-      
+
       <!-- Add card form -->
       <div v-if="showAddCard" class="mt-3">
         <add-credit-card @card-added="handleCardAdded" />
       </div>
     </div>
-    
+
     <!-- Payment buttons -->
     <div class="flex flex-col space-y-3">
       <!-- Direct payment -->
-      <button 
+      <button
         @click="processDirectPayment"
-        :disabled="!canProceed || isLoading" 
-        class="bg-indigo-600 text-white py-2 px-4 rounded-lg hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        :disabled="!canProceed || isLoading"
+        class="inline-flex items-center justify-center bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white font-medium py-2 px-4 rounded-full transition-colors duration-200 shadow-[0_1px_2px_rgba(23,37,84,0.2),0_3px_8px_-2px_rgba(23,37,84,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)] disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
       >
         <span v-if="isLoading">
-          <svg class="animate-spin -ml-1 mr-2 h-4 w-4 text-white inline-block" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+          <svg class="animate-spin -ml-1 mr-2 h-4 w-4 inline-block" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
             <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
           </svg>
@@ -110,15 +110,15 @@
         </span>
         <span v-else>Pay Now</span>
       </button>
-      
+
       <!-- Checkout option -->
-      <button 
+      <button
         @click="processCheckout"
-        :disabled="!amountValid || isLoading" 
-        class="border border-indigo-600 text-indigo-600 py-2 px-4 rounded-lg hover:bg-indigo-50 disabled:opacity-50 disabled:cursor-not-allowed"
+        :disabled="!amountValid || isLoading"
+        class="inline-flex items-center justify-center border border-blue-950/[0.14] text-blue-950/80 hover:text-blue-950 hover:border-blue-950/30 hover:bg-blue-950/[0.03] dark:border-white/[0.16] dark:text-blue-100/80 dark:hover:text-white dark:hover:border-white/30 dark:hover:bg-white/[0.06] font-medium py-2 px-4 rounded-full transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
       >
         <span v-if="isCheckoutLoading">
-          <svg class="animate-spin -ml-1 mr-2 h-4 w-4 text-indigo-600 inline-block" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+          <svg class="animate-spin -ml-1 mr-2 h-4 w-4 inline-block" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
             <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
           </svg>

--- a/frontend/vuejs/src/apps/payments/components/organisms/forms/PaymentForm/PaymentForm.vue
+++ b/frontend/vuejs/src/apps/payments/components/organisms/forms/PaymentForm/PaymentForm.vue
@@ -8,36 +8,36 @@
     </div>
 
     <div class="payment-method mb-6">
-      <h3 class="text-lg font-medium text-white mb-4">Payment Method</h3>
-      
-      <div 
-        ref="cardElement" 
-        class="p-4 bg-dark-800 border border-gray-700 rounded-lg mb-4"
+      <h3 class="text-lg font-medium tracking-tight text-blue-950 dark:text-white mb-4 transition-colors duration-300">Payment Method</h3>
+
+      <div
+        ref="cardElement"
+        class="p-4 bg-white dark:bg-white/[0.05] border border-blue-950/[0.12] dark:border-white/[0.14] rounded-xl mb-4 transition-colors duration-200"
       ></div>
-      
-      <div v-if="cardError" class="text-red-500 text-sm mb-4">
+
+      <div v-if="cardError" class="text-red-600 dark:text-red-400 text-sm mb-4">
         {{ cardError }}
       </div>
     </div>
 
     <div class="summary mb-6">
-      <h3 class="text-lg font-medium text-white mb-4">Summary</h3>
-      <div class="bg-dark-800 border border-gray-700 rounded-lg p-4">
-        <div class="flex justify-between py-2 border-b border-gray-700">
-          <span class="text-gray-400">Amount</span>
-          <span class="text-white">${{ amount.toFixed(2) }}</span>
+      <h3 class="text-lg font-medium tracking-tight text-blue-950 dark:text-white mb-4 transition-colors duration-300">Summary</h3>
+      <div class="bg-white/85 dark:bg-white/[0.045] border border-blue-950/[0.08] dark:border-white/[0.1] backdrop-blur-sm rounded-2xl p-4 transition-colors duration-300">
+        <div class="flex justify-between py-2 border-b border-blue-950/[0.08] dark:border-white/[0.1]">
+          <span class="text-blue-950/60 dark:text-blue-100/55">Amount</span>
+          <span class="tabular-nums text-blue-950 dark:text-white">${{ amount.toFixed(2) }}</span>
         </div>
         <div class="flex justify-between py-2">
-          <span class="text-gray-400">Total</span>
-          <span class="font-medium text-white">${{ amount.toFixed(2) }}</span>
+          <span class="text-blue-950/60 dark:text-blue-100/55">Total</span>
+          <span class="font-medium tabular-nums text-blue-950 dark:text-white">${{ amount.toFixed(2) }}</span>
         </div>
       </div>
     </div>
 
-    <button 
+    <button
       @click="submitPayment"
       :disabled="loading || !cardComplete"
-      class="w-full py-3 px-6 bg-primary-500 text-white font-medium rounded-lg transition-all duration-200 hover:bg-primary-600 disabled:opacity-50 disabled:cursor-not-allowed"
+      class="w-full inline-flex items-center justify-center py-3 px-6 bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white font-medium rounded-full transition-colors duration-200 shadow-[0_1px_2px_rgba(23,37,84,0.2),0_3px_8px_-2px_rgba(23,37,84,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)] disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
     >
       <span v-if="loading" class="flex items-center justify-center">
         <span class="mr-2">Processing</span>
@@ -90,15 +90,18 @@ export default {
         // Create elements with minimal configuration
         const elements = stripe.value.elements();
         
+        // Match the Stripe iframe text to the theme's ink color
+        const isDarkMode = document.documentElement.classList.contains('dark');
+
         // Create card element with simple styling
         card.value = elements.create('card', {
           style: {
             base: {
-              color: '#fff',
+              color: isDarkMode ? '#ffffff' : '#172554',
               fontFamily: '"Inter", sans-serif',
               fontSize: '16px',
               '::placeholder': {
-                color: '#6b7280'
+                color: isDarkMode ? 'rgba(255, 255, 255, 0.4)' : 'rgba(23, 37, 84, 0.4)'
               }
             },
             invalid: {

--- a/frontend/vuejs/src/apps/payments/components/organisms/forms/PaymentFormSection/PaymentFormSection.vue
+++ b/frontend/vuejs/src/apps/payments/components/organisms/forms/PaymentFormSection/PaymentFormSection.vue
@@ -6,15 +6,15 @@
       <div>
         <!-- Clean section title -->
         <div class="mb-6 text-center md:text-left">
-          <span class="text-sm font-medium text-gray-600 dark:text-gray-400 uppercase tracking-wide">{{ title }}</span>
+          <span class="text-xs font-semibold uppercase tracking-[0.16em] text-blue-700 dark:text-blue-300/70 transition-colors duration-300">{{ title }}</span>
         </div>
-        
+
         <!-- Custom Amount Input -->
         <div>
           <div class="mb-4">
             <div class="relative mt-1 rounded-xl shadow-sm">
               <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-                <span class="text-gray-500 dark:text-gray-400 sm:text-sm">$</span>
+                <span class="text-blue-950/60 dark:text-blue-100/55 sm:text-sm">$</span>
               </div>
               <input
                 v-model.number="amount"
@@ -22,23 +22,23 @@
                 :min="minAmount"
                 :max="maxAmount"
                 :step="step"
-                class="no-focus-effect block w-full rounded-xl border-gray-300 dark:border-white/20 bg-white dark:bg-white/5 py-3 pl-8 pr-28 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-white/40"
+                class="block w-full rounded-xl border border-blue-950/[0.12] dark:border-white/[0.14] bg-white dark:bg-white/[0.05] py-3 pl-8 pr-28 text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-blue-100/30 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:border-blue-500/50 dark:focus-visible:border-blue-300/50"
               />
               <div class="absolute inset-y-0 right-12 flex flex-col justify-center py-1 gap-0.5">
-                <button 
-                  type="button" 
+                <button
+                  type="button"
                   @click="incrementAmount"
-                  class="flex items-center justify-center px-1 text-gray-500 dark:text-gray-400"
+                  class="flex items-center justify-center px-1 rounded text-blue-950/50 hover:text-blue-950 dark:text-blue-100/50 dark:hover:text-white transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50"
                   tabindex="-1"
                 >
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4">
                     <path fill-rule="evenodd" d="M10 17a.75.75 0 01-.75-.75V5.612L5.29 9.77a.75.75 0 01-1.08-1.04l5.25-5.5a.75.75 0 011.08 0l5.25 5.5a.75.75 0 11-1.08 1.04l-3.96-4.158V16.25A.75.75 0 0110 17z" clip-rule="evenodd" />
                   </svg>
                 </button>
-                <button 
-                  type="button" 
+                <button
+                  type="button"
                   @click="decrementAmount"
-                  class="flex items-center justify-center px-1 text-gray-500 dark:text-gray-400"
+                  class="flex items-center justify-center px-1 rounded text-blue-950/50 hover:text-blue-950 dark:text-blue-100/50 dark:hover:text-white transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50"
                   tabindex="-1"
                 >
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-4 h-4">
@@ -47,19 +47,19 @@
                 </button>
               </div>
               <div class="absolute inset-y-0 right-0 flex items-center pr-3">
-                <span class="text-gray-500 dark:text-gray-400 sm:text-sm">USD</span>
+                <span class="text-blue-950/60 dark:text-blue-100/55 sm:text-sm">USD</span>
               </div>
             </div>
-            <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">{{ helpText }}</p>
+            <p class="mt-2 text-sm text-blue-950/60 dark:text-blue-100/55 transition-colors duration-300">{{ helpText }}</p>
           </div>
         </div>
       </div>
-      
+
       <!-- Payment Method Section (wider, 2 columns) -->
       <div class="md:col-span-2">
         <!-- Clean section title -->
         <div class="mb-6 text-center md:text-left">
-          <span class="text-sm font-medium text-gray-600 dark:text-gray-400 uppercase tracking-wide">{{ paymentSectionTitle }}</span>
+          <span class="text-xs font-semibold uppercase tracking-[0.16em] text-blue-700 dark:text-blue-300/70 transition-colors duration-300">{{ paymentSectionTitle }}</span>
         </div>
         
         <!-- Payment Form -->
@@ -68,42 +68,39 @@
           <div class="mb-8">
             <!-- Credit Card Information -->
             <div class="mb-4">
-              <div 
-                id="card-element" 
+              <div
+                id="card-element"
                 ref="cardElement"
-                class="block w-full rounded-xl border border-gray-300 dark:border-white/20 bg-white dark:bg-white/5 py-3 px-4 text-gray-900 dark:text-white transition-all duration-300 focus-within:border-gray-900 dark:focus-within:border-white/40 focus-within:ring-1 focus-within:ring-gray-900 dark:focus-within:ring-white/40 min-h-[45px]"
+                class="block w-full rounded-xl border border-blue-950/[0.12] dark:border-white/[0.14] bg-white dark:bg-white/[0.05] py-3 px-4 text-blue-950 dark:text-white transition-all duration-300 focus-within:border-blue-500/50 dark:focus-within:border-blue-300/50 focus-within:ring-2 focus-within:ring-blue-500/40 dark:focus-within:ring-blue-300/50 min-h-[45px]"
               ></div>
               <div id="card-errors" class="mt-2 text-sm text-red-600 dark:text-red-400"></div>
             </div>
           </div>
-          
+
           <!-- Order Summary -->
-          <div class="mb-8 rounded-xl border border-gray-200 dark:border-white/10 bg-gray-50 dark:bg-white/5 overflow-hidden">
-            <div class="p-4 border-b border-gray-200 dark:border-white/10 bg-white dark:bg-white/5">
-              <h4 class="font-semibold text-gray-900 dark:text-white">{{ summaryTitle }}</h4>
-              <p class="text-sm text-gray-500 dark:text-gray-400">{{ summarySubtitle }}</p>
+          <div class="mb-8 rounded-xl border border-blue-950/[0.08] dark:border-white/[0.1] bg-white/70 dark:bg-white/[0.03] overflow-hidden transition-colors duration-300">
+            <div class="p-4 border-b border-blue-950/[0.08] dark:border-white/[0.1] bg-white/85 dark:bg-white/[0.045]">
+              <h4 class="font-semibold tracking-tight text-blue-950 dark:text-white transition-colors duration-300">{{ summaryTitle }}</h4>
+              <p class="text-sm text-blue-950/60 dark:text-blue-100/55 transition-colors duration-300">{{ summarySubtitle }}</p>
             </div>
             <div class="p-4">
-              <div class="flex justify-between py-2 border-b border-gray-200 dark:border-white/10">
-                <span class="text-gray-600 dark:text-gray-400">{{ amountSummaryLabel }}</span>
-                <span class="font-medium text-gray-900 dark:text-white">${{ formattedAmount }}</span>
+              <div class="flex justify-between py-2 border-b border-blue-950/[0.08] dark:border-white/[0.1]">
+                <span class="text-blue-950/60 dark:text-blue-100/55">{{ amountSummaryLabel }}</span>
+                <span class="font-medium tabular-nums text-blue-950 dark:text-white">${{ formattedAmount }}</span>
               </div>
               <div class="flex justify-between py-2">
-                <span class="text-gray-600 dark:text-gray-400">{{ totalLabel }}</span>
-                <span class="font-semibold text-gray-900 dark:text-white">${{ formattedAmount }}</span>
+                <span class="text-blue-950/60 dark:text-blue-100/55">{{ totalLabel }}</span>
+                <span class="font-semibold tabular-nums text-blue-950 dark:text-white">${{ formattedAmount }}</span>
               </div>
             </div>
           </div>
-          
-          <!-- Submit Button with clean styling -->
-          <button 
+
+          <!-- Submit Button with navy ink pill styling -->
+          <button
             type="submit"
             :disabled="!isValidAmount || isLoading || !cardComplete"
-            class="group relative w-full inline-flex items-center justify-center gap-3 px-8 py-4 bg-gray-900 dark:bg-white text-white dark:text-gray-900 rounded-full font-medium text-lg transition-all duration-300 hover:scale-[1.02] hover:shadow-2xl disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100 disabled:hover:shadow-none overflow-hidden"
+            class="group relative w-full inline-flex items-center justify-center gap-3 px-8 py-4 rounded-full font-medium text-lg bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white transition-all duration-200 hover:-translate-y-0.5 active:translate-y-0 shadow-[0_1px_2px_rgba(23,37,84,0.25),0_8px_20px_-6px_rgba(23,37,84,0.35),inset_0_1px_0_rgba(255,255,255,0.12)] hover:shadow-[0_2px_3px_rgba(23,37,84,0.22),0_14px_28px_-8px_rgba(23,37,84,0.4),inset_0_1px_0_rgba(255,255,255,0.12)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.5),0_10px_24px_-8px_rgba(0,0,0,0.55)] dark:hover:shadow-[0_2px_3px_rgba(0,0,0,0.5),0_14px_30px_-8px_rgba(0,0,0,0.6)] disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
           >
-            <!-- Subtle shine effect on hover -->
-            <span class="absolute inset-0 bg-gradient-to-r from-transparent via-white/10 to-transparent translate-x-[-200%] group-hover:translate-x-[200%] transition-transform duration-700 ease-out"></span>
-            
             <span v-if="isLoading" class="relative flex items-center justify-center gap-2">
               <svg class="animate-spin h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -275,11 +272,11 @@ const initializeStripe = () => {
     const card = elements.create('card', {
       style: {
         base: {
-          color: isDarkMode ? '#FFFFFF' : '#111827',
+          color: isDarkMode ? '#FFFFFF' : '#172554',
           fontFamily: 'ui-sans-serif, system-ui, sans-serif',
           fontSize: '16px',
           '::placeholder': {
-            color: isDarkMode ? 'rgba(255, 255, 255, 0.4)' : 'rgba(107, 114, 128, 0.8)'
+            color: isDarkMode ? 'rgba(255, 255, 255, 0.4)' : 'rgba(23, 37, 84, 0.4)'
           }
         },
         invalid: {
@@ -422,28 +419,13 @@ input[type="number"] {
   -moz-appearance: textfield;
 }
 
-/* Remove all focus effects */
-.no-focus-effect {
-  outline: none !important;
-  box-shadow: none !important;
-  border-color: inherit !important;
-}
-
-.no-focus-effect:focus {
-  outline: none !important;
-  box-shadow: none !important;
-  border-color: rgb(209 213 219) !important; /* border-gray-300 */
-}
-
-.no-focus-effect:focus-visible {
-  outline: none !important;
-  box-shadow: none !important;
-  border-color: rgb(209 213 219) !important;
-}
-
-:root.dark .no-focus-effect:focus,
-:root.dark .no-focus-effect:focus-visible {
-  border-color: rgba(255, 255, 255, 0.2) !important; /* dark:border-white/20 */
+/* Respect users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  button[type="submit"],
+  button[type="submit"]:hover,
+  button[type="submit"]:active {
+    transform: none;
+  }
 }
 
 /* Ensure Stripe element container is properly displayed */

--- a/frontend/vuejs/src/apps/payments/components/organisms/messages/ErrorMessage/ErrorMessage.vue
+++ b/frontend/vuejs/src/apps/payments/components/organisms/messages/ErrorMessage/ErrorMessage.vue
@@ -3,21 +3,21 @@
     <!-- Error Icon -->
     <div class="error-icon mb-6">
       <svg class="w-20 h-20 mx-auto" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path 
-          stroke-linecap="round" 
-          stroke-linejoin="round" 
-          stroke-width="1.5" 
-          d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" 
-          class="stroke-red-500" 
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="1.5"
+          d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z"
+          class="stroke-red-500 dark:stroke-red-400"
         />
       </svg>
     </div>
 
-    <h1 class="text-3xl font-bold text-white mb-4">{{ title }}</h1>
-    <p class="text-gray-400 mb-8">{{ subtitle }}</p>
+    <h1 class="font-display text-3xl font-semibold tracking-[-0.02em] text-blue-950 dark:text-white mb-4 transition-colors duration-300">{{ title }}</h1>
+    <p class="text-blue-950/65 dark:text-blue-100/65 mb-8 transition-colors duration-300">{{ subtitle }}</p>
 
-    <div v-if="message" class="bg-red-900/20 border border-red-900/30 rounded-lg p-4 mb-8 max-w-md mx-auto">
-      <p class="text-red-400">{{ message }}</p>
+    <div v-if="message" class="bg-red-50/80 dark:bg-red-500/10 border border-red-200/70 dark:border-red-400/25 rounded-xl p-4 mb-8 max-w-md mx-auto transition-colors duration-300">
+      <p class="text-red-700 dark:text-red-300">{{ message }}</p>
     </div>
 
     <!-- Actions -->
@@ -35,12 +35,12 @@
     </div>
 
     <!-- Help Text -->
-    <p v-if="helpText" class="mt-8 text-sm text-gray-400">
+    <p v-if="helpText" class="mt-8 text-sm text-blue-950/60 dark:text-blue-100/55 transition-colors duration-300">
       {{ helpText }}
-      <a 
-        v-if="contactLink" 
-        :href="contactLink" 
-        class="text-primary-400 hover:text-primary-300"
+      <a
+        v-if="contactLink"
+        :href="contactLink"
+        class="text-blue-700 hover:text-blue-800 dark:text-blue-300 dark:hover:text-blue-200 underline decoration-blue-700/30 dark:decoration-blue-300/30 underline-offset-2 rounded transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
       >
         {{ contactText }}
       </a>
@@ -120,6 +120,12 @@ export default defineComponent({
   100% {
     transform: scale(0.95);
     opacity: 0.8;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .error-icon {
+    animation: none;
   }
 }
 </style> 

--- a/frontend/vuejs/src/apps/payments/components/organisms/messages/SuccessMessage/SuccessMessage.vue
+++ b/frontend/vuejs/src/apps/payments/components/organisms/messages/SuccessMessage/SuccessMessage.vue
@@ -8,26 +8,26 @@
       </svg>
     </div>
 
-    <h1 class="text-3xl font-bold text-white mb-4">{{ title }}</h1>
-    <p class="text-gray-400 mb-8">{{ subtitle }}</p>
+    <h1 class="font-display text-3xl font-semibold tracking-[-0.02em] text-blue-950 dark:text-white mb-4 transition-colors duration-300">{{ title }}</h1>
+    <p class="text-blue-950/65 dark:text-blue-100/65 mb-8 transition-colors duration-300">{{ subtitle }}</p>
 
     <!-- Payment Details -->
-    <div class="bg-dark-900 rounded-lg p-6 mb-8 max-w-md mx-auto">
+    <div class="rounded-2xl bg-white/85 dark:bg-white/[0.045] border border-blue-950/[0.08] dark:border-white/[0.1] backdrop-blur-sm p-6 mb-8 max-w-md mx-auto transition-colors duration-300">
       <div class="space-y-4">
         <div v-for="(detail, index) in details" :key="index" class="flex justify-between items-center">
-          <span class="text-gray-400">{{ detail.label }}:</span>
-          <span 
-            class="text-xl font-semibold" 
-            :class="detail.highlight ? 'text-primary-500' : 'text-white'"
+          <span class="text-blue-950/60 dark:text-blue-100/55">{{ detail.label }}:</span>
+          <span
+            class="text-xl font-semibold tabular-nums"
+            :class="detail.highlight ? 'text-blue-700 dark:text-blue-300' : 'text-blue-950 dark:text-white'"
           >
             {{ detail.value }}
           </span>
         </div>
-        
-        <div v-if="total" class="border-t border-dark-700 pt-4">
+
+        <div v-if="total" class="border-t border-blue-950/[0.08] dark:border-white/[0.1] pt-4">
           <div class="flex justify-between items-center">
-            <span class="text-gray-400">{{ totalLabel }}:</span>
-            <span class="text-2xl font-bold text-white">{{ total }}</span>
+            <span class="text-blue-950/60 dark:text-blue-100/55">{{ totalLabel }}:</span>
+            <span class="text-2xl font-semibold tabular-nums text-blue-950 dark:text-white">{{ total }}</span>
           </div>
         </div>
       </div>
@@ -125,7 +125,7 @@ export default defineComponent({
   stroke-dashoffset: 166;
   stroke-width: 2;
   stroke-miterlimit: 10;
-  stroke: #00ffc6;
+  stroke: #059669;
   fill: none;
   animation: stroke 0.6s cubic-bezier(0.65, 0, 0.45, 1) forwards;
 }
@@ -135,12 +135,27 @@ export default defineComponent({
   stroke-dasharray: 48;
   stroke-dashoffset: 48;
   stroke-width: 3;
-  stroke: #00ffc6;
+  stroke: #059669;
   animation: stroke 0.3s cubic-bezier(0.65, 0, 0.45, 1) 0.8s forwards;
+}
+
+:root.dark .checkmark-circle,
+.dark .checkmark-circle,
+:root.dark .checkmark-check,
+.dark .checkmark-check {
+  stroke: #34d399;
 }
 
 @keyframes stroke {
   100% {
+    stroke-dashoffset: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .checkmark-circle,
+  .checkmark-check {
+    animation: none;
     stroke-dashoffset: 0;
   }
 }

--- a/frontend/vuejs/src/apps/payments/components/organisms/sections/ModelPricingSection/ModelPricingSection.vue
+++ b/frontend/vuejs/src/apps/payments/components/organisms/sections/ModelPricingSection/ModelPricingSection.vue
@@ -1,48 +1,48 @@
 <template>
   <div class="relative" :class="animate ? 'animate-fade-in-up animation-delay-450' : ''">
-    <!-- Card with clean design (matching home page) -->
-    <div class="relative p-8 rounded-3xl bg-white/80 dark:bg-white/[0.02] backdrop-blur-sm border border-gray-200/80 dark:border-white/[0.08] transition-all duration-300 hover:shadow-xl hover:shadow-gray-200/30 dark:hover:shadow-none">
-      
+    <!-- Crisp card with hairline blue tint -->
+    <div class="model-pricing-card relative p-8 rounded-2xl bg-white/85 dark:bg-white/[0.045] backdrop-blur-sm border border-blue-200/70 dark:border-blue-300/[0.14] transition-all duration-300">
+
       <div class="relative z-10">
         <!-- Clean section title -->
         <div class="mb-8">
-          <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mb-2 transition-colors duration-300">{{ title }}</h2>
-          <p class="text-gray-500 dark:text-white/60 transition-colors duration-300">Token-based pricing for AI models</p>
+          <h2 class="text-2xl font-semibold tracking-tight text-blue-950 dark:text-white mb-2 transition-colors duration-300">{{ title }}</h2>
+          <p class="text-blue-950/65 dark:text-blue-100/65 transition-colors duration-300">Token-based pricing for AI models</p>
         </div>
-        
+
         <div class="grid grid-cols-1 gap-4">
-          <!-- Model price cards with clean styling -->
-          <div 
+          <!-- Model price rows with hairline styling -->
+          <div
             v-for="model in models"
             :key="model.id"
-            class="flex flex-col sm:flex-row sm:items-center sm:justify-between p-5 rounded-2xl bg-gray-50 dark:bg-white/[0.03] border border-gray-200/50 dark:border-white/[0.06] transition-all duration-300 gap-4"
+            class="flex flex-col sm:flex-row sm:items-center sm:justify-between p-5 rounded-2xl bg-white/70 dark:bg-white/[0.03] border border-blue-950/[0.08] dark:border-white/[0.1] transition-all duration-300 gap-4"
           >
             <div class="flex flex-col flex-1">
               <div class="flex items-center gap-3 mb-1">
-                <span class="font-semibold text-gray-900 dark:text-white transition-colors duration-300">{{ model.name }}</span>
+                <span class="font-semibold tracking-tight text-blue-950 dark:text-white transition-colors duration-300">{{ model.name }}</span>
               </div>
-              <p v-if="model.description" class="text-sm text-gray-500 dark:text-white/50 transition-colors duration-300">{{ model.description }}</p>
+              <p v-if="model.description" class="text-sm text-blue-950/60 dark:text-blue-100/55 transition-colors duration-300">{{ model.description }}</p>
             </div>
             <div class="flex flex-col items-start sm:items-end gap-1.5">
               <div class="flex items-baseline gap-2">
-                <span class="text-lg font-semibold text-gray-900 dark:text-white transition-colors duration-300">${{ model.inputPrice }}</span>
-                <span class="text-xs text-gray-500 dark:text-white/50 transition-colors duration-300">per 1M input tokens</span>
+                <span class="text-lg font-semibold tabular-nums text-blue-950 dark:text-white transition-colors duration-300">${{ model.inputPrice }}</span>
+                <span class="text-xs text-blue-950/60 dark:text-blue-100/55 transition-colors duration-300">per 1M input tokens</span>
               </div>
               <div class="flex items-baseline gap-2">
-                <span class="text-lg font-semibold text-gray-900 dark:text-white transition-colors duration-300">${{ model.outputPrice }}</span>
-                <span class="text-xs text-gray-500 dark:text-white/50 transition-colors duration-300">per 1M output tokens</span>
+                <span class="text-lg font-semibold tabular-nums text-blue-950 dark:text-white transition-colors duration-300">${{ model.outputPrice }}</span>
+                <span class="text-xs text-blue-950/60 dark:text-blue-100/55 transition-colors duration-300">per 1M output tokens</span>
               </div>
             </div>
           </div>
         </div>
-        
+
         <!-- Information note with clean styling -->
-        <div class="mt-6 p-4 rounded-2xl bg-gray-50 dark:bg-white/[0.03] border border-gray-200/50 dark:border-white/[0.06] transition-colors duration-300">
+        <div class="mt-6 p-4 rounded-2xl bg-blue-50/60 dark:bg-blue-400/[0.06] border border-blue-200/70 dark:border-blue-300/[0.14] transition-colors duration-300">
           <div class="flex items-start gap-3">
-            <svg class="w-5 h-5 text-gray-600 dark:text-white/60 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+            <svg class="w-5 h-5 text-blue-600 dark:text-blue-300 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
               <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd" />
             </svg>
-            <p class="text-sm text-gray-600 dark:text-white/60 leading-relaxed transition-colors duration-300">Pricing is based on tokens processed. Input tokens (prompts) and output tokens (responses) are charged separately per million tokens. Credits are automatically deducted from your account balance.</p>
+            <p class="text-sm text-blue-950/70 dark:text-blue-100/70 leading-relaxed transition-colors duration-300">Pricing is based on tokens processed. Input tokens (prompts) and output tokens (responses) are charged separately per million tokens. Credits are automatically deducted from your account balance.</p>
           </div>
         </div>
       </div>
@@ -129,5 +129,28 @@ const props = defineProps({
 
 .animation-delay-450 {
   animation-delay: 450ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-in-up {
+    animation: none;
+  }
+}
+
+/* Crisp, sharply-defined card: hairline edge + tight layered shadow */
+.model-pricing-card {
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.03),
+    0 1px 2px rgba(15, 23, 42, 0.06),
+    0 4px 10px -2px rgba(15, 23, 42, 0.07),
+    0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
+
+.dark .model-pricing-card {
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 12px 28px -10px rgba(0, 0, 0, 0.55);
 }
 </style>

--- a/frontend/vuejs/src/apps/payments/components/organisms/tables/TransactionTable/TransactionTable.vue
+++ b/frontend/vuejs/src/apps/payments/components/organisms/tables/TransactionTable/TransactionTable.vue
@@ -3,10 +3,10 @@
     <!-- Filters -->
     <div class="mb-6 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
       <div class="flex items-center">
-        <span class="text-gray-400 mr-2">Filter:</span>
-        <select 
-          v-model="filter" 
-          class="bg-dark-900 border border-dark-700 text-white rounded-lg px-3 py-2 focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+        <span class="text-blue-950/60 dark:text-blue-100/55 mr-2 transition-colors duration-300">Filter:</span>
+        <select
+          v-model="filter"
+          class="bg-white dark:bg-white/[0.05] border border-blue-950/[0.12] dark:border-white/[0.14] text-blue-950 dark:text-white rounded-lg px-3 py-2 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:border-blue-500/50 dark:focus-visible:border-blue-300/50"
         >
           <option value="all">All Transactions</option>
           <option value="completed">Completed</option>
@@ -15,10 +15,10 @@
         </select>
       </div>
       <div class="flex items-center">
-        <span class="text-gray-400 mr-2">Sort:</span>
-        <select 
-          v-model="sort" 
-          class="bg-dark-900 border border-dark-700 text-white rounded-lg px-3 py-2 focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+        <span class="text-blue-950/60 dark:text-blue-100/55 mr-2 transition-colors duration-300">Sort:</span>
+        <select
+          v-model="sort"
+          class="bg-white dark:bg-white/[0.05] border border-blue-950/[0.12] dark:border-white/[0.14] text-blue-950 dark:text-white rounded-lg px-3 py-2 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:border-blue-500/50 dark:focus-visible:border-blue-300/50"
         >
           <option value="date-desc">Newest First</option>
           <option value="date-asc">Oldest First</option>
@@ -29,33 +29,33 @@
     </div>
 
     <!-- Table -->
-    <div class="overflow-x-auto">
-      <table class="min-w-full divide-y divide-dark-700">
-        <thead class="bg-dark-900">
+    <div class="overflow-x-auto rounded-2xl border border-blue-950/[0.08] dark:border-white/[0.1] transition-colors duration-300">
+      <table class="min-w-full divide-y divide-blue-950/[0.08] dark:divide-white/[0.1]">
+        <thead class="bg-blue-50/60 dark:bg-white/[0.04]">
           <tr>
-            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
+            <th scope="col" class="px-6 py-3 text-left text-xs font-semibold text-blue-950/60 dark:text-blue-100/55 uppercase tracking-[0.16em]">
               Date
             </th>
-            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
+            <th scope="col" class="px-6 py-3 text-left text-xs font-semibold text-blue-950/60 dark:text-blue-100/55 uppercase tracking-[0.16em]">
               Description
             </th>
-            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
+            <th scope="col" class="px-6 py-3 text-left text-xs font-semibold text-blue-950/60 dark:text-blue-100/55 uppercase tracking-[0.16em]">
               Amount
             </th>
-            <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
+            <th scope="col" class="px-6 py-3 text-left text-xs font-semibold text-blue-950/60 dark:text-blue-100/55 uppercase tracking-[0.16em]">
               Status
             </th>
           </tr>
         </thead>
-        <tbody class="bg-dark-800 divide-y divide-dark-700">
-          <tr v-for="transaction in paginatedTransactions" :key="transaction.id" class="hover:bg-dark-700">
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-300">
+        <tbody class="bg-white/85 dark:bg-white/[0.02] divide-y divide-blue-950/[0.08] dark:divide-white/[0.1]">
+          <tr v-for="transaction in paginatedTransactions" :key="transaction.id" class="hover:bg-blue-50/50 dark:hover:bg-white/[0.04] transition-colors duration-200">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-blue-950/80 dark:text-blue-100/75">
               {{ formatDate(transaction.created_at) }}
             </td>
-            <td class="px-6 py-4 text-sm text-gray-300">
+            <td class="px-6 py-4 text-sm text-blue-950/80 dark:text-blue-100/75">
               {{ transaction.description }}
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium" :class="getAmountClass(transaction.amount)">
+            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium tabular-nums" :class="getAmountClass(transaction.amount)">
               {{ formatAmount(transaction.amount) }}
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-sm">
@@ -67,7 +67,7 @@
 
           <!-- Empty State -->
           <tr v-if="paginatedTransactions.length === 0">
-            <td colspan="4" class="px-6 py-8 text-center text-gray-400">
+            <td colspan="4" class="px-6 py-8 text-center text-blue-950/60 dark:text-blue-100/55">
               No transactions found matching your filters.
             </td>
           </tr>
@@ -77,7 +77,7 @@
 
     <!-- Pagination -->
     <div class="mt-6 flex justify-between items-center">
-      <div class="text-sm text-gray-400">
+      <div class="text-sm text-blue-950/60 dark:text-blue-100/55 transition-colors duration-300">
         Showing {{ paginatedTransactions.length }} of {{ filteredTransactions.length }} transactions
       </div>
       <div class="flex space-x-2">
@@ -196,17 +196,17 @@ export default defineComponent({
     }
 
     const getAmountClass = (amount: number) => {
-      return amount >= 0 ? 'text-green-500' : 'text-red-500'
+      return amount >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'
     }
 
     const getStatusClass = (status: string) => {
       const statusLower = status.toLowerCase()
       if (statusLower === 'completed' || statusLower === 'succeeded') {
-        return 'bg-green-100 text-green-800'
+        return 'bg-emerald-100 text-emerald-800 dark:bg-emerald-400/10 dark:text-emerald-300'
       } else if (statusLower === 'pending' || statusLower === 'processing') {
-        return 'bg-yellow-100 text-yellow-800'
+        return 'bg-amber-100 text-amber-800 dark:bg-amber-400/10 dark:text-amber-300'
       } else {
-        return 'bg-red-100 text-red-800'
+        return 'bg-red-100 text-red-800 dark:bg-red-400/10 dark:text-red-300'
       }
     }
 

--- a/frontend/vuejs/src/apps/payments/layouts/PaymentLayout.vue
+++ b/frontend/vuejs/src/apps/payments/layouts/PaymentLayout.vue
@@ -1,9 +1,11 @@
-<!-- Payment layout with clean minimal styling -->
+<!-- Payment layout - warm porcelain editorial canvas shared by all payment pages -->
 <template>
   <DefaultLayout>
     <!-- Main Content -->
-    <div class="payment-layout min-h-screen">
-      <main class="relative min-h-screen">
+    <div class="payment-layout relative min-h-screen font-body transition-colors duration-500">
+      <!-- Grain texture over the whole canvas -->
+      <div class="grain-overlay absolute inset-0 z-[1] pointer-events-none" aria-hidden="true"></div>
+      <main class="relative z-10 min-h-screen">
         <slot></slot>
       </main>
     </div>
@@ -73,8 +75,45 @@ export default defineComponent({
 </script>
 
 <style scoped>
-/* Minimal clean styling */
+/* One continuous warm-porcelain canvas; pages paint soft washes on top.
+   The gradient ends on the footer's exact background (bg-white / dark #0a0a0a)
+   so the page hands off seamlessly. */
 .payment-layout {
-  /* All styling handled by parent components */
+  background: linear-gradient(180deg, #fdf9f2 0%, #faf7f1 45%, #ffffff 100%);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+:root.dark .payment-layout,
+.dark .payment-layout {
+  background: linear-gradient(180deg, #0c0c0e 0%, #0a0b0f 50%, #0a0a0a 100%);
+}
+
+/* Fine film grain keeps large soft gradients from banding and adds texture */
+.grain-overlay {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)' opacity='0.5'/%3E%3C/svg%3E");
+  background-size: 160px 160px;
+  opacity: 0.035;
+  mix-blend-mode: multiply;
+}
+
+:root.dark .grain-overlay,
+.dark .grain-overlay {
+  opacity: 0.05;
+  mix-blend-mode: overlay;
+}
+</style>
+
+<!-- Unscoped: brand-tinted text selection on payment pages -->
+<style>
+.payment-layout ::selection {
+  background: rgba(158, 205, 243, 0.55);
+  color: #172554;
+}
+
+.dark .payment-layout ::selection {
+  background: rgba(96, 165, 250, 0.4);
+  color: #eff6ff;
 }
 </style> 

--- a/frontend/vuejs/src/apps/payments/views/PaymentCancelView.vue
+++ b/frontend/vuejs/src/apps/payments/views/PaymentCancelView.vue
@@ -1,14 +1,9 @@
 <template>
   <PaymentLayout>
-    <div class="payment-cancel-view min-h-screen bg-white dark:bg-[#0a0a0a] relative overflow-hidden transition-colors duration-500">
-      <!-- Minimal background with subtle texture - matching checkout page -->
-      <div class="fixed inset-0 pointer-events-none">
-        <!-- Subtle gradient - very minimal -->
-        <div class="absolute inset-0 bg-gradient-to-b from-gray-50/50 via-white to-white dark:from-[#0a0a0a] dark:via-[#0a0a0a] dark:to-[#0a0a0a] transition-colors duration-500"></div>
-        
-        <!-- Very subtle grid pattern for texture -->
-        <div class="absolute inset-0 opacity-[0.015] dark:opacity-[0.02]" 
-             style="background-image: linear-gradient(rgba(128,128,128,0.1) 1px, transparent 1px), linear-gradient(90deg, rgba(128,128,128,0.1) 1px, transparent 1px); background-size: 64px 64px;"></div>
+    <div class="payment-cancel-view min-h-screen relative overflow-hidden transition-colors duration-500">
+      <!-- Atmosphere: one soft apricot wash over the porcelain canvas -->
+      <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
+        <div class="cancel-glow-warm absolute -top-24 left-1/2 -translate-x-1/2 w-[760px] h-[440px]"></div>
       </div>
 
       <!-- Content Container -->
@@ -17,35 +12,35 @@
         <div class="max-w-2xl mx-auto animate-fade-in-up">
           <!-- Cancel Header -->
           <div class="text-center mb-12">
-            <div class="w-20 h-20 rounded-full bg-orange-100 dark:bg-orange-900/20 flex items-center justify-center mx-auto mb-6">
-              <i class="fas fa-exclamation-triangle text-3xl text-orange-600 dark:text-orange-400"></i>
+            <div class="w-20 h-20 rounded-full bg-orange-100 dark:bg-orange-400/[0.16] ring-1 ring-orange-200/80 dark:ring-orange-400/30 flex items-center justify-center mx-auto mb-6">
+              <i class="fas fa-exclamation-triangle text-3xl text-orange-600 dark:text-orange-300"></i>
             </div>
-            <h1 class="text-4xl sm:text-5xl font-semibold text-gray-900 dark:text-white mb-4 tracking-tight">Payment Cancelled</h1>
-            <p class="text-xl text-gray-500 dark:text-white/60">
+            <h1 class="font-display text-4xl sm:text-5xl font-semibold text-blue-950 dark:text-white mb-4 tracking-[-0.02em] leading-[1.05] text-balance">Payment Cancelled</h1>
+            <p class="text-xl text-blue-950/65 dark:text-blue-100/65 leading-relaxed">
               Your payment has been cancelled and you have not been charged.
             </p>
           </div>
-          
+
           <!-- Info Card -->
-          <div class="rounded-2xl bg-gray-50 dark:bg-white/[0.03] border border-gray-200 dark:border-white/[0.08] p-8 mb-12">
-            <p class="text-gray-600 dark:text-gray-400 text-center">
+          <div class="crisp-card rounded-2xl bg-white/85 dark:bg-white/[0.045] border border-blue-950/[0.08] dark:border-white/[0.1] backdrop-blur-sm p-8 mb-12">
+            <p class="text-blue-950/65 dark:text-blue-100/65 text-center leading-relaxed">
               If you encountered any issues or have questions about our payment process, please contact our support team.
             </p>
           </div>
-          
+
           <!-- Action Buttons -->
           <div class="flex flex-col sm:flex-row gap-4 justify-center">
-            <router-link 
-              to="/payments/pricing" 
-              class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-xl bg-gray-900 dark:bg-white text-white dark:text-gray-900 font-medium transition-all duration-200 hover:scale-105 hover:shadow-lg"
+            <router-link
+              to="/payments/pricing"
+              class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-full font-medium bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white transition-all duration-200 hover:-translate-y-0.5 active:translate-y-0 shadow-[0_1px_2px_rgba(23,37,84,0.25),0_8px_20px_-6px_rgba(23,37,84,0.35),inset_0_1px_0_rgba(255,255,255,0.12)] hover:shadow-[0_2px_3px_rgba(23,37,84,0.22),0_14px_28px_-8px_rgba(23,37,84,0.4),inset_0_1px_0_rgba(255,255,255,0.12)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.5),0_10px_24px_-8px_rgba(0,0,0,0.55)] dark:hover:shadow-[0_2px_3px_rgba(0,0,0,0.5),0_14px_30px_-8px_rgba(0,0,0,0.6)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
             >
               <i class="fas fa-redo"></i>
               <span>Try Again</span>
             </router-link>
-            
-            <router-link 
-              to="/" 
-              class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-xl bg-white/50 dark:bg-white/[0.03] border border-gray-200 dark:border-white/[0.08] text-gray-900 dark:text-white font-medium transition-all duration-200 hover:scale-105 hover:shadow-lg"
+
+            <router-link
+              to="/"
+              class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-full font-medium border border-blue-950/[0.14] text-blue-950/80 hover:text-blue-950 hover:border-blue-950/30 hover:bg-blue-950/[0.03] dark:border-white/[0.16] dark:text-blue-100/80 dark:hover:text-white dark:hover:border-white/30 dark:hover:bg-white/[0.06] transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
             >
               <i class="fas fa-home"></i>
               <span>Back to Home</span>
@@ -104,6 +99,39 @@ import PaymentLayout from '../layouts/PaymentLayout.vue'
 
 .animate-fade-in-up {
   animation: fade-in-up 0.6s ease-out forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-in-up {
+    animation: none;
+  }
+}
+
+/* Soft warm wash echoing the home hero's apricot glow */
+.cancel-glow-warm {
+  background: radial-gradient(closest-side, rgba(251, 146, 60, 0.11), rgba(251, 146, 60, 0.03) 55%, transparent 75%);
+  filter: blur(48px);
+}
+
+.dark .cancel-glow-warm {
+  background: radial-gradient(closest-side, rgba(251, 146, 60, 0.06), rgba(251, 146, 60, 0.02) 55%, transparent 75%);
+}
+
+/* Crisp, sharply-defined cards: hairline edge + tight layered shadow */
+.crisp-card {
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.03),
+    0 1px 2px rgba(15, 23, 42, 0.06),
+    0 4px 10px -2px rgba(15, 23, 42, 0.07),
+    0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
+
+.dark .crisp-card {
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 12px 28px -10px rgba(0, 0, 0, 0.55);
 }
 
 /* Smooth scroll behavior */

--- a/frontend/vuejs/src/apps/payments/views/PaymentSuccessView.vue
+++ b/frontend/vuejs/src/apps/payments/views/PaymentSuccessView.vue
@@ -1,14 +1,9 @@
 <template>
   <PaymentLayout>
-    <div class="payment-success-view min-h-screen bg-white dark:bg-[#0a0a0a] relative overflow-hidden transition-colors duration-500">
-      <!-- Minimal background with subtle texture - matching checkout page -->
-      <div class="fixed inset-0 pointer-events-none">
-        <!-- Subtle gradient - very minimal -->
-        <div class="absolute inset-0 bg-gradient-to-b from-gray-50/50 via-white to-white dark:from-[#0a0a0a] dark:via-[#0a0a0a] dark:to-[#0a0a0a] transition-colors duration-500"></div>
-        
-        <!-- Very subtle grid pattern for texture -->
-        <div class="absolute inset-0 opacity-[0.015] dark:opacity-[0.02]" 
-             style="background-image: linear-gradient(rgba(128,128,128,0.1) 1px, transparent 1px), linear-gradient(90deg, rgba(128,128,128,0.1) 1px, transparent 1px); background-size: 64px 64px;"></div>
+    <div class="payment-success-view min-h-screen relative overflow-hidden transition-colors duration-500">
+      <!-- Atmosphere: one soft apricot wash over the porcelain canvas -->
+      <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
+        <div class="success-glow-warm absolute -top-24 left-1/2 -translate-x-1/2 w-[760px] h-[440px]"></div>
       </div>
 
       <!-- Content Container -->
@@ -16,42 +11,42 @@
         <!-- Success Section -->
         <div class="max-w-2xl mx-auto">
           <div v-if="isLoading" class="animate-fade-in-up">
-            <div class="rounded-2xl bg-white/50 dark:bg-white/[0.03] border border-gray-200 dark:border-white/[0.08] backdrop-blur-sm p-12 text-center">
+            <div class="crisp-card rounded-2xl bg-white/85 dark:bg-white/[0.045] border border-blue-950/[0.08] dark:border-white/[0.1] backdrop-blur-sm p-12 text-center">
               <div class="flex justify-center">
-                <svg class="animate-spin h-12 w-12 text-gray-900 dark:text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <svg class="animate-spin h-12 w-12 text-blue-950 dark:text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                   <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                   <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                 </svg>
               </div>
-              <p class="mt-4 text-gray-600 dark:text-gray-400">Processing your payment...</p>
+              <p class="mt-4 text-blue-950/65 dark:text-blue-100/65">Processing your payment...</p>
             </div>
           </div>
           
           <div v-else-if="paymentProcessed" class="animate-fade-in-up space-y-6">
             <!-- Success Header -->
             <div class="text-center mb-12">
-              <div class="w-20 h-20 rounded-full bg-emerald-100 dark:bg-emerald-900/20 flex items-center justify-center mx-auto mb-6">
-                <i class="fas fa-check text-3xl text-emerald-600 dark:text-emerald-400"></i>
+              <div class="w-20 h-20 rounded-full bg-emerald-100 dark:bg-emerald-400/[0.14] ring-1 ring-emerald-200/80 dark:ring-emerald-300/[0.18] flex items-center justify-center mx-auto mb-6">
+                <i class="fas fa-check text-3xl text-emerald-600 dark:text-emerald-300"></i>
               </div>
-              <h1 class="text-4xl sm:text-5xl font-semibold text-gray-900 dark:text-white mb-4 tracking-tight">
+              <h1 class="font-display text-4xl sm:text-5xl font-semibold text-blue-950 dark:text-white mb-4 tracking-[-0.02em] leading-[1.05] text-balance">
                 {{ isSubscription ? 'Subscription Activated!' : 'Payment Successful!' }}
               </h1>
-              <p class="text-xl text-gray-500 dark:text-white/60">
+              <p class="text-xl text-blue-950/65 dark:text-blue-100/65 leading-relaxed">
                 {{ isSubscription ? 'Your subscription is now active. Welcome aboard!' : 'Thank you for your payment.' }}
               </p>
             </div>
 
             <!-- Success Details Card -->
-            <div class="rounded-2xl bg-emerald-50 dark:bg-emerald-900/10 border border-emerald-200 dark:border-emerald-800/30 p-8 text-center">
+            <div class="crisp-card rounded-2xl bg-emerald-50/80 dark:bg-emerald-400/[0.07] border border-emerald-200/70 dark:border-emerald-300/[0.18] backdrop-blur-sm p-8 text-center">
               <p v-if="isSubscription" class="text-lg text-emerald-900 dark:text-emerald-100">
                 Your plan is now active. You can manage your subscription at any time.
               </p>
               <p v-else class="text-lg text-emerald-900 dark:text-emerald-100 mb-3">
                 We've added <span class="font-semibold text-2xl">{{ creditsAdded }}</span> credits to your account!
               </p>
-              <div v-if="!isSubscription" class="mt-6 pt-6 border-t border-emerald-200 dark:border-emerald-800/30">
+              <div v-if="!isSubscription" class="mt-6 pt-6 border-t border-emerald-200/70 dark:border-emerald-300/[0.18]">
                 <p class="text-emerald-700 dark:text-emerald-300/80">Your new balance</p>
-                <p class="text-3xl font-semibold text-emerald-900 dark:text-emerald-100 mt-2">${{ balance.toLocaleString() }}</p>
+                <p class="font-display text-3xl font-semibold tabular-nums text-emerald-900 dark:text-emerald-100 mt-2">${{ balance.toLocaleString() }}</p>
               </div>
             </div>
 
@@ -61,43 +56,43 @@
                 v-if="isSubscription"
                 @click="manageSubscription"
                 :disabled="portalLoading"
-                class="inline-flex items-center gap-2 px-8 py-4 rounded-xl bg-gray-900 dark:bg-white text-white dark:text-gray-900 font-medium transition-all duration-200 hover:scale-105 hover:shadow-lg disabled:opacity-50"
+                class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-full font-medium bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white transition-all duration-200 hover:-translate-y-0.5 active:translate-y-0 shadow-[0_1px_2px_rgba(23,37,84,0.25),0_8px_20px_-6px_rgba(23,37,84,0.35),inset_0_1px_0_rgba(255,255,255,0.12)] hover:shadow-[0_2px_3px_rgba(23,37,84,0.22),0_14px_28px_-8px_rgba(23,37,84,0.4),inset_0_1px_0_rgba(255,255,255,0.12)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.5),0_10px_24px_-8px_rgba(0,0,0,0.55)] dark:hover:shadow-[0_2px_3px_rgba(0,0,0,0.5),0_14px_30px_-8px_rgba(0,0,0,0.6)] disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
               >
                 <i class="fas fa-cog"></i>
                 <span>{{ portalLoading ? 'Loading...' : 'Manage Subscription' }}</span>
               </button>
               <router-link
                 to="/imagi/projects"
-                class="inline-flex items-center gap-2 px-8 py-4 rounded-xl font-medium transition-all duration-200 hover:scale-105 hover:shadow-lg"
+                class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-full font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
                 :class="isSubscription
-                  ? 'bg-gray-100 dark:bg-white/[0.06] text-gray-900 dark:text-white border border-gray-200 dark:border-white/[0.08]'
-                  : 'bg-gray-900 dark:bg-white text-white dark:text-gray-900'"
+                  ? 'border border-blue-950/[0.14] text-blue-950/80 hover:text-blue-950 hover:border-blue-950/30 hover:bg-blue-950/[0.03] dark:border-white/[0.16] dark:text-blue-100/80 dark:hover:text-white dark:hover:border-white/30 dark:hover:bg-white/[0.06] transition-colors'
+                  : 'bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white hover:-translate-y-0.5 active:translate-y-0 shadow-[0_1px_2px_rgba(23,37,84,0.25),0_8px_20px_-6px_rgba(23,37,84,0.35),inset_0_1px_0_rgba(255,255,255,0.12)] hover:shadow-[0_2px_3px_rgba(23,37,84,0.22),0_14px_28px_-8px_rgba(23,37,84,0.4),inset_0_1px_0_rgba(255,255,255,0.12)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.5),0_10px_24px_-8px_rgba(0,0,0,0.55)] dark:hover:shadow-[0_2px_3px_rgba(0,0,0,0.5),0_14px_30px_-8px_rgba(0,0,0,0.6)]'"
               >
                 <i class="fas fa-rocket"></i>
                 <span>Start Building</span>
               </router-link>
             </div>
           </div>
-          
+
           <div v-else-if="error" class="animate-fade-in-up">
             <!-- Error Header -->
             <div class="text-center mb-12">
-              <div class="w-20 h-20 rounded-full bg-red-100 dark:bg-red-900/20 flex items-center justify-center mx-auto mb-6">
+              <div class="w-20 h-20 rounded-full bg-red-100 dark:bg-red-400/[0.14] ring-1 ring-red-200/80 dark:ring-red-300/[0.18] flex items-center justify-center mx-auto mb-6">
                 <i class="fas fa-exclamation-triangle text-3xl text-red-600 dark:text-red-400"></i>
               </div>
-              <h1 class="text-4xl sm:text-5xl font-semibold text-gray-900 dark:text-white mb-4 tracking-tight">Payment Processing Error</h1>
+              <h1 class="font-display text-4xl sm:text-5xl font-semibold text-blue-950 dark:text-white mb-4 tracking-[-0.02em] leading-[1.05] text-balance">Payment Processing Error</h1>
             </div>
-            
+
             <!-- Error Details Card -->
-            <div class="rounded-2xl bg-red-50 dark:bg-red-900/10 border border-red-200 dark:border-red-800/30 p-8">
+            <div class="crisp-card rounded-2xl bg-red-50/80 dark:bg-red-500/10 border border-red-200/70 dark:border-red-400/25 backdrop-blur-sm p-8">
               <p class="text-red-700 dark:text-red-300/80 text-center">{{ error }}</p>
             </div>
-            
+
             <!-- Action Buttons -->
             <div class="flex justify-center mt-12">
-              <router-link 
-                to="/payments/pricing" 
-                class="inline-flex items-center gap-2 px-8 py-4 rounded-xl bg-gray-900 dark:bg-white text-white dark:text-gray-900 font-medium transition-all duration-200 hover:scale-105 hover:shadow-lg"
+              <router-link
+                to="/payments/pricing"
+                class="inline-flex items-center justify-center gap-2 px-8 py-4 rounded-full font-medium bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white transition-all duration-200 hover:-translate-y-0.5 active:translate-y-0 shadow-[0_1px_2px_rgba(23,37,84,0.25),0_8px_20px_-6px_rgba(23,37,84,0.35),inset_0_1px_0_rgba(255,255,255,0.12)] hover:shadow-[0_2px_3px_rgba(23,37,84,0.22),0_14px_28px_-8px_rgba(23,37,84,0.4),inset_0_1px_0_rgba(255,255,255,0.12)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.5),0_10px_24px_-8px_rgba(0,0,0,0.55)] dark:hover:shadow-[0_2px_3px_rgba(0,0,0,0.5),0_14px_30px_-8px_rgba(0,0,0,0.6)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
               >
                 <i class="fas fa-arrow-left"></i>
                 <span>Back to Payments</span>
@@ -228,6 +223,39 @@ onMounted(async () => {
 
 .animate-fade-in-up {
   animation: fade-in-up 0.6s ease-out forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-in-up {
+    animation: none;
+  }
+}
+
+/* Soft warm wash echoing the home hero's apricot glow */
+.success-glow-warm {
+  background: radial-gradient(closest-side, rgba(251, 146, 60, 0.11), rgba(251, 146, 60, 0.03) 55%, transparent 75%);
+  filter: blur(48px);
+}
+
+.dark .success-glow-warm {
+  background: radial-gradient(closest-side, rgba(251, 146, 60, 0.06), rgba(251, 146, 60, 0.02) 55%, transparent 75%);
+}
+
+/* Crisp, sharply-defined cards: hairline edge + tight layered shadow */
+.crisp-card {
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.03),
+    0 1px 2px rgba(15, 23, 42, 0.06),
+    0 4px 10px -2px rgba(15, 23, 42, 0.07),
+    0 12px 28px -10px rgba(15, 23, 42, 0.10);
+}
+
+.dark .crisp-card {
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 1px 2px rgba(0, 0, 0, 0.5),
+    0 4px 10px -2px rgba(0, 0, 0, 0.45),
+    0 12px 28px -10px rgba(0, 0, 0, 0.55);
 }
 
 /* Smooth scroll behavior */

--- a/frontend/vuejs/src/apps/payments/views/PricingView.vue
+++ b/frontend/vuejs/src/apps/payments/views/PricingView.vue
@@ -1,34 +1,39 @@
 <template>
   <PaymentLayout>
-    <div class="pricing-view min-h-screen bg-white dark:bg-[#0a0a0a] relative overflow-hidden transition-colors duration-500">
-      <!-- Minimal Background Effects -->
-      <div class="fixed inset-0 pointer-events-none -z-10">
-        <div class="absolute inset-0 bg-gradient-to-b from-gray-50/50 via-white to-white dark:from-[#0a0a0a] dark:via-[#0a0a0a] dark:to-[#0a0a0a] transition-colors duration-500"></div>
-        <div class="absolute inset-0 opacity-[0.015] dark:opacity-[0.02]"
-             style="background-image: linear-gradient(rgba(128,128,128,0.1) 1px, transparent 1px), linear-gradient(90deg, rgba(128,128,128,0.1) 1px, transparent 1px); background-size: 64px 64px;"></div>
-        <div class="absolute top-1/2 left-1/2 w-[800px] h-[400px] bg-gradient-radial from-gray-200/30 dark:from-white/[0.02] via-transparent to-transparent rounded-full blur-3xl transform -translate-x-1/2 -translate-y-1/2"></div>
+    <div class="pricing-view relative min-h-screen overflow-hidden transition-colors duration-500">
+      <!-- Atmosphere: soft apricot + baby-blue washes over the porcelain canvas -->
+      <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
+        <div class="pricing-glow-warm absolute -top-32 left-1/2 -translate-x-1/2 w-[860px] h-[520px]"></div>
+        <div class="pricing-glow-cool absolute top-64 -left-48 w-[640px] h-[480px]"></div>
       </div>
 
       <!-- Content Container -->
       <div class="relative z-10 max-w-6xl mx-auto px-6 sm:px-8 lg:px-12 pt-24 pb-24 md:pt-32 md:pb-32">
         <!-- Header Section -->
         <div class="mb-16 md:mb-20 text-center">
-          <p class="text-sm font-medium text-gray-500 dark:text-white/50 uppercase tracking-widest mb-4 transition-colors duration-300">
-            Pricing
-          </p>
-          <h1 class="text-4xl sm:text-5xl md:text-6xl font-semibold text-gray-900 dark:text-white mb-6 tracking-tight transition-colors duration-300">
-            Choose your plan
+          <!-- Editorial kicker: tracked small caps flanked by fading hairline rules -->
+          <div class="pricing-rise flex items-center justify-center gap-4 mb-8" style="animation-delay: 0ms">
+            <span aria-hidden="true" class="hidden sm:block h-px w-12 md:w-16 bg-gradient-to-l from-blue-950/25 to-transparent dark:from-white/25"></span>
+            <span class="flex items-center gap-3">
+              <span aria-hidden="true" class="w-1 h-1 rotate-45 bg-orange-500/80 dark:bg-orange-400/80"></span>
+              <span class="text-[10px] sm:text-[11px] font-semibold uppercase tracking-[0.25em] sm:tracking-[0.3em] leading-none text-blue-950/70 dark:text-blue-100/55 whitespace-nowrap">Pricing</span>
+              <span aria-hidden="true" class="w-1 h-1 rotate-45 bg-orange-500/80 dark:bg-orange-400/80"></span>
+            </span>
+            <span aria-hidden="true" class="hidden sm:block h-px w-12 md:w-16 bg-gradient-to-r from-blue-950/25 to-transparent dark:from-white/25"></span>
+          </div>
+          <h1 class="pricing-rise font-display font-semibold text-4xl sm:text-5xl md:text-6xl mb-6 tracking-[-0.02em] leading-[1.05] text-balance text-blue-950 dark:text-white transition-colors duration-300" style="animation-delay: 90ms">
+            Choose your <em class="pricing-accent not-italic">plan</em>
           </h1>
-          <p class="text-xl text-gray-500 dark:text-white/60 max-w-3xl mx-auto transition-colors duration-300">
+          <p class="pricing-rise text-xl text-blue-950/65 dark:text-blue-100/65 leading-relaxed text-pretty max-w-3xl mx-auto transition-colors duration-300" style="animation-delay: 180ms">
             Simple, transparent pricing for every team. Start building today with the plan that fits your needs.
           </p>
         </div>
 
         <!-- Error Message -->
         <div v-if="error" class="mb-8 max-w-2xl mx-auto">
-          <div class="rounded-2xl bg-red-50 dark:bg-red-900/10 border border-red-200 dark:border-red-800/30 p-4 transition-colors duration-300">
+          <div class="rounded-2xl bg-red-50/80 dark:bg-red-500/10 border border-red-200/70 dark:border-red-400/25 p-4 transition-colors duration-300">
             <div class="flex items-center gap-3">
-              <svg class="w-5 h-5 text-red-500 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+              <svg class="w-5 h-5 text-red-500 dark:text-red-400 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
                 <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"/>
               </svg>
               <p class="text-sm text-red-700 dark:text-red-300">{{ error }}</p>
@@ -54,11 +59,13 @@
 
         <!-- On-Demand Section -->
         <div class="mb-16">
+          <!-- Hairline divider -->
+          <div class="section-divider mb-12 md:mb-16" aria-hidden="true"></div>
           <div class="text-center mb-8">
-            <h2 class="text-2xl font-semibold text-gray-900 dark:text-white mb-2 transition-colors duration-300">
+            <h2 class="font-display text-2xl sm:text-3xl font-semibold text-blue-950 dark:text-white tracking-[-0.015em] leading-[1.08] mb-2 transition-colors duration-300">
               Need extra usage?
             </h2>
-            <p class="text-gray-500 dark:text-white/60 transition-colors duration-300">
+            <p class="text-blue-950/65 dark:text-blue-100/65 leading-relaxed transition-colors duration-300">
               Purchase additional credits on demand, anytime.
             </p>
           </div>
@@ -72,11 +79,11 @@
 
         <!-- Secure Payment Badge -->
         <div class="text-center">
-          <div class="inline-flex items-center gap-3 py-3 px-6 bg-white/50 dark:bg-white/[0.03] backdrop-blur-sm rounded-full border border-gray-200/50 dark:border-white/[0.06] transition-colors duration-300">
-            <div class="w-8 h-8 rounded-full bg-gray-100 dark:bg-white/[0.05] flex items-center justify-center">
-              <i class="fas fa-lock text-gray-600 dark:text-gray-400"></i>
+          <div class="inline-flex items-center gap-3 py-3 px-6 bg-white/85 dark:bg-white/[0.07] backdrop-blur-sm rounded-full border border-blue-950/[0.08] dark:border-white/[0.14] transition-colors duration-300">
+            <div class="w-8 h-8 rounded-full bg-orange-100 dark:bg-orange-400/[0.16] ring-1 ring-orange-200/80 dark:ring-orange-400/30 flex items-center justify-center">
+              <i class="fas fa-lock text-xs text-orange-600 dark:text-orange-300"></i>
             </div>
-            <span class="text-gray-600 dark:text-gray-400 text-sm">Powered by Stripe. Secure and encrypted.</span>
+            <span class="text-blue-950/70 dark:text-blue-100/55 text-sm">Powered by Stripe. Secure and encrypted.</span>
           </div>
         </div>
       </div>
@@ -213,5 +220,72 @@ const handleOnDemandPurchase = async (amount: number) => {
 </script>
 
 <style scoped>
-/* Minimal, clean styling matching home page */
+/* Staggered entrance: header items rise in sequence on page load */
+.pricing-rise {
+  animation: pricing-rise 0.9s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@keyframes pricing-rise {
+  from {
+    opacity: 0;
+    transform: translateY(22px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pricing-rise {
+    animation: none;
+  }
+}
+
+/* Atmosphere washes */
+.pricing-glow-warm {
+  background: radial-gradient(closest-side, rgba(251, 146, 60, 0.16), rgba(251, 146, 60, 0.05) 55%, transparent 75%);
+  filter: blur(40px);
+}
+
+.pricing-glow-cool {
+  background: radial-gradient(closest-side, rgba(158, 205, 243, 0.28), rgba(158, 205, 243, 0.08) 55%, transparent 75%);
+  filter: blur(44px);
+}
+
+.dark .pricing-glow-warm {
+  background: radial-gradient(closest-side, rgba(251, 146, 60, 0.09), rgba(251, 146, 60, 0.025) 55%, transparent 75%);
+}
+
+.dark .pricing-glow-cool {
+  background: radial-gradient(closest-side, rgba(96, 165, 250, 0.11), rgba(96, 165, 250, 0.03) 55%, transparent 75%);
+}
+
+/* Italic serif accent with the warm gradient ink */
+.pricing-accent {
+  font-style: italic;
+  font-variation-settings: 'SOFT' 30, 'WONK' 1;
+  background: linear-gradient(115deg, #c2410c 5%, #ea580c 55%, #b45309 95%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  padding-right: 0.06em;
+}
+
+.dark .pricing-accent {
+  background: linear-gradient(115deg, #fb923c 5%, #fcd34d 60%, #f59e0b 95%);
+  -webkit-background-clip: text;
+  background-clip: text;
+}
+
+/* Hairline gradient divider that fades at the edges */
+.section-divider {
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(23, 37, 84, 0.12), transparent);
+}
+
+.dark .section-divider {
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.1), transparent);
+}
 </style>

--- a/frontend/vuejs/src/shared/components/atoms/buttons/GradientButton.vue
+++ b/frontend/vuejs/src/shared/components/atoms/buttons/GradientButton.vue
@@ -3,7 +3,7 @@
     :is="componentTag"
     :to="to"
     :disabled="disabled"
-    class="inline-flex items-center justify-center rounded-full font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#16120e]"
+    class="inline-flex items-center justify-center rounded-full font-medium transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
     :class="[
       sizeClass,
       disabled

--- a/frontend/vuejs/src/shared/components/organisms/navigation/BaseFooter.vue
+++ b/frontend/vuejs/src/shared/components/organisms/navigation/BaseFooter.vue
@@ -1,5 +1,5 @@
 <template>
-  <footer class="crisp-footer relative bg-white dark:bg-[#0a0a0a] border-t border-gray-200 dark:border-white/[0.12] transition-colors duration-300">
+  <footer class="crisp-footer relative font-body bg-white dark:bg-[#0a0a0a] border-t border-blue-950/[0.08] dark:border-white/[0.14] transition-colors duration-300">
     <div class="relative max-w-7xl mx-auto px-6 sm:px-8 lg:px-12">
       
       <!-- Main footer content -->
@@ -8,14 +8,14 @@
           
           <!-- Product section -->
           <div>
-            <h4 class="text-sm font-semibold text-gray-900 dark:text-white mb-4 transition-colors duration-300">
+            <h4 class="text-xs font-semibold uppercase tracking-[0.16em] text-blue-950/70 dark:text-blue-100/55 mb-4 transition-colors duration-300">
               Product
             </h4>
             <ul class="space-y-3">
               <li>
                 <router-link 
                   to="/imagi/projects" 
-                  class="text-sm text-gray-600 dark:text-white/60 hover:text-gray-900 dark:hover:text-white transition-colors duration-200"
+                  class="text-sm rounded-sm text-blue-950/65 dark:text-blue-100/65 hover:text-blue-950 dark:hover:text-white transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
                 >
                   Imagi
                 </router-link>
@@ -23,7 +23,7 @@
               <li>
                 <router-link 
                   to="/payments/pricing" 
-                  class="text-sm text-gray-600 dark:text-white/60 hover:text-gray-900 dark:hover:text-white transition-colors duration-200"
+                  class="text-sm rounded-sm text-blue-950/65 dark:text-blue-100/65 hover:text-blue-950 dark:hover:text-white transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
                 >
                   Pricing
                 </router-link>
@@ -33,14 +33,14 @@
 
           <!-- Resources section -->
           <div>
-            <h4 class="text-sm font-semibold text-gray-900 dark:text-white mb-4 transition-colors duration-300">
+            <h4 class="text-xs font-semibold uppercase tracking-[0.16em] text-blue-950/70 dark:text-blue-100/55 mb-4 transition-colors duration-300">
               Resources
             </h4>
             <ul class="space-y-3">
               <li>
                 <router-link 
                   to="/docs" 
-                  class="text-sm text-gray-600 dark:text-white/60 hover:text-gray-900 dark:hover:text-white transition-colors duration-200"
+                  class="text-sm rounded-sm text-blue-950/65 dark:text-blue-100/65 hover:text-blue-950 dark:hover:text-white transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
                 >
                   Documentation
                 </router-link>
@@ -50,14 +50,14 @@
 
           <!-- Company section -->
           <div>
-            <h4 class="text-sm font-semibold text-gray-900 dark:text-white mb-4 transition-colors duration-300">
+            <h4 class="text-xs font-semibold uppercase tracking-[0.16em] text-blue-950/70 dark:text-blue-100/55 mb-4 transition-colors duration-300">
               Company
             </h4>
             <ul class="space-y-3">
               <li>
                 <router-link 
                   to="/about" 
-                  class="text-sm text-gray-600 dark:text-white/60 hover:text-gray-900 dark:hover:text-white transition-colors duration-200"
+                  class="text-sm rounded-sm text-blue-950/65 dark:text-blue-100/65 hover:text-blue-950 dark:hover:text-white transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
                 >
                   About Us
                 </router-link>
@@ -67,14 +67,14 @@
 
           <!-- Legal section -->
           <div>
-            <h4 class="text-sm font-semibold text-gray-900 dark:text-white mb-4 transition-colors duration-300">
+            <h4 class="text-xs font-semibold uppercase tracking-[0.16em] text-blue-950/70 dark:text-blue-100/55 mb-4 transition-colors duration-300">
               Legal
             </h4>
             <ul class="space-y-3">
               <li>
                 <router-link 
                   to="/privacy" 
-                  class="text-sm text-gray-600 dark:text-white/60 hover:text-gray-900 dark:hover:text-white transition-colors duration-200"
+                  class="text-sm rounded-sm text-blue-950/65 dark:text-blue-100/65 hover:text-blue-950 dark:hover:text-white transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
                 >
                   Privacy Policy
                 </router-link>
@@ -82,7 +82,7 @@
               <li>
                 <router-link 
                   to="/terms" 
-                  class="text-sm text-gray-600 dark:text-white/60 hover:text-gray-900 dark:hover:text-white transition-colors duration-200"
+                  class="text-sm rounded-sm text-blue-950/65 dark:text-blue-100/65 hover:text-blue-950 dark:hover:text-white transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
                 >
                   Terms of Service
                 </router-link>
@@ -93,9 +93,9 @@
       </div>
 
       <!-- Bottom bar -->
-      <div class="py-5 border-t border-gray-200 dark:border-white/[0.12] transition-colors duration-300">
+      <div class="py-5 border-t border-blue-950/[0.08] dark:border-white/[0.14] transition-colors duration-300">
         <div class="flex items-center justify-between">
-          <p class="text-gray-500 dark:text-white/50 text-sm transition-colors duration-300">
+          <p class="text-blue-950/60 dark:text-blue-100/55 text-sm transition-colors duration-300">
             &copy; {{ currentYear }} Imagi. All rights reserved.
           </p>
           

--- a/frontend/vuejs/src/shared/components/organisms/navigation/BaseNavbar.vue
+++ b/frontend/vuejs/src/shared/components/organisms/navigation/BaseNavbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav class="crisp-nav fixed w-full z-50 bg-white/80 dark:bg-[#0a0a0a]/80 backdrop-blur-xl border-b border-gray-200/80 dark:border-white/[0.08] transition-colors duration-300">
+  <nav class="crisp-nav fixed w-full z-50 font-body bg-white/80 dark:bg-[#0a0a0a]/80 backdrop-blur-xl border-b border-blue-950/[0.08] dark:border-white/[0.08] transition-colors duration-300">
     <div class="relative px-6 sm:px-8 lg:px-12" :class="fluid ? 'w-full' : 'max-w-7xl mx-auto'">
       <div class="relative flex items-center h-14">
         <!-- Left section -->

--- a/frontend/vuejs/src/shared/components/pages/NotFound.vue
+++ b/frontend/vuejs/src/shared/components/pages/NotFound.vue
@@ -1,17 +1,49 @@
+<!-- 404 page - warm porcelain editorial design -->
 <template>
-  <div class="min-h-screen flex items-center justify-center bg-dark-900">
-    <div class="text-center">
-      <h1 class="text-6xl font-bold text-primary-500 mb-4">404</h1>
-      <h2 class="text-2xl font-semibold text-gray-300 mb-6">Page Not Found</h2>
-      <p class="text-gray-400 mb-8">
+  <div class="not-found-page relative min-h-screen overflow-hidden font-body flex items-center justify-center px-6 sm:px-8 transition-colors duration-500">
+
+    <!-- Grain texture over the canvas -->
+    <div class="grain-overlay absolute inset-0 z-[1] pointer-events-none" aria-hidden="true"></div>
+
+    <!-- Atmosphere: one soft apricot wash behind the folio -->
+    <div class="absolute inset-0 pointer-events-none" aria-hidden="true">
+      <div class="nf-glow-warm absolute left-1/2 top-[42%] -translate-x-1/2 -translate-y-1/2 w-[700px] h-[440px]"></div>
+    </div>
+
+    <div class="relative z-10 max-w-xl mx-auto text-center py-24">
+
+      <!-- Folio number: giant serif with the warm gradient ink -->
+      <h1 class="nf-item font-display font-semibold text-[6rem] sm:text-[8rem] leading-none tracking-[-0.02em] mb-4" style="animation-delay: 0ms">
+        <em class="nf-accent">404</em>
+      </h1>
+
+      <!-- Editorial kicker: tracked small caps flanked by fading hairline rules -->
+      <div class="nf-item flex items-center justify-center gap-4 mb-8" style="animation-delay: 90ms">
+        <span aria-hidden="true" class="hidden sm:block h-px w-10 md:w-14 bg-gradient-to-l from-blue-950/25 to-transparent dark:from-white/25"></span>
+        <h2 class="flex items-center gap-3">
+          <span aria-hidden="true" class="w-1 h-1 rotate-45 bg-orange-500/80 dark:bg-orange-400/80"></span>
+          <span class="text-[10px] sm:text-[11px] font-semibold uppercase tracking-[0.25em] leading-none text-blue-950/70 dark:text-blue-100/55 whitespace-nowrap">Page Not Found</span>
+          <span aria-hidden="true" class="w-1 h-1 rotate-45 bg-orange-500/80 dark:bg-orange-400/80"></span>
+        </h2>
+        <span aria-hidden="true" class="hidden sm:block h-px w-10 md:w-14 bg-gradient-to-r from-blue-950/25 to-transparent dark:from-white/25"></span>
+      </div>
+
+      <p class="nf-item text-lg text-blue-950/65 dark:text-blue-100/65 leading-relaxed text-pretty mb-10 transition-colors duration-300" style="animation-delay: 180ms">
         The page you're looking for doesn't exist or has been moved.
       </p>
-      <router-link
-        to="/"
-        class="inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 transition-colors duration-200"
-      >
-        Return Home
-      </router-link>
+
+      <!-- Navy ink pill home button -->
+      <div class="nf-item" style="animation-delay: 270ms">
+        <router-link
+          to="/"
+          class="group inline-flex items-center justify-center gap-3 px-8 py-4 rounded-full font-medium text-lg bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white transition-all duration-200 hover:-translate-y-0.5 active:translate-y-0 shadow-[0_1px_2px_rgba(23,37,84,0.25),0_8px_20px_-6px_rgba(23,37,84,0.35),inset_0_1px_0_rgba(255,255,255,0.12)] hover:shadow-[0_2px_3px_rgba(23,37,84,0.22),0_14px_28px_-8px_rgba(23,37,84,0.4),inset_0_1px_0_rgba(255,255,255,0.12)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.5),0_10px_24px_-8px_rgba(0,0,0,0.55)] dark:hover:shadow-[0_2px_3px_rgba(0,0,0,0.5),0_14px_30px_-8px_rgba(0,0,0,0.6)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
+        >
+          <span>Return Home</span>
+          <svg class="w-5 h-5 transition-transform duration-300 group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+          </svg>
+        </router-link>
+      </div>
     </div>
   </div>
 </template>
@@ -21,3 +53,95 @@ defineOptions({
   name: 'NotFound'
 })
 </script>
+
+<style scoped>
+/* Short-page porcelain canvas: starts porcelain, ends on the footer white */
+.not-found-page {
+  background: linear-gradient(180deg, #fdf9f2 0%, #faf7f1 55%, #ffffff 100%);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+:root.dark .not-found-page,
+.dark .not-found-page {
+  background: linear-gradient(180deg, #0c0c0e 0%, #0a0b0f 55%, #0a0a0a 100%);
+}
+
+/* Fine film grain over the canvas */
+.grain-overlay {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160' viewBox='0 0 160 160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)' opacity='0.5'/%3E%3C/svg%3E");
+  background-size: 160px 160px;
+  opacity: 0.035;
+  mix-blend-mode: multiply;
+}
+
+:root.dark .grain-overlay,
+.dark .grain-overlay {
+  opacity: 0.05;
+  mix-blend-mode: overlay;
+}
+
+/* Soft warm wash behind the folio number */
+.nf-glow-warm {
+  background: radial-gradient(closest-side, rgba(251, 146, 60, 0.13), rgba(251, 146, 60, 0.04) 55%, transparent 75%);
+  filter: blur(44px);
+}
+
+.dark .nf-glow-warm {
+  background: radial-gradient(closest-side, rgba(251, 146, 60, 0.07), rgba(251, 146, 60, 0.02) 55%, transparent 75%);
+}
+
+/* Italic serif folio number with the warm gradient ink */
+.nf-accent {
+  font-style: italic;
+  font-variation-settings: 'SOFT' 30, 'WONK' 1;
+  background: linear-gradient(115deg, #c2410c 5%, #ea580c 55%, #b45309 95%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  padding-right: 0.06em; /* keep the italic terminal from clipping */
+}
+
+.dark .nf-accent {
+  background: linear-gradient(115deg, #fb923c 5%, #fcd34d 60%, #f59e0b 95%);
+  -webkit-background-clip: text;
+  background-clip: text;
+}
+
+/* Staggered entrance: each .nf-item rises in sequence on page load */
+.nf-item {
+  animation: nf-rise 0.9s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@keyframes nf-rise {
+  from {
+    opacity: 0;
+    transform: translateY(22px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nf-item {
+    animation: none;
+  }
+}
+</style>
+
+<!-- Unscoped: brand-tinted text selection on the 404 page -->
+<style>
+.not-found-page ::selection {
+  background: rgba(158, 205, 243, 0.55);
+  color: #172554;
+}
+
+.dark .not-found-page ::selection {
+  background: rgba(96, 165, 250, 0.4);
+  color: #eff6ff;
+}
+</style>

--- a/frontend/vuejs/src/shared/layouts/BaseLayout.vue
+++ b/frontend/vuejs/src/shared/layouts/BaseLayout.vue
@@ -8,9 +8,9 @@
     <div class="overflow-auto
                 [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar]:h-2
                 [&::-webkit-scrollbar-track]:bg-transparent
-                [&::-webkit-scrollbar-thumb]:bg-gray-300 dark:[&::-webkit-scrollbar-thumb]:bg-dark-700 [&::-webkit-scrollbar-thumb]:rounded
-                [&::-webkit-scrollbar-thumb:hover]:bg-gray-400 dark:[&::-webkit-scrollbar-thumb:hover]:bg-dark-600
-                [&_*:focus-visible]:outline-2 [&_*:focus-visible]:outline-primary-500 [&_*:focus-visible]:outline-offset-2
+                [&::-webkit-scrollbar-thumb]:bg-blue-950/15 dark:[&::-webkit-scrollbar-thumb]:bg-white/10 [&::-webkit-scrollbar-thumb]:rounded
+                [&::-webkit-scrollbar-thumb:hover]:bg-blue-950/25 dark:[&::-webkit-scrollbar-thumb:hover]:bg-white/20
+                [&_*:focus-visible]:outline-2 [&_*:focus-visible]:outline-blue-500/40 dark:[&_*:focus-visible]:outline-blue-300/50 [&_*:focus-visible]:outline-offset-2
                 [scrollbar-width]:thin">
       <slot></slot>
     </div>

--- a/frontend/vuejs/src/shared/layouts/DashboardLayout.vue
+++ b/frontend/vuejs/src/shared/layouts/DashboardLayout.vue
@@ -8,15 +8,15 @@
     <div class="flex" :class="appShell ? 'h-dvh overflow-hidden' : 'min-h-screen'">
       <!-- Sidebar -->
       <aside
-        class="fixed inset-y-0 left-0 z-30 flex flex-col transition-all duration-300 ease-in-out border-r border-gray-200 dark:border-dark-800/70 shadow-xl"
+        class="fixed inset-y-0 left-0 z-30 flex flex-col transition-all duration-300 ease-in-out border-r border-blue-950/[0.08] dark:border-white/[0.08] shadow-xl"
         :class="[
           isSidebarCollapsed
             ? 'w-16 bg-white dark:bg-[#0a0a0a]'
             : (extraWide
-              ? 'w-[36rem] bg-white dark:bg-dark-950/95 backdrop-blur-md'
+              ? 'w-[36rem] bg-white dark:bg-[#0a0a0a]/95 backdrop-blur-md'
               : (wide
-                ? 'w-80 bg-white dark:bg-dark-950/95 backdrop-blur-md'
-                : 'w-72 bg-white dark:bg-dark-950/95 backdrop-blur-md')),
+                ? 'w-80 bg-white dark:bg-[#0a0a0a]/95 backdrop-blur-md'
+                : 'w-72 bg-white dark:bg-[#0a0a0a]/95 backdrop-blur-md')),
           mobileOverlay ? 'max-md:top-16 max-md:w-full max-md:bg-white max-md:dark:bg-[#0a0a0a] max-md:backdrop-blur-none' : '',
           mobileOverlay ? (isSidebarCollapsed ? 'max-md:-translate-x-full' : 'max-md:translate-x-0') : ''
         ]"
@@ -30,7 +30,7 @@
           <!-- Collapse/Expand Button -->
           <button 
             @click="toggleSidebar"
-            class="sidebar-toggle-btn flex items-center justify-center w-8 h-8 rounded-md text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-dark-800/70 hover:text-gray-900 dark:hover:text-white transition-colors duration-200"
+            class="sidebar-toggle-btn flex items-center justify-center w-8 h-8 rounded-md text-blue-950/60 dark:text-blue-100/60 hover:bg-blue-950/[0.04] dark:hover:bg-white/[0.06] hover:text-blue-950 dark:hover:text-white transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
             :title="isSidebarCollapsed ? 'Expand Sidebar' : 'Collapse Sidebar'"
           >
             <i 
@@ -48,17 +48,17 @@
               :key="item.name"
               :to="item.to"
               :class="[
-                'group flex items-center px-3 py-2 text-sm font-medium rounded-lg transition-all duration-200',
-                isActivePath(item) 
-                  ? 'bg-primary-500/10 text-primary-400 shadow-sm' 
-                  : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-dark-800/70 hover:text-gray-900 dark:hover:text-white'
+                'group flex items-center px-3 py-2 text-sm font-medium rounded-lg transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]',
+                isActivePath(item)
+                  ? 'bg-blue-50/80 dark:bg-blue-400/10 text-blue-700 dark:text-blue-300 shadow-sm'
+                  : 'text-blue-950/65 dark:text-blue-100/65 hover:bg-blue-950/[0.04] dark:hover:bg-white/[0.06] hover:text-blue-950 dark:hover:text-white'
               ]"
             >
               <i 
                 :class="[
                   item.icon,
                   'text-lg transition-colors duration-200',
-                  isActivePath(item) ? 'text-primary-400' : 'text-gray-600 dark:text-gray-500 group-hover:text-gray-900 dark:group-hover:text-white',
+                  isActivePath(item) ? 'text-blue-700 dark:text-blue-300' : 'text-blue-950/50 dark:text-blue-100/40 group-hover:text-blue-950 dark:group-hover:text-white',
                   isSidebarCollapsed ? '' : 'mr-3'
                 ]"
               ></i>
@@ -78,7 +78,7 @@
         </div>
 
         <!-- Bottom Actions -->
-        <div class="flex-shrink-0 border-t border-gray-200 dark:border-dark-800/70">
+        <div class="flex-shrink-0 border-t border-blue-950/[0.08] dark:border-white/[0.08]">
           <!-- Additional bottom actions from slot -->
           <slot name="sidebar-bottom"></slot>
         </div>
@@ -95,7 +95,7 @@
       >
         <!-- Navbar -->
         <BaseNavbar
-          class="fixed top-0 right-0 z-20 bg-white/80 dark:bg-dark-900/80 backdrop-blur-md border-b border-gray-200 dark:border-dark-800/70 shadow-sm"
+          class="fixed top-0 right-0 z-20 bg-white/80 dark:bg-[#0a0a0a]/80 backdrop-blur-md border-b border-blue-950/[0.08] dark:border-white/[0.08]"
           :class="[
             isSidebarCollapsed ? 'left-16' : (extraWide ? 'left-[36rem]' : (wide ? 'left-80' : 'left-72')),
             mobileOverlay ? 'max-md:left-0' : ''
@@ -136,14 +136,15 @@
 
         <!-- Main content area -->
         <main
-          class="flex-1 flex flex-col relative pt-16 bg-white dark:bg-gradient-to-b dark:from-dark-950 dark:to-dark-900 overflow-hidden"
+          class="flex-1 flex flex-col relative pt-16 bg-white dark:bg-[#0a0a0a] overflow-hidden"
           :class="appShell ? 'min-h-0' : ''"
         >
           <slot :isSidebarCollapsed="isSidebarCollapsed"></slot>
         </main>
 
-        <!-- Footer (hidden for full-screen app-shell views like the builder) -->
-        <BaseFooter v-if="!appShell" class="border-t border-gray-200 dark:border-dark-800/70 bg-gray-50 dark:bg-dark-900/50 backdrop-blur-sm" />
+        <!-- Footer (hidden for full-screen app-shell views like the builder);
+             BaseFooter supplies its own white / dark #0a0a0a canvas + hairline. -->
+        <BaseFooter v-if="!appShell" />
       </div>
     </div>
   </BaseLayout>
@@ -252,27 +253,9 @@ aside {
   visibility: visible;
 }
 
-/* Remove all outline and focus effects from sidebar toggle button */
+/* No tap flash on the toggle; keyboard focus shows the canonical ring via
+   the focus-visible utilities on the button itself. */
 .sidebar-toggle-btn {
-  outline: 0 !important;
-  outline-width: 0 !important;
-  outline-style: none !important;
-  outline-offset: 0 !important;
-  outline-color: transparent !important;
-  box-shadow: none !important;
-  -webkit-tap-highlight-color: transparent !important;
-}
-
-.sidebar-toggle-btn:hover,
-.sidebar-toggle-btn:focus,
-.sidebar-toggle-btn:focus-visible,
-.sidebar-toggle-btn:active {
-  outline: 0 !important;
-  outline-width: 0 !important;
-  outline-style: none !important;
-  outline-offset: 0 !important;
-  outline-color: transparent !important;
-  box-shadow: none !important;
-  -webkit-box-shadow: none !important;
+  -webkit-tap-highlight-color: transparent;
 }
 </style>

--- a/frontend/vuejs/src/shared/layouts/MinimalLayout.vue
+++ b/frontend/vuejs/src/shared/layouts/MinimalLayout.vue
@@ -1,7 +1,7 @@
-<!-- Minimal layout without navbar or footer -->
+<!-- Minimal layout without navbar or footer - warm porcelain canvas -->
 <template>
   <BaseLayout>
-    <div class="min-h-screen flex flex-col items-center justify-center bg-dark-950 px-4 sm:px-6 lg:px-8">
+    <div class="minimal-canvas min-h-screen flex flex-col items-center justify-center px-4 sm:px-6 lg:px-8 font-body transition-colors duration-500">
       <slot></slot>
     </div>
   </BaseLayout>
@@ -16,4 +16,16 @@ export default {
     BaseLayout
   }
 }
-</script> 
+</script>
+
+<style scoped>
+/* Short-page porcelain canvas: starts porcelain, ends on the footer white */
+.minimal-canvas {
+  background: linear-gradient(180deg, #fdf9f2 0%, #ffffff 100%);
+}
+
+:root.dark .minimal-canvas,
+.dark .minimal-canvas {
+  background: linear-gradient(180deg, #0c0c0e 0%, #0a0a0a 100%);
+}
+</style>


### PR DESCRIPTION
## Summary

The home page redesign (porcelain gradient canvas + grain texture, Fraunces serif display headlines with gradient-ink accents, ink-navy text tokens, navy ink pill buttons, hairline crisp cards, editorial kickers/section pills) previously only lived on the home page — every other surface was still on the older flat-white/gray system (Pricing was the most visibly off-brand, with gray text throughout; About/Privacy/Terms used solid alternating orange/blue blocks).

This PR brings the rest of the site into that system:

- **Full conversion** (porcelain canvas, grain, serif headlines, kickers/pills, crisp cards, navy pill buttons): About / Privacy / Terms, auth (login/register), docs, payments/pricing, project manager, and shared chrome (navbar, footer, 404, layouts)
- **Token harmonization only** (dense product UI kept structurally intact — no layout rebuilds): build workspace, marketing, operate, and sell dashboards — ink text, navy pill buttons, hairline crisp-card panels

Along the way:
- Retired the last flat-gray/amber canvases and legacy gradient buttons
- Added missing `prefers-reduced-motion` opt-outs on several spinner/pulse animations that lacked them
- Corrected a handful of focus-ring offset colors (including the last stale `#16120e` offset in the shared `GradientButton`)
- Normalized the Stripe Elements `appearance` config off its old neon theme (display config only — no checkout logic touched)
- Small unrelated fix: `backend-django` dev server now falls back to an auto-assigned port instead of hardcoding 8000, so it doesn't fail to start when another concurrent session already holds that port

Presentational only — no routes, props, stores, or business logic changed. Tool-identity accent colors (e.g. Sell's emerald, status badge semantics) were intentionally kept.

## Test plan

- [x] `npm run type-check` (vue-tsc) passes
- [x] `npm run lint` passes (0 errors, pre-existing unused-var warnings only)
- [x] Verified in the browser: About, Sign-in, Pricing, Docs in light mode; About, Pricing, Docs in dark mode
- [ ] Reviewer spot-check of build/marketing/operate/sell dashboards (harmonize-only, not visually verified page-by-page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)