### PR TITLE
Split browser/build workspace onto its own compute tier

### DIFF
--- a/backend/django/Dockerfile
+++ b/backend/django/Dockerfile
@@ -50,7 +50,11 @@ EXPOSE 8000
 # ASGI via uvicorn workers: agent runs stream over SSE for minutes, which sync
 # workers cannot hold open (one run would occupy a whole worker, and gunicorn
 # would kill it at --timeout since sync workers do not heartbeat mid-request).
-CMD python manage.py migrate --noinput && \
+#
+# The same image runs as two Railway services (see settings.IMAGI_ROLE). Only
+# the 'web' tier applies migrations on boot; the 'workspace' tier skips them so
+# the two services never race the same migration against the shared Postgres.
+CMD if [ "${IMAGI_ROLE:-web}" = "web" ]; then python manage.py migrate --noinput; fi && \
     gunicorn imagi.asgi:application \
         --worker-class uvicorn.workers.UvicornWorker \
         --bind "[::]:${PORT:-8000}" \

--- a/backend/django/imagi/settings.py
+++ b/backend/django/imagi/settings.py
@@ -31,6 +31,16 @@ load_dotenv(BASE_DIR / '.env')
 # debug pages or stack traces in production.
 DEBUG = os.environ.get('DJANGO_DEBUG', 'False').lower() in ('true', '1', 'yes')
 
+# Which tier this process serves. Both tiers run this same image against the
+# same Postgres and SECRET_KEY; only nginx routing and this flag differ.
+#  - 'web' (default): stateless API — auth, payments, project metadata. Reads
+#    the ProjectFile DB mirror; never touches a working copy on disk.
+#  - 'workspace': the stateful tier that owns the on-disk working copies under
+#    PROJECTS_ROOT (on a persistent volume) and runs the dev servers, headless
+#    browser preview, and agent runs. All disk-touching endpoints route here.
+# See the two-service split in the Dockerfile CMD and the frontend nginx.conf.
+IMAGI_ROLE = os.environ.get('IMAGI_ROLE', 'web')
+
 # SECURITY WARNING: keep the secret key used in production secret!
 # No hardcoded fallback: a publicly-known key would allow session-cookie /
 # signed-token forgery. Require it in production; allow an ephemeral

--- a/frontend/vuejs/nginx.conf
+++ b/frontend/vuejs/nginx.conf
@@ -1,3 +1,23 @@
+# Route /api traffic to the right compute tier by path. Most endpoints are
+# stateless and go to the web tier (`backend`); the handful that read or write
+# a project's live working copy on disk go to the stateful `workspace` tier
+# that owns those copies (dev servers, headless browser, agent runs). Keeping
+# every disk-touching write on the single workspace replica is what stops its
+# volume-backed source-of-truth copy from silently diverging from the web tier.
+#
+# $uri is the normalized request path (no query string). proxy_pass consumes it
+# through a variable, so nginx re-resolves the hostname per request (see
+# 00-resolver.conf) — Railway reassigns a private IP on every redeploy.
+map $uri $api_upstream {
+    default                                                  "http://backend.railway.internal:8000";
+    ~^/api/v1/builder/                                       "http://workspace.railway.internal:8000";
+    ~^/api/v1/agents/                                        "http://workspace.railway.internal:8000";
+    ~^/api/v1/project-manager/                               "http://workspace.railway.internal:8000";
+    # The one Sell endpoint that writes a page into the project on disk; the
+    # rest of Sell (Stripe, public storefront, webhooks) stays on the web tier.
+    ~^/api/v1/sell/projects/[0-9]+/templates/[^/]+/install/  "http://workspace.railway.internal:8000";
+}
+
 server {
     listen 80;
     server_name _;
@@ -5,13 +25,12 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # Proxy API requests to Django backend via Railway private network.
-    # Using a variable forces nginx to re-resolve the hostname per request
-    # (honoring the resolver's TTL) instead of caching the IP at startup —
-    # Railway assigns a new private IP on every backend redeploy.
+    # Proxy API requests to the compute tier chosen by $api_upstream (see the
+    # map above). Passing a variable to proxy_pass forces nginx to re-resolve
+    # the hostname per request (honoring the resolver's TTL) instead of caching
+    # the IP at startup — Railway assigns a new private IP on every redeploy.
     location /api/ {
-        set $backend_upstream "http://backend.railway.internal:8000";
-        proxy_pass $backend_upstream;
+        proxy_pass $api_upstream;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Moves the heavy, stateful workload — headless-browser preview, per-project dev servers, and coding-agent runs — off the stateless API tier onto its own Railway **Workspace** service that owns the on-disk working copies (persistent volume at `/data`).

## Changes
- **settings**: `IMAGI_ROLE` (`web` default | `workspace`) so one image runs as either tier against the same Postgres + `SECRET_KEY`.
- **Dockerfile**: only the `web` tier runs migrations on boot (no migration race between the two services).
- **nginx**: `map`-based fan-out sends the four disk-touching path patterns (`builder`, `agents`, `project-manager`, and the one Sell page-install endpoint) to `workspace.railway.internal`; everything else stays on the web tier.

## Rollout (already staged, zero-downtime)
The `Workspace` service is already created, deployed, and Online with the volume attached, building from this branch. Merging this flips Frontend routing to it and updates Backend's Dockerfile. Workspace being live first means no 502 window on the build-workspace routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)