### PR TITLE
Align site copy with usage-based pricing; fold Max into one card

### DIFF
--- a/frontend/vuejs/src/apps/home/components/organisms/sections/DeployPreviewSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/DeployPreviewSection.vue
@@ -169,7 +169,7 @@
             <div class="flex flex-col sm:flex-row items-center justify-between gap-4">
               <p class="text-sm text-white/40 text-center sm:text-left">
                 <i class="fas fa-clock text-amber-400/60 mr-2"></i>
-                Imagi-hosted deployment launching Q1 2026
+                Imagi-hosted deployment launching Q4 2026
               </p>
               <router-link 
                 to="/contact"

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/FAQSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/FAQSection.vue
@@ -192,13 +192,13 @@ export default defineComponent({
       {
         icon: 'fas fa-dollar-sign',
         question: 'How does pricing work?',
-        answer: 'Imagi offers monthly subscription plans: Hobby ($10/month), Pro ($50/month), and Max ($100/month). Each plan includes a monthly allowance of AI usage and project deployments, with higher tiers unlocking more deployments, usage, and support. You can cancel anytime.',
+        answer: 'Imagi starts with a free plan, plus two paid plans: Pro ($20/month) and Max, which you can set to 5× ($100/month) or 20× ($200/month) more usage than Pro. Instead of counting deployments, your AI usage refreshes on a rolling 5-hour session with a separate weekly limit — higher plans unlock more usage every session and week, along with advanced models and priority support. You can cancel anytime.',
         link: { text: 'View pricing details', to: '/payments/pricing' }
       },
       {
         icon: 'fas fa-rocket',
         question: 'When will deployment be available?',
-        answer: 'Imagi-hosted deployment is coming in Q1 2026. You\'ll be able to publish your app to a .imagi.app domain with one click. Custom domains, SSL, and auto-scaling will be included. Join the waitlist to get early access.',
+        answer: 'Imagi-hosted deployment is coming in Q4 2026. You\'ll be able to publish your app to a .imagi.app domain with one click. Custom domains, SSL, and auto-scaling will be included. Join the waitlist to get early access.',
         link: { text: 'Join the waitlist', to: '/contact' }
       },
       {

--- a/frontend/vuejs/src/apps/home/components/organisms/sections/StatsSection.vue
+++ b/frontend/vuejs/src/apps/home/components/organisms/sections/StatsSection.vue
@@ -87,10 +87,10 @@ export default defineComponent({
       type: Array,
       default: () => [
         {
-          value: '$10',
-          unit: '/mo',
+          value: 'Free',
+          unit: '',
           label: 'Plans Starting At',
-          caption: 'Simple monthly plans that include AI usage and deployments—cancel anytime.'
+          caption: 'Start free, then upgrade as you grow. Usage refreshes on a rolling 5-hour session and a weekly limit—cancel anytime.'
         },
         {
           value: '30',

--- a/frontend/vuejs/src/apps/home/views/Home.vue
+++ b/frontend/vuejs/src/apps/home/views/Home.vue
@@ -27,7 +27,7 @@
           primaryButtonText="Get Started"
           primaryButtonTo="/imagi/projects"
           :showSecondaryButton="false"
-          footnote="Plans start at $10/month. Cancel anytime."
+          footnote="Start for free. Upgrade anytime as you grow."
         />
       </main>
     </div>

--- a/frontend/vuejs/src/apps/payments/components/molecules/cards/SubscriptionTierCard/SubscriptionTierCard.vue
+++ b/frontend/vuejs/src/apps/payments/components/molecules/cards/SubscriptionTierCard/SubscriptionTierCard.vue
@@ -22,9 +22,32 @@
     <!-- Price -->
     <div class="flex items-baseline gap-1 mb-6">
       <span class="font-display text-4xl font-semibold text-blue-950 dark:text-white tracking-tight tabular-nums transition-colors duration-300">
-        {{ price === 0 ? 'Free' : `$${price}` }}
+        {{ active.price === 0 ? 'Free' : `$${active.price}` }}
       </span>
-      <span v-if="price !== 0" class="text-blue-950/60 dark:text-blue-100/55 text-sm transition-colors duration-300">/month</span>
+      <span v-if="active.price !== 0" class="text-blue-950/60 dark:text-blue-100/55 text-sm transition-colors duration-300">/month</span>
+    </div>
+
+    <!-- Usage option selector (Max-style tiers pick between 5× and 20×) -->
+    <div
+      v-if="options && options.length > 1"
+      class="flex w-full p-1 mb-6 rounded-full bg-blue-950/[0.04] dark:bg-white/[0.05] border border-blue-950/[0.07] dark:border-white/[0.08]"
+      role="tablist"
+      aria-label="Usage amount"
+    >
+      <button
+        v-for="(opt, i) in options"
+        :key="opt.lookupKey"
+        type="button"
+        role="tab"
+        :aria-selected="selected === i"
+        @click="selected = i"
+        class="flex-1 py-1.5 px-3 rounded-full text-xs font-semibold transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50"
+        :class="selected === i
+          ? 'bg-white text-blue-950 shadow-sm dark:bg-[#f3ede2] dark:text-blue-950'
+          : 'text-blue-950/55 hover:text-blue-950/80 dark:text-blue-100/55 dark:hover:text-blue-100/80'"
+      >
+        {{ opt.label }}
+      </button>
     </div>
 
     <!-- Key Highlights: usage refreshes on a rolling 5-hour session and a weekly limit -->
@@ -33,20 +56,20 @@
         <svg class="w-4 h-4 flex-shrink-0" :class="isPopular ? 'text-orange-600 dark:text-orange-300' : 'text-blue-600 dark:text-blue-300'" fill="currentColor" viewBox="0 0 20 20">
           <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-12a1 1 0 10-2 0v4a1 1 0 00.293.707l2.828 2.829a1 1 0 101.415-1.415L11 9.586V6z" clip-rule="evenodd"/>
         </svg>
-        <span>{{ sessionLimit }}</span>
+        <span>{{ active.sessionLimit }}</span>
       </div>
       <div class="flex items-center gap-2 text-sm text-blue-950/70 dark:text-blue-100/70 transition-colors duration-300">
         <svg class="w-4 h-4 flex-shrink-0" :class="isPopular ? 'text-orange-600 dark:text-orange-300' : 'text-blue-600 dark:text-blue-300'" fill="currentColor" viewBox="0 0 20 20">
           <path fill-rule="evenodd" d="M6 2a1 1 0 00-1 1v1H4a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V6a2 2 0 00-2-2h-1V3a1 1 0 10-2 0v1H7V3a1 1 0 00-1-1zm0 5a1 1 0 000 2h8a1 1 0 100-2H6z" clip-rule="evenodd"/>
         </svg>
-        <span>{{ weeklyLimit }}</span>
+        <span>{{ active.weeklyLimit }}</span>
       </div>
     </div>
 
     <!-- Feature List -->
     <ul class="space-y-3 mb-8 pt-5 border-t border-blue-950/[0.06] dark:border-white/[0.07]">
       <li
-        v-for="(feature, index) in features"
+        v-for="(feature, index) in active.features"
         :key="index"
         class="flex items-start gap-3 text-sm text-blue-950/70 dark:text-blue-100/70 transition-colors duration-300"
       >
@@ -64,7 +87,7 @@
 
     <!-- CTA Button -->
     <button
-      @click="$emit('subscribe')"
+      @click="$emit('subscribe', active.lookupKey)"
       :disabled="loading"
       class="w-full inline-flex items-center justify-center py-3 px-6 rounded-full font-medium text-sm transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
       :class="[
@@ -86,20 +109,51 @@
 </template>
 
 <script setup lang="ts">
-defineProps<{
-  name: string
+import { ref, computed } from 'vue'
+
+interface TierOption {
+  label: string
   price: number
-  features: string[]
+  lookupKey: string
   sessionLimit: string
   weeklyLimit: string
+  features: string[]
+}
+
+const props = defineProps<{
+  name: string
   cta?: string
   isPopular?: boolean
   loading?: boolean
+  // Single-option tiers pass these directly…
+  price?: number
+  lookupKey?: string | null
+  sessionLimit?: string
+  weeklyLimit?: string
+  features?: string[]
+  // …multi-option tiers (e.g. Max) pass these instead.
+  options?: TierOption[]
 }>()
 
 defineEmits<{
-  subscribe: []
+  subscribe: [lookupKey: string | null]
 }>()
+
+const selected = ref(0)
+
+// What's currently shown: the selected option for multi-option tiers,
+// otherwise the tier's own props.
+const active = computed(() => {
+  const opt = props.options?.[selected.value]
+  if (opt) return opt
+  return {
+    price: props.price ?? 0,
+    lookupKey: props.lookupKey ?? null,
+    sessionLimit: props.sessionLimit ?? '',
+    weeklyLimit: props.weeklyLimit ?? '',
+    features: props.features ?? [],
+  }
+})
 </script>
 
 <style scoped>

--- a/frontend/vuejs/src/apps/payments/views/PricingView.vue
+++ b/frontend/vuejs/src/apps/payments/views/PricingView.vue
@@ -8,7 +8,7 @@
       </div>
 
       <!-- Content Container -->
-      <div class="relative z-10 max-w-7xl mx-auto px-6 sm:px-8 lg:px-12 pt-24 pb-24 md:pt-32 md:pb-32">
+      <div class="relative z-10 max-w-6xl mx-auto px-6 sm:px-8 lg:px-12 pt-24 pb-24 md:pt-32 md:pb-32">
         <!-- Header Section -->
         <div class="mb-16 md:mb-20 text-center">
           <!-- Editorial kicker: tracked small caps flanked by fading hairline rules -->
@@ -42,19 +42,21 @@
         </div>
 
         <!-- Subscription Tier Cards -->
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-16 md:mb-20">
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-6 md:gap-8 mb-16 md:mb-20">
           <SubscriptionTierCard
             v-for="tier in tiers"
-            :key="tier.name + tier.price"
+            :key="tier.name"
             :name="tier.name"
             :price="tier.price"
+            :lookup-key="tier.lookupKey"
             :cta="tier.cta"
             :features="tier.features"
             :session-limit="tier.sessionLimit"
             :weekly-limit="tier.weeklyLimit"
+            :options="tier.options"
             :is-popular="tier.isPopular"
-            :loading="loadingTier === (tier.lookupKey ?? tier.name)"
-            @subscribe="handleSubscribe(tier)"
+            :loading="isTierLoading(tier)"
+            @subscribe="(lookupKey) => handleSubscribe(tier, lookupKey)"
           />
         </div>
 
@@ -142,52 +144,73 @@ const tiers: Tier[] = [
   },
   {
     name: 'Max',
-    price: 100,
-    lookupKey: 'max_5x_monthly',
     cta: 'Get Started',
-    sessionLimit: '5× more usage every 5 hours',
-    weeklyLimit: '5× higher weekly limit',
-    features: [
-      'Everything in Pro',
-      '5× more usage than Pro',
-      'Higher output limits',
-      'Early access to new features',
-    ],
     isPopular: false,
-  },
-  {
-    name: 'Max',
-    price: 200,
-    lookupKey: 'max_20x_monthly',
-    cta: 'Get Started',
-    sessionLimit: '20× more usage every 5 hours',
-    weeklyLimit: '20× higher weekly limit',
-    features: [
-      'Everything in Pro',
-      '20× more usage than Pro',
-      'Highest output limits',
-      'Priority access at peak times',
+    // A single Max plan with selectable usage options, mirroring Claude's Max tier.
+    options: [
+      {
+        label: '5× usage',
+        price: 100,
+        lookupKey: 'max_5x_monthly',
+        sessionLimit: '5× more usage every 5 hours',
+        weeklyLimit: '5× higher weekly limit',
+        features: [
+          'Everything in Pro',
+          '5× more usage than Pro',
+          'Higher output limits',
+          'Early access to new features',
+        ],
+      },
+      {
+        label: '20× usage',
+        price: 200,
+        lookupKey: 'max_20x_monthly',
+        sessionLimit: '20× more usage every 5 hours',
+        weeklyLimit: '20× higher weekly limit',
+        features: [
+          'Everything in Pro',
+          '20× more usage than Pro',
+          'Highest output limits',
+          'Priority access at peak times',
+        ],
+      },
     ],
-    isPopular: false,
   },
 ]
 
-interface Tier {
-  name: string
+interface TierOption {
+  label: string
   price: number
-  lookupKey: string | null
-  cta: string
+  lookupKey: string
   sessionLimit: string
   weeklyLimit: string
   features: string[]
-  isPopular: boolean
 }
 
-const handleSubscribe = async (tier: Tier) => {
+interface Tier {
+  name: string
+  cta: string
+  isPopular: boolean
+  // Single-option tiers set these directly; multi-option tiers use `options` instead.
+  price?: number
+  lookupKey?: string | null
+  sessionLimit?: string
+  weeklyLimit?: string
+  features?: string[]
+  options?: TierOption[]
+}
+
+// A Max-style tier is "loading" while any of its options is checking out.
+const isTierLoading = (tier: Tier) => {
+  if (tier.options) return tier.options.some((o) => o.lookupKey === loadingTier.value)
+  return loadingTier.value === (tier.lookupKey ?? tier.name)
+}
+
+const handleSubscribe = async (tier: Tier, lookupKey: string | null) => {
   error.value = ''
 
   // Free plan has no checkout — send new users to sign up, existing users into the app.
-  if (!tier.lookupKey) {
+  if (!lookupKey) {
     router.push(authStore.isAuthenticated ? { path: '/' } : { path: '/auth/register' })
     return
   }
@@ -199,10 +222,10 @@ const handleSubscribe = async (tier: Tier) => {
   }
 
   try {
-    loadingTier.value = tier.lookupKey
+    loadingTier.value = lookupKey
 
     const response = await paymentService.createCheckoutSession({
-      lookup_key: tier.lookupKey,
+      lookup_key: lookupKey,
       success_url: window.location.origin + '/payments/success',
       cancel_url: window.location.origin + '/payments/cancel',
     })


### PR DESCRIPTION
## Summary

Brings the marketing site and pricing page in line with the new Free/Pro/Max usage-based model (rolling 5-hour session + weekly limit), and consolidates the two Max tiers into a single card with an in-card usage selector — mirroring Claude's Max plan.

## Changes

**Home page copy**
- StatsSection tile now leads with **Free** instead of `$10/mo`
- CTA footnote → "Start for free. Upgrade anytime as you grow."
- FAQ pricing answer rewritten around the rolling 5-hour session and weekly limit (Free + Pro + Max with 5×/20× options) instead of deployments/dollar allowances

**Pricing page**
- The two Max tiers ($100 5× and $200 20×) collapse into **one Max card** with a segmented **5× / 20×** selector
- `SubscriptionTierCard` takes an optional `options` array and drives price, session/weekly limits, and features off the selected option
- `PricingView` returns to a balanced 3-up grid and routes checkout through the chosen option's Stripe lookup key (`max_5x_monthly` / `max_20x_monthly`)

**Dates**
- Stale "Q1 2026" deployment dates bumped to **Q4 2026**

## Verification
- `npm run type-check` passes
- Verified in-browser: selecting 20× live-updates price → \$200, both usage limits, and all feature lines; 5× → \$100. 3-up grid renders correctly at desktop width.

## Notes
- **Q4 2026** for deployment dates is a placeholder — adjust if the roadmap differs.
- `FAQSection` is exported in the barrel but not yet mounted in any view, so its edits aren't live on the site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)