### PR TITLE
Restructure subscription plans around usage limits

### DIFF
--- a/frontend/vuejs/src/apps/payments/components/molecules/cards/OnDemandCard/OnDemandCard.vue
+++ b/frontend/vuejs/src/apps/payments/components/molecules/cards/OnDemandCard/OnDemandCard.vue
@@ -7,7 +7,7 @@
           On-Demand Credits
         </h3>
         <p class="text-blue-950/65 dark:text-blue-100/65 text-sm leading-relaxed text-pretty transition-colors duration-300">
-          Need extra API usage beyond your plan? Purchase additional credits anytime. Credits are added to your account instantly and never expire.
+          Hit your session or weekly limit? Buy additional usage credits anytime. Credits are added to your account instantly, stack on top of your plan, and never expire.
         </p>
       </div>
 

--- a/frontend/vuejs/src/apps/payments/components/molecules/cards/SubscriptionTierCard/SubscriptionTierCard.vue
+++ b/frontend/vuejs/src/apps/payments/components/molecules/cards/SubscriptionTierCard/SubscriptionTierCard.vue
@@ -22,24 +22,24 @@
     <!-- Price -->
     <div class="flex items-baseline gap-1 mb-6">
       <span class="font-display text-4xl font-semibold text-blue-950 dark:text-white tracking-tight tabular-nums transition-colors duration-300">
-        ${{ price }}
+        {{ price === 0 ? 'Free' : `$${price}` }}
       </span>
-      <span class="text-blue-950/60 dark:text-blue-100/55 text-sm transition-colors duration-300">/month</span>
+      <span v-if="price !== 0" class="text-blue-950/60 dark:text-blue-100/55 text-sm transition-colors duration-300">/month</span>
     </div>
 
-    <!-- Key Highlights -->
+    <!-- Key Highlights: usage refreshes on a rolling 5-hour session and a weekly limit -->
     <div class="mb-6 space-y-2">
       <div class="flex items-center gap-2 text-sm text-blue-950/70 dark:text-blue-100/70 transition-colors duration-300">
         <svg class="w-4 h-4 flex-shrink-0" :class="isPopular ? 'text-orange-600 dark:text-orange-300' : 'text-blue-600 dark:text-blue-300'" fill="currentColor" viewBox="0 0 20 20">
-          <path d="M10.394 2.08a1 1 0 00-.788 0l-7 3a1 1 0 000 1.84L5.25 8.051a.999.999 0 01.356-.257l4-1.714a1 1 0 11.788 1.838l-3.14 1.346L10 11.25l6.606-2.83a1 1 0 000-1.84l-7-3zM3.31 9.397L5 10.12v4.102a8.969 8.969 0 00-1.05-.174 1 1 0 01-.89-.89 11.115 11.115 0 01.25-3.762zM9.3 16.573A9.026 9.026 0 007 14.935v-3.957l1.818.78a3 3 0 002.364 0l5.508-2.361a11.026 11.026 0 01.25 3.762 1 1 0 01-.89.89 8.968 8.968 0 00-5.35 2.524 1 1 0 01-1.4 0zM6 18a1 1 0 001-1v-2.065a8.935 8.935 0 00-2-.712V17a1 1 0 001 1z"/>
+          <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clip-rule="evenodd"/>
         </svg>
-        <span>{{ deployments }}</span>
+        <span>{{ sessionLimit }}</span>
       </div>
       <div class="flex items-center gap-2 text-sm text-blue-950/70 dark:text-blue-100/70 transition-colors duration-300">
         <svg class="w-4 h-4 flex-shrink-0" :class="isPopular ? 'text-orange-600 dark:text-orange-300' : 'text-blue-600 dark:text-blue-300'" fill="currentColor" viewBox="0 0 20 20">
-          <path fill-rule="evenodd" d="M4 4a2 2 0 00-2 2v4a2 2 0 002 2V6h10a2 2 0 00-2-2H4zm2 6a2 2 0 012-2h8a2 2 0 012 2v4a2 2 0 01-2 2H8a2 2 0 01-2-2v-4zm6 4a2 2 0 100-4 2 2 0 000 4z" clip-rule="evenodd"/>
+          <path fill-rule="evenodd" d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z" clip-rule="evenodd"/>
         </svg>
-        <span>{{ apiUsage }}</span>
+        <span>{{ weeklyLimit }}</span>
       </div>
     </div>
 
@@ -80,7 +80,7 @@
         </svg>
         Processing...
       </span>
-      <span v-else>Get Started</span>
+      <span v-else>{{ cta ?? 'Get Started' }}</span>
     </button>
   </div>
 </template>
@@ -90,8 +90,9 @@ defineProps<{
   name: string
   price: number
   features: string[]
-  deployments: string
-  apiUsage: string
+  sessionLimit: string
+  weeklyLimit: string
+  cta?: string
   isPopular?: boolean
   loading?: boolean
 }>()

--- a/frontend/vuejs/src/apps/payments/views/PricingView.vue
+++ b/frontend/vuejs/src/apps/payments/views/PricingView.vue
@@ -8,7 +8,7 @@
       </div>
 
       <!-- Content Container -->
-      <div class="relative z-10 max-w-6xl mx-auto px-6 sm:px-8 lg:px-12 pt-24 pb-24 md:pt-32 md:pb-32">
+      <div class="relative z-10 max-w-7xl mx-auto px-6 sm:px-8 lg:px-12 pt-24 pb-24 md:pt-32 md:pb-32">
         <!-- Header Section -->
         <div class="mb-16 md:mb-20 text-center">
           <!-- Editorial kicker: tracked small caps flanked by fading hairline rules -->
@@ -25,7 +25,7 @@
             Choose your <em class="pricing-accent not-italic">plan</em>
           </h1>
           <p class="pricing-rise text-xl text-blue-950/65 dark:text-blue-100/65 leading-relaxed text-pretty max-w-3xl mx-auto transition-colors duration-300" style="animation-delay: 180ms">
-            Simple, transparent pricing for every team. Start building today with the plan that fits your needs.
+            Start free, then upgrade as you grow. Usage refreshes on a rolling 5-hour session and a weekly limit — pick the plan that fits how much you build.
           </p>
         </div>
 
@@ -42,17 +42,18 @@
         </div>
 
         <!-- Subscription Tier Cards -->
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-6 md:gap-8 mb-16 md:mb-20">
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-16 md:mb-20">
           <SubscriptionTierCard
             v-for="tier in tiers"
-            :key="tier.lookupKey"
+            :key="tier.name + tier.price"
             :name="tier.name"
             :price="tier.price"
+            :cta="tier.cta"
             :features="tier.features"
-            :deployments="tier.deployments"
-            :api-usage="tier.apiUsage"
+            :session-limit="tier.sessionLimit"
+            :weekly-limit="tier.weeklyLimit"
             :is-popular="tier.isPopular"
-            :loading="loadingTier === tier.lookupKey"
+            :loading="loadingTier === (tier.lookupKey ?? tier.name)"
             @subscribe="handleSubscribe(tier)"
           />
         </div>
@@ -108,46 +109,64 @@ const loadingTier = ref<string | null>(null)
 const loadingOnDemand = ref(false)
 const error = ref('')
 
-const tiers = [
+const tiers: Tier[] = [
   {
-    name: 'Hobby',
-    price: 10,
-    lookupKey: 'hobby_monthly',
-    deployments: '1 project deployment',
-    apiUsage: '$10 of API usage per month',
+    name: 'Free',
+    price: 0,
+    lookupKey: null,
+    cta: 'Start for free',
+    sessionLimit: 'Basic usage every 5 hours',
+    weeklyLimit: 'Limited weekly usage',
     features: [
-      '1 project deployment',
-      '$10 API usage/month',
+      'Access to the core AI builder',
+      '1 active project',
+      'Standard models',
       'Community support',
-      'Basic analytics',
     ],
     isPopular: false,
   },
   {
     name: 'Pro',
-    price: 50,
+    price: 20,
     lookupKey: 'pro_monthly',
-    deployments: '5 project deployments',
-    apiUsage: '$50 of API usage per month',
+    cta: 'Get Started',
+    sessionLimit: 'More usage every 5 hours',
+    weeklyLimit: 'Full weekly usage',
     features: [
-      '5 project deployments',
-      '$50 API usage/month',
+      'Everything in Free',
+      'Unlimited projects',
+      'Advanced models',
       'Priority support',
-      'Advanced analytics',
     ],
     isPopular: true,
   },
   {
     name: 'Max',
     price: 100,
-    lookupKey: 'max_monthly',
-    deployments: 'Unlimited project deployments',
-    apiUsage: '$100 of API usage per month',
+    lookupKey: 'max_5x_monthly',
+    cta: 'Get Started',
+    sessionLimit: '5× more usage every 5 hours',
+    weeklyLimit: '5× higher weekly limit',
     features: [
-      'Unlimited deployments',
-      '$100 API usage/month',
-      'Dedicated support',
-      'Full analytics suite',
+      'Everything in Pro',
+      '5× more usage than Pro',
+      'Higher output limits',
+      'Early access to new features',
+    ],
+    isPopular: false,
+  },
+  {
+    name: 'Max',
+    price: 200,
+    lookupKey: 'max_20x_monthly',
+    cta: 'Get Started',
+    sessionLimit: '20× more usage every 5 hours',
+    weeklyLimit: '20× higher weekly limit',
+    features: [
+      'Everything in Pro',
+      '20× more usage than Pro',
+      'Highest output limits',
+      'Priority access at peak times',
     ],
     isPopular: false,
   },
@@ -156,15 +175,22 @@ const tiers = [
 interface Tier {
   name: string
   price: number
-  lookupKey: string
-  deployments: string
-  apiUsage: string
+  lookupKey: string | null
+  cta: string
+  sessionLimit: string
+  weeklyLimit: string
   features: string[]
   isPopular: boolean
 }
 
 const handleSubscribe = async (tier: Tier) => {
   error.value = ''
+
+  // Free plan has no checkout — send new users to sign up, existing users into the app.
+  if (!tier.lookupKey) {
+    router.push(authStore.isAuthenticated ? { path: '/' } : { path: '/auth/register' })
+    return
+  }
 
   // Check authentication
   if (!authStore.isAuthenticated) {


### PR DESCRIPTION
## What changed

Reworked the subscription options on the pricing page to match an Anthropic/Claude-style usage model — a rolling **5-hour session** allowance plus a **weekly limit** — instead of project deployments and dollar-denominated API usage.

**Plans** (was three: Hobby / Pro / Max):

| Plan | Price | Session (5-hour) | Weekly |
|---|---|---|---|
| **Free** | $0 | Basic usage every 5 hours | Limited weekly usage |
| **Pro** *(Most Popular)* | $20 | More usage every 5 hours | Full weekly usage |
| **Max** | $100 | 5× more usage every 5 hours | 5× higher weekly limit |
| **Max** | $200 | 20× more usage every 5 hours | 20× higher weekly limit |

The on-demand **usage credits** card is kept and reframed as extra usage for when a session or weekly limit is reached.

## Why

The old lineup ($10/$50/$100 with deployment counts and "$X API usage/month") no longer reflects how usage is metered. This aligns the paid tiers and free entry point with the new session + weekly limit model.

## Details

- `PricingView.vue`: new four-tier data, responsive 4-up grid (`sm:grid-cols-2 lg:grid-cols-4`), container widened to `max-w-7xl`, updated header copy.
- `SubscriptionTierCard.vue`: surfaces session/weekly limits with clock + calendar icons, renders "Free" for the $0 tier, accepts a custom CTA label (props `sessionLimit`, `weeklyLimit`, `cta`).
- `OnDemandCard.vue`: copy updated to reference hitting session/weekly limits.
- **Free plan skips Stripe** — its CTA routes new users to `/auth/register` and signed-in users into the app. Paid tiers still use Stripe checkout.

## Reviewer note — Stripe setup required

Checkout resolves plans against live Stripe Prices by `lookup_key`. Before the paid tiers can check out, create recurring Prices with these lookup keys:

- `pro_monthly` — $20
- `max_5x_monthly` — $100
- `max_20x_monthly` — $200

(The old `hobby_monthly` / `max_monthly` keys are no longer referenced.)

## Verification

- `vue-tsc --noEmit` passes.
- Rendered the page on the dev server: all four cards display correctly with the Pro "Most Popular" badge and the usage-limit highlights; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)