### PR TITLE
Guard project working-copy writes to the workspace tier

### DIFF
--- a/backend/django/apps/Imagi/Build/services/project_files_service.py
+++ b/backend/django/apps/Imagi/Build/services/project_files_service.py
@@ -26,11 +26,43 @@ Design
 import logging
 import os
 
+from django.conf import settings
 from django.db import transaction
 
 from apps.Imagi.Build.models import ProjectFile
 
 logger = logging.getLogger(__name__)
+
+
+class WrongTierError(RuntimeError):
+    """Raised when a project working copy is mutated on the wrong compute tier.
+
+    In the split deployment only the 'workspace' tier owns the on-disk working
+    copies (its volume is the source of truth). The 'web' tier's disk is
+    ephemeral, so a write there would silently diverge from the volume — see
+    the IMAGI_ROLE notes in settings.
+    """
+
+
+def ensure_workspace_tier(operation: str = 'modify a project working copy') -> None:
+    """Guard: refuse working-copy mutations on the stateless web tier.
+
+    Fires only when this process is explicitly the web tier of a split
+    deployment (``IMAGI_ROLE == 'web'``). Single-process deployments — local
+    dev, tests, a non-split box — leave IMAGI_ROLE unset and are unaffected,
+    as is the workspace tier itself. This turns a mis-routed write (e.g. a new
+    disk-touching endpoint that the nginx ``$api_upstream`` map does not send
+    to workspace) into a loud, immediate failure instead of a silent
+    divergence between the volume and the DB mirror.
+    """
+    if settings.IMAGI_ROLE == 'web':
+        raise WrongTierError(
+            f"Refusing to {operation} on the 'web' tier: project working copies "
+            f"live on the workspace tier's volume, so a write here would land on "
+            f"ephemeral disk and silently diverge from the source of truth. This "
+            f"request was almost certainly routed to the wrong service — check the "
+            f"nginx $api_upstream map in frontend/vuejs/nginx.conf."
+        )
 
 # Only text files with these extensions are stored in the database.
 # Everything else (images, binaries, lockfiles we don't care about) lives
@@ -102,6 +134,7 @@ def record_file(project, rel_path: str, content: str = None):
     row, or None when the path is not syncable (binary/ignored/too large)
     or the mirror is suppressed for a worktree run.
     """
+    ensure_workspace_tier('write a project file')
     if mirror_suppressed(project):
         return None
     rel_path = _normalize_rel_path(rel_path)
@@ -138,6 +171,7 @@ def record_file(project, rel_path: str, content: str = None):
 
 def remove_file(project, rel_path: str) -> int:
     """Delete the database copy of a project file. Returns rows deleted."""
+    ensure_workspace_tier('delete a project file')
     if mirror_suppressed(project):
         return 0
     rel_path = _normalize_rel_path(rel_path)
@@ -147,6 +181,7 @@ def remove_file(project, rel_path: str) -> int:
 
 def remove_directory(project, rel_dir: str) -> int:
     """Delete database copies of every file under a directory prefix."""
+    ensure_workspace_tier('delete a project directory')
     if mirror_suppressed(project):
         return 0
     rel_dir = _normalize_rel_path(rel_dir).rstrip('/')

--- a/backend/django/apps/Imagi/Build/tests/test_project_files.py
+++ b/backend/django/apps/Imagi/Build/tests/test_project_files.py
@@ -15,7 +15,7 @@ import shutil
 import tempfile
 
 from django.contrib.auth.models import User
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from apps.Imagi.ProjectManager.models import Project as PMProject
 from apps.Imagi.Build.models import ProjectFile
@@ -227,3 +227,56 @@ class ReadFallbackTests(ProjectFilesTestCase):
         content = service.get_file_content('frontend/vuejs/src/App.vue')
 
         self.assertEqual(content, 'db only')
+
+
+class TierGuardTests(ProjectFilesTestCase):
+    """The workspace-role guard: working-copy mutations are refused on the
+    stateless 'web' tier, so a mis-routed disk write fails loudly instead of
+    silently diverging from the volume-backed source of truth. Every mutation
+    funnels through these write-through functions, so guarding them covers the
+    agent tools, the builder file/dir endpoints, and app/project scaffolding."""
+
+    @override_settings(IMAGI_ROLE='web')
+    def test_web_tier_blocks_record_file(self):
+        with self.assertRaises(project_files_service.WrongTierError):
+            project_files_service.record_file(
+                self.project, 'frontend/vuejs/src/App.vue', content='x'
+            )
+        self.assertIsNone(self._db_content('frontend/vuejs/src/App.vue'))
+
+    @override_settings(IMAGI_ROLE='web')
+    def test_web_tier_blocks_remove_file(self):
+        with self.assertRaises(project_files_service.WrongTierError):
+            project_files_service.remove_file(self.project, 'frontend/vuejs/src/App.vue')
+
+    @override_settings(IMAGI_ROLE='web')
+    def test_web_tier_blocks_remove_directory(self):
+        with self.assertRaises(project_files_service.WrongTierError):
+            project_files_service.remove_directory(self.project, 'frontend/vuejs/src/apps')
+
+    @override_settings(IMAGI_ROLE='web')
+    def test_guard_fires_ahead_of_mirror_suppression(self):
+        # Worktree runs suppress the mirror, but the guard sits ahead of that
+        # early return, so a suppressed write on the wrong tier still fails.
+        self.project._suppress_db_mirror = True
+        with self.assertRaises(project_files_service.WrongTierError):
+            project_files_service.record_file(
+                self.project, 'frontend/vuejs/src/App.vue', content='x'
+            )
+
+    @override_settings(IMAGI_ROLE='workspace')
+    def test_workspace_tier_allows_writes(self):
+        row = project_files_service.record_file(
+            self.project, 'frontend/vuejs/src/App.vue', content='ok'
+        )
+        self.assertIsNotNone(row)
+        self.assertEqual(self._db_content('frontend/vuejs/src/App.vue'), 'ok')
+
+    @override_settings(IMAGI_ROLE='')
+    def test_unset_role_is_inert(self):
+        # Single-process deployments (local dev, tests, a non-split box) leave
+        # IMAGI_ROLE unset — one process owns everything, so writes are allowed.
+        row = project_files_service.record_file(
+            self.project, 'frontend/vuejs/src/App.vue', content='ok'
+        )
+        self.assertIsNotNone(row)

--- a/backend/django/imagi/settings.py
+++ b/backend/django/imagi/settings.py
@@ -31,15 +31,19 @@ load_dotenv(BASE_DIR / '.env')
 # debug pages or stack traces in production.
 DEBUG = os.environ.get('DJANGO_DEBUG', 'False').lower() in ('true', '1', 'yes')
 
-# Which tier this process serves. Both tiers run this same image against the
-# same Postgres and SECRET_KEY; only nginx routing and this flag differ.
-#  - 'web' (default): stateless API — auth, payments, project metadata. Reads
-#    the ProjectFile DB mirror; never touches a working copy on disk.
+# Which tier this process serves in the split deployment. Both tiers run this
+# same image against the same Postgres and SECRET_KEY; only nginx routing and
+# this flag differ. See the Dockerfile CMD and the frontend nginx.conf.
+#  - 'web': stateless API — auth, payments, project metadata. Reads the
+#    ProjectFile DB mirror; must never write a working copy to disk (its disk
+#    is ephemeral, so a stray write silently diverges from the source of
+#    truth). project_files_service.ensure_workspace_tier() enforces this.
 #  - 'workspace': the stateful tier that owns the on-disk working copies under
 #    PROJECTS_ROOT (on a persistent volume) and runs the dev servers, headless
 #    browser preview, and agent runs. All disk-touching endpoints route here.
-# See the two-service split in the Dockerfile CMD and the frontend nginx.conf.
-IMAGI_ROLE = os.environ.get('IMAGI_ROLE', 'web')
+#  - '' (unset): single-process deployments — local dev, tests, a non-split
+#    box — where one process owns everything. The tier guard is inert here.
+IMAGI_ROLE = os.environ.get('IMAGI_ROLE', '').strip().lower()
 
 # SECURITY WARNING: keep the secret key used in production secret!
 # No hardcoded fallback: a publicly-known key would allow session-cookie /


### PR DESCRIPTION
Cheap insurance for the two-tier split (#100): make a mis-routed working-copy write **fail loudly** instead of silently diverging from the workspace volume that is the source of truth.

## The risk this closes
On the stateless `web` tier the disk is ephemeral. If a disk-touching endpoint ever reaches `web` — e.g. a new endpoint added under a prefix the nginx `$api_upstream` map doesn't send to `workspace` — the write would land on throwaway disk + the DB mirror, while the volume's canonical copy never sees it. Silent divergence.

## Change
- `ensure_workspace_tier()` in `project_files_service`, called from the three write-through functions **every** project-content mutation funnels through (`record_file` / `remove_file` / `remove_directory`) — so it covers the agent tools, builder file/dir endpoints, and app/project scaffolding in one place. Placed **ahead** of the mirror-suppression early return, so even a suppressed worktree write on the wrong tier fails.
- `IMAGI_ROLE` now normalizes and defaults to `''` (unspecified). The guard enforces **only** when a process is explicitly `web`, so local dev, tests, non-split boxes, and the workspace tier are all unaffected.
- 6 tests: web-tier blocking (record/remove/remove_directory), suppression-ordering, and workspace/unset pass-through. Full `apps.Imagi.Build` suite green except one **pre-existing, unrelated** failure (`test_rejects_run_when_over_usage_limit`, stale `PLANS['starter']` key — flagged separately).

## Activation (required)
Set `IMAGI_ROLE=web` on the **Backend** service. I've staged this via CLI with `--skip-deploys`, so it takes effect when this PR merges and Backend redeploys. Workspace already has `IMAGI_ROLE=workspace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)