### PR TITLE
Simplify empty chat state and move version restores into the thread

### DIFF
--- a/frontend/vuejs/src/apps/docs/views/DocsBuildingWithAI.vue
+++ b/frontend/vuejs/src/apps/docs/views/DocsBuildingWithAI.vue
@@ -189,21 +189,21 @@
         </div>
       </section>
 
-      <!-- Version history -->
+      <!-- Checkpoints -->
       <section class="mb-16">
         <h2 class="font-display text-3xl sm:text-4xl font-semibold text-blue-950 dark:text-white mb-6 tracking-[-0.015em] transition-colors duration-300">
           Never Lose Your Work
         </h2>
         <p class="text-blue-950/70 dark:text-blue-100/70 text-lg leading-relaxed mb-8 transition-colors duration-300">
-          Imagi saves a version of your app every time it changes, so you never have to think about saving—and you can always
-          go back.
+          Every message you send is a checkpoint. Imagi saves your app's state before the agent starts working, so you never
+          have to think about saving—and you can always go back.
         </p>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <DocsCard title="Version history">
-            Open the history menu to see past versions, each with a description and timestamp. Restore any one and your app
-            rolls back to that point—your current work stays safely in history.
+          <DocsCard title="Checkpoints in the chat">
+            Your restore points live right in the conversation: each message you sent marks the moment before the agent
+            acted on it, so the chat itself is your app's history.
           </DocsCard>
-          <DocsCard title="Rewind a message">
+          <DocsCard title="Restore a checkpoint">
             Hover any earlier message and choose "Restore checkpoint" to roll both your app and the conversation back to the
             moment before that message—handy for trying a different direction.
           </DocsCard>

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/chat/ChatConversation.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/chat/ChatConversation.vue
@@ -2,26 +2,11 @@
   <div class="h-full flex flex-col relative z-10 transition-colors duration-300" :class="{'mode-transition': disableAllAnimations}">
     <!-- Messages Container -->
     <div ref="messagesContainer" class="flex-grow overflow-y-auto overflow-x-hidden px-4 py-6">
-      <!-- Empty state -->
-      <div v-if="!processedMessages.length" class="h-full flex flex-col items-center justify-center px-6 py-4 text-center min-h-0">
-        <div class="empty-icon flex items-center justify-center w-12 h-12 rounded-2xl mb-4">
-          <i class="fas fa-wand-magic-sparkles text-base"></i>
-        </div>
-        <h3 class="text-sm font-semibold text-blue-950 dark:text-white mb-1.5">What should we build?</h3>
+      <!-- Empty state: one quiet line, nothing to dismiss or click -->
+      <div v-if="!processedMessages.length" class="h-full flex items-center justify-center px-6 py-4 text-center min-h-0">
         <p class="text-xs text-blue-950/45 dark:text-blue-100/45 max-w-[230px] leading-relaxed">
-          Describe a page, feature, or change and the agent will build it into your project.
+          Describe a change and the agent will build it into your app.
         </p>
-        <div v-if="examples?.length" class="mt-4 flex flex-col items-stretch gap-1.5 w-full max-w-[240px]">
-          <button
-            v-for="example in examples"
-            :key="example"
-            type="button"
-            class="rounded-full border border-blue-100 dark:border-white/[0.08] bg-blue-50/50 dark:bg-white/[0.04] px-3 py-1.5 text-[11px] font-medium text-blue-950/70 dark:text-white/65 hover:bg-blue-50 hover:text-blue-950 dark:hover:bg-white/[0.08] dark:hover:text-white transition-colors truncate"
-            @click="emit('use-example', example)"
-          >
-            {{ example }}
-          </button>
-        </div>
       </div>
       
       <template v-if="processedMessages.length > 0">
@@ -150,8 +135,6 @@ const props = defineProps<{
   isProcessing?: boolean
   /** What the agent is doing right now; empty while its reply is streaming. */
   statusText?: string
-  /** Starter prompts offered in the empty state; clicking one emits use-example. */
-  examples?: string[]
   /** Whether restore chips may show: false on task transcripts (their edits
    *  live in a worktree, not the canonical timeline) and while a
    *  canonical-tree run is live. Omitted = fall back to !isProcessing. */
@@ -177,7 +160,6 @@ const showActivityIndicator = computed(() => {
 
 const emit = defineEmits<{
   (e: 'apply-code', code: string): void
-  (e: 'use-example', example: string): void
   (e: 'restore-checkpoint', message: AIMessage): void
 }>()
 
@@ -673,24 +655,6 @@ const copyToClipboard = (code: string) => {
   .dark .status-shimmer {
     color: rgba(219, 234, 254, 0.65);
   }
-}
-
-/* Empty state icon: navy ink tile matching the site's primary button */
-.empty-icon {
-  color: #fdf9f2;
-  background: theme('colors.blue.950');
-  box-shadow:
-    0 1px 2px rgba(23, 37, 84, 0.2),
-    0 6px 14px -4px rgba(23, 37, 84, 0.25),
-    inset 0 1px 0 rgba(255, 255, 255, 0.12);
-}
-
-.dark .empty-icon {
-  color: theme('colors.blue.950');
-  background: #f3ede2;
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.4),
-    0 6px 14px -4px rgba(0, 0, 0, 0.45);
 }
 
 /* Prose styling for dark mode */

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
@@ -1,8 +1,8 @@
 <template>
   <div v-if="!isCollapsed" class="flex flex-col h-full bg-white dark:bg-[#0a0a0a] transition-colors duration-300">
-    <!-- Header: manager toggle + instance title. Relative so the version
-         dropdown can anchor to the full header width — the sidebar clips
-         overflow, so a narrow panel can't fit it anchored to the button. -->
+    <!-- Header: manager toggle + instance title. Version restores live
+         inline in the transcript (the per-message checkpoint chips), so the
+         header carries no history controls. -->
     <div class="shrink-0 relative flex items-center gap-2 px-3 py-2 border-b border-blue-950/[0.08] dark:border-white/[0.14]">
       <div class="relative group max-md:hidden">
         <button
@@ -20,78 +20,6 @@
       <div class="flex-1 min-w-0 text-xs font-semibold text-blue-950/80 dark:text-blue-100/85 truncate">
         {{ activeInstance?.title || 'New instance' }}
       </div>
-
-      <!-- Version history toggle -->
-      <div ref="historyRoot" class="relative group shrink-0">
-        <button
-          :class="[
-            'flex items-center justify-center w-8 h-8 rounded-md transition-colors duration-200',
-            historyOpen
-              ? 'bg-blue-50 dark:bg-white/[0.08] text-blue-950 dark:text-white'
-              : 'text-blue-950/60 dark:text-white/60 hover:bg-blue-50 dark:hover:bg-white/[0.08] hover:text-blue-950 dark:hover:text-white'
-          ]"
-          @click="toggleHistory"
-        >
-          <i class="fas fa-clock-rotate-left text-sm"></i>
-        </button>
-        <div
-          v-if="!historyOpen"
-          class="pointer-events-none absolute right-0 top-full mt-1.5 z-50 whitespace-nowrap rounded-md bg-blue-950 dark:bg-white/95 px-2 py-1 text-[11px] font-medium text-white dark:text-blue-950 shadow-lg opacity-0 group-hover:opacity-100 transition-opacity duration-150"
-        >
-          Version history
-        </div>
-      </div>
-
-      <!-- Version history dropdown (anchored to the header, not the button:
-           the sidebar clips overflow, so it must fit the panel's width) -->
-      <div
-        v-if="historyOpen"
-        ref="historyDropdown"
-        class="absolute right-2 top-full mt-1 z-50 w-72 max-w-[calc(100%-1rem)] rounded-xl border border-blue-100 dark:border-white/[0.08] bg-white dark:bg-[#0f0f0f] shadow-xl overflow-hidden"
-      >
-        <div class="px-3 py-2 border-b border-blue-100 dark:border-white/[0.08] text-[11px] font-semibold uppercase tracking-wider text-blue-950/50 dark:text-white/50">
-          Version history
-        </div>
-        <div class="max-h-72 overflow-y-auto py-1">
-          <div
-            v-if="versionsLoading && !(versionHistory && versionHistory.length)"
-            class="flex items-center gap-2 px-3 py-4 text-xs text-blue-950/40 dark:text-white/40"
-          >
-            <i class="fas fa-circle-notch fa-spin text-[11px]"></i>
-            <span>Loading versions…</span>
-          </div>
-          <div
-            v-else-if="!(versionHistory && versionHistory.length)"
-            class="px-3 py-4 text-xs text-blue-950/40 dark:text-white/40"
-          >
-            No versions yet — they appear as your app changes.
-          </div>
-          <div
-            v-for="version in versionHistory"
-            :key="version.hash"
-            class="flex items-center gap-2 px-3 py-2 hover:bg-blue-50/60 dark:hover:bg-white/[0.04] transition-colors"
-          >
-            <div class="flex-1 min-w-0">
-              <p class="text-xs font-medium text-blue-950/85 dark:text-white/85 truncate" :title="version.message">
-                {{ version.message || 'Project update' }}
-              </p>
-              <p class="text-[10px] text-blue-950/40 dark:text-white/35 truncate">
-                {{ version.relative_date || version.date || '' }}
-              </p>
-            </div>
-            <button
-              type="button"
-              :disabled="anyRunActive"
-              :title="anyRunActive ? 'Wait for the agent to finish (or stop it) before restoring' : undefined"
-              class="shrink-0 rounded-full border border-blue-200/70 dark:border-white/[0.12] px-2.5 py-1 text-[11px] font-medium text-blue-950/70 dark:text-white/70 hover:bg-blue-950 hover:border-blue-950 hover:text-[#fdf9f2] dark:hover:bg-[#f3ede2] dark:hover:border-[#f3ede2] dark:hover:text-blue-950 transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:border-blue-200/70 dark:disabled:hover:border-white/[0.12] disabled:hover:text-blue-950/70 dark:disabled:hover:text-white/70"
-              @click="onRestoreVersion(version)"
-            >
-              Restore
-            </button>
-          </div>
-        </div>
-      </div>
-
     </div>
 
     <!-- Conversation Area (scrollable) -->
@@ -105,9 +33,7 @@
         :messages="ensureValidMessages(activeInstance?.conversation || [])"
         :is-processing="!!activeInstance?.isProcessing"
         :status-text="activeInstance?.statusText || ''"
-        :examples="promptExamples"
         :can-restore="canRestoreCheckpoints"
-        @use-example="handleExamplePrompt"
         @restore-checkpoint="emit('restore-checkpoint', $event)"
         class="flex-1"
       />
@@ -375,20 +301,10 @@
 import { ref, computed, nextTick, onMounted, onBeforeUnmount } from 'vue'
 import { useAgentStore } from '../../../stores/agentStore'
 import { useUsageStore, formatCompactTokens, formatResetTime } from '@/shared/stores/usage'
-import { useConfirm } from '../../../composables/useConfirm'
 import { ChatConversation } from '../../organisms/chat'
 import type { AIMessage, AIModel } from '../../../types/index'
 import type { ReasoningEffort, ReasoningEffortOption } from '../../../types/services'
 import { REASONING_EFFORTS } from '../../../types/services'
-
-/** One commit from the project's version history (backend versions shape). */
-interface VersionEntry {
-  hash: string
-  message?: string
-  author?: string
-  date?: string
-  relative_date?: string
-}
 
 // Props
 const props = defineProps<{
@@ -396,18 +312,12 @@ const props = defineProps<{
   onPromptSubmit: (prompt: string) => Promise<void>
   onModelSelect: (modelId: string) => Promise<void>
   onEffortSelect: (effort: ReasoningEffort) => Promise<void>
-  onExamplePrompt: (example: string) => void
   isCollapsed?: boolean
-  versionHistory?: VersionEntry[]
-  versionsLoading?: boolean
-  promptExamples?: string[]
 }>()
 
 const emit = defineEmits<{
   (e: 'toggleManager'): void
   (e: 'stop'): void
-  (e: 'load-versions'): void
-  (e: 'restore-version', hash: string): void
   (e: 'restore-checkpoint', message: AIMessage): void
 }>()
 
@@ -415,13 +325,6 @@ const store = useAgentStore()
 const activeInstance = computed(() => store.activeInstance)
 const prompt = ref('')
 const promptTextarea = ref<HTMLTextAreaElement | null>(null)
-
-// --- Version history dropdown ---
-
-const { confirm } = useConfirm()
-const historyOpen = ref(false)
-const historyRoot = ref<HTMLElement | null>(null)
-const historyDropdown = ref<HTMLElement | null>(null)
 
 // Restores git-reset the canonical working tree. Only canonical-tree
 // (chat/lead) runs write to it — kind='task' runs edit their own git
@@ -439,36 +342,10 @@ const canRestoreCheckpoints = computed(() =>
   activeInstance.value?.kind !== 'task' && !anyRunActive.value
 )
 
-function toggleHistory() {
-  historyOpen.value = !historyOpen.value
-  // The list may be stale (the agent commits as it works); refresh on open.
-  if (historyOpen.value) emit('load-versions')
-}
-
-async function onRestoreVersion(version: VersionEntry) {
-  const confirmed = await confirm({
-    title: 'Restore This Version',
-    message: 'Restore your app to this version? Current work stays in history.',
-    confirmText: 'Restore',
-    cancelText: 'Cancel',
-    type: 'warning'
-  })
-  if (!confirmed) return
-  historyOpen.value = false
-  emit('restore-version', version.hash)
-}
-
 function onDocMousedown(e: MouseEvent) {
   const target = e.target as Node
   // The toggle buttons count as "inside": closing on their mousedown would
   // make the follow-up click toggle the menu straight back open.
-  if (
-    historyOpen.value &&
-    !historyRoot.value?.contains(target) &&
-    !historyDropdown.value?.contains(target)
-  ) {
-    historyOpen.value = false
-  }
   if (
     usageOpen.value &&
     !usageRoot.value?.contains(target) &&
@@ -760,11 +637,6 @@ function handleStopClick() {
     store.clearQueuedPrompt(instance.id)
   }
   emit('stop')
-}
-
-function handleExamplePrompt(exampleText: string) {
-  prompt.value = exampleText
-  handlePrompt()
 }
 
 async function handleModelSelect(modelId: string) {

--- a/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
+++ b/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
@@ -8,7 +8,7 @@
 <template>
   <div class="relative">
     <!-- Single confirm host for the whole workspace (useConfirm state is
-         global): manager deletes and version restores both open this modal. -->
+         global): manager deletes and checkpoint restores both open this modal. -->
     <ConfirmModal
       :is-open="confirmModal.isModalOpen.value"
       :options="confirmModal.modalOptions.value"
@@ -48,15 +48,9 @@
                 :on-prompt-submit="handlePrompt"
                 :on-model-select="handleModelSelect"
                 :on-effort-select="handleEffortSelect"
-                :on-example-prompt="handleExamplePrompt"
                 :is-collapsed="false"
-                :version-history="versionHistory"
-                :versions-loading="isLoadingVersions"
-                :prompt-examples="promptExamplesComputed"
                 @toggle-manager="setSidebarView('manager')"
                 @stop="handleStop"
-                @load-versions="loadVersionHistory"
-                @restore-version="onVersionSelect"
                 @restore-checkpoint="onRestoreCheckpoint"
               />
             </KeepAlive>
@@ -257,86 +251,10 @@ function handleManagerSelect() {
 }
 
 /** An accepted task's worktree just merged into the canonical tree —
- *  refresh everything that mirrors it (same pattern as version restore). */
+ *  refresh everything that mirrors it (same pattern as a checkpoint restore). */
 async function handleTaskAccepted() {
   await loadProjectFiles(true)
-  await loadVersionHistory()
   previewRef.value?.reload()
-}
-
-// Version history state and actions (surfaced in BuilderSidebarChat's
-// history dropdown; restores are confirmed there before reaching us)
-type VersionEntry = {
-  hash: string
-  message?: string
-  author?: string
-  date?: string
-  relative_date?: string
-}
-const versionHistory = ref<VersionEntry[]>([])
-const isLoadingVersions = ref<boolean>(false)
-
-async function loadVersionHistory() {
-  if (!projectId.value) return
-  try {
-    isLoadingVersions.value = true
-    const res = await AgentService.getVersionHistory(projectId.value)
-    // Support either versions or commits shapes
-    const list = (res && (res as any).versions) || (res as any).commits || []
-    versionHistory.value = Array.isArray(list)
-      ? list.filter((v: any): v is VersionEntry => !!v && typeof v.hash === 'string')
-      : []
-  } catch (e) {
-    console.error('Failed to load version history:', e)
-  } finally {
-    isLoadingVersions.value = false
-  }
-}
-
-// The auto-commit after a run is deferred (~500ms) inside
-// VersionControlService, so an immediate refetch would miss it.
-function refreshVersionHistorySoon() {
-  setTimeout(() => void loadVersionHistory(), 2000)
-}
-
-async function onVersionSelect(hash: string) {
-  if (!hash || !projectId.value) return
-  const { showNotification } = useNotification()
-  // Restoring runs `git reset --hard` on the canonical working tree, which
-  // only canonical-tree (chat/lead) runs write to — kind='task' runs edit
-  // their own git worktrees, so they neither block a restore nor are
-  // affected by one. The backend enforces the same rule with a 409 for
-  // runs started from other tabs.
-  if (store.instances.some(i => i.kind !== 'task' && i.isProcessing)) {
-    showNotification({
-      type: 'info',
-      message: 'The agent is still working — wait for it to finish (or stop it) before restoring a version.',
-      duration: 4000
-    })
-    return
-  }
-  try {
-    const res = await AgentService.resetToVersion(projectId.value, hash)
-    if ((res as any)?.success === false) {
-      throw new Error((res as any)?.error || 'Restore failed')
-    }
-    await handleVersionReset({ hash })
-    await loadVersionHistory()
-    showNotification({
-      type: 'success',
-      message: 'Your app was restored to the selected version.',
-      duration: 3000
-    })
-    // The previewed dev server now serves the restored files; reload the page.
-    previewRef.value?.reload()
-  } catch (e) {
-    console.error('Failed to reset to selected version:', e)
-    showNotification({
-      type: 'error',
-      message: `Could not restore that version: ${e instanceof Error ? e.message : 'Unknown error'}`,
-      duration: 5000
-    })
-  }
 }
 
 // Inline per-message checkpoint restore (the Cursor rewind flow): rewind the
@@ -372,7 +290,6 @@ async function onRestoreCheckpoint(message: AIMessage) {
     }
     // The working tree changed wholesale — refresh everything that mirrors it.
     await loadProjectFiles(true)
-    await loadVersionHistory()
     chatRef.value?.setPromptText(prompt)
     showNotification({
       type: 'success',
@@ -403,15 +320,6 @@ const currentProject = computed(() => {
   return projectStore.currentProject || null
 })
 
-// Starter prompts for the chat's empty state — founder language, each one a
-// change the agent can visibly finish in a single run.
-const promptExamplesComputed = computed(() => [
-  'Add a contact page with a form',
-  'Change the homepage headline and colors',
-  'Add an About page that tells my story',
-  'Make the site look great on phones',
-])
-
 // Display name for the Project Web App title
 const projectTitle = computed(() => {
   const name = currentProject.value && (currentProject.value as any).name
@@ -439,18 +347,6 @@ const navbarDescSanitized = computed(() => {
     : ''
   return raw.trim()
 })
-
-// Refresh files and clear any selection on version reset
-async function handleVersionReset(version: Record<string, any>) {
-  try {
-    console.debug('Version reset to:', version)
-    await loadProjectFiles(true)
-    const instance = store.activeInstance
-    if (instance) store.setInstanceFile(instance.id, null)
-  } catch (e) {
-    console.error('Error handling version reset:', e)
-  }
-}
 
 // Helper function to get just the filename
 function getFileName(path: string): string {
@@ -577,7 +473,6 @@ async function handlePrompt(promptText: string, targetInstanceId?: string) {
       // The commit endpoint stages `git add .` itself and no-ops when
       // nothing actually changed, so this is safe even if the edit failed.
       createCommitFromPrompt('/', `${promptText} ${suffix}`)
-      refreshVersionHistorySoon()
     }
 
     // The message appears on the first sign of life — text OR a tool call —
@@ -694,9 +589,8 @@ async function handlePrompt(promptText: string, targetInstanceId?: string) {
         } catch (refreshError) {
           console.warn('Error refreshing files after agent edit:', refreshError)
         }
+        // The commit becomes the checkpoint the next message can restore to.
         createCommitFromPrompt(response.files_changed[0] ?? '/', promptText)
-        // The commit above becomes a new restorable version.
-        refreshVersionHistorySoon()
       }
     } catch (agentError) {
       if (abortController.signal.aborted) {
@@ -783,10 +677,6 @@ async function handlePrompt(promptText: string, targetInstanceId?: string) {
 function handleStop() {
   const instance = store.activeInstance
   if (instance) store.abortInstanceRun(instance.id)
-}
-
-function handleExamplePrompt(exampleText: string) {
-  handlePrompt(exampleText)
 }
 
 /** "Fix it" pressed on the preview's console-error banner. */
@@ -974,8 +864,6 @@ async function retryProjectLoad() {
     await loadProjectFiles(true)
     // Ensure default apps exist after retry load
     await ensureDefaultApps()
-    // Refresh version history after retry
-    await loadVersionHistory()
 
     // loadInstances rebuilds instances under fresh local ids, which would
     // orphan any in-flight stream still keyed to the old ones.
@@ -1136,8 +1024,6 @@ onMounted(async () => {
         await executeOnce('loadProjectFiles', () => loadProjectFiles(true));
         // Ensure default apps are present for new/empty projects
         await ensureDefaultApps()
-        // Load version history for header dropdown
-        await loadVersionHistory()
 
         // Load agent instances for this project (creates a starter instance if none)
         await executeOnce('loadInstances', () => store.loadInstances(projectId.value))


### PR DESCRIPTION
## Summary
- Empty agent-instance chat now shows one quiet line instead of an icon, heading, and four example-prompt buttons
- Removed the header's version-history dropdown/button — restoring a version now happens entirely via the inline per-message "Restore checkpoint" chip already in the transcript
- Updated the docs page's "Never Lose Your Work" section to describe checkpoints living in the chat rather than a separate history menu

## Test plan
- [x] `npm run type-check` passes
- [x] `npx vitest run` — 94 tests pass
- [x] Manually verified in the browser preview: blank instance shows the simplified empty state, chat header has no history button, docs page renders updated copy, no console errors