### PR TITLE
Full-width top-bar frame for docs; corner-pinned nav toggle

### DIFF
--- a/frontend/vuejs/src/apps/docs/layouts/DocsLayout.vue
+++ b/frontend/vuejs/src/apps/docs/layouts/DocsLayout.vue
@@ -7,13 +7,12 @@
     content-offset-class="md:ml-64"
     nav-offset-class="md:left-64"
     mobile-default-collapsed
+    full-width-nav
   >
-    <!-- Section header: a quiet eyebrow that labels the panel -->
+    <!-- Section header: a quiet uppercase eyebrow, aligned with the nav labels
+         below it (icon dropped for a cleaner, text-forward panel). -->
     <template #sidebar-header>
-      <div class="flex items-center gap-2 pl-1">
-        <span class="inline-flex items-center justify-center w-6 h-6 rounded-lg bg-blue-950/[0.05] dark:bg-white/[0.07] text-blue-950/70 dark:text-blue-100/70">
-          <i class="fas fa-book-open text-[11px]"></i>
-        </span>
+      <div class="pl-3">
         <span class="text-[11px] font-semibold uppercase tracking-[0.16em] text-blue-950/60 dark:text-blue-100/55">
           Documentation
         </span>
@@ -27,19 +26,12 @@
           :key="item.to"
           :to="item.to"
           :class="[
-            'group flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-xl transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]',
+            'group flex items-center px-3 py-2 text-sm font-medium rounded-xl transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]',
             isActive(item.to)
               ? 'docs-nav-active text-blue-950 dark:text-white'
               : 'text-blue-950/65 dark:text-blue-100/60 hover:bg-blue-950/[0.04] dark:hover:bg-white/[0.06] hover:text-blue-950 dark:hover:text-white'
           ]"
         >
-          <i
-            :class="[
-              item.icon,
-              'text-base w-5 text-center transition-colors duration-200',
-              isActive(item.to) ? 'text-blue-700 dark:text-blue-300' : 'text-blue-950/45 dark:text-blue-100/40 group-hover:text-blue-950 dark:group-hover:text-white'
-            ]"
-          ></i>
           <span class="truncate">{{ item.name }}</span>
         </router-link>
       </nav>
@@ -67,11 +59,11 @@ import { DashboardLayout } from '@/shared/layouts'
 const route = useRoute()
 
 const navigationItems = [
-  { name: 'Welcome', to: '/docs', icon: 'fas fa-book' },
-  { name: 'Building with AI', to: '/docs/building', icon: 'fas fa-wand-magic-sparkles' },
-  { name: 'Running Your Business', to: '/docs/running-your-business', icon: 'fas fa-briefcase' },
-  { name: 'Models & Reasoning', to: '/docs/models', icon: 'fas fa-microchip' },
-  { name: 'Plans & Usage', to: '/docs/plans', icon: 'fas fa-gauge-high' }
+  { name: 'Welcome', to: '/docs' },
+  { name: 'Building with AI', to: '/docs/building' },
+  { name: 'Running Your Business', to: '/docs/running-your-business' },
+  { name: 'Models & Reasoning', to: '/docs/models' },
+  { name: 'Plans & Usage', to: '/docs/plans' }
 ]
 
 const isActive = (path) => route.path === path

--- a/frontend/vuejs/src/shared/layouts/DashboardLayout.vue
+++ b/frontend/vuejs/src/shared/layouts/DashboardLayout.vue
@@ -19,9 +19,13 @@
            page. On mobile it drops below the navbar and becomes an off-canvas
            drawer that floats over the content. -->
       <aside
-        class="sidebar-panel fixed inset-y-0 left-0 z-30 flex flex-col max-md:top-16 border-r border-blue-950/[0.08] dark:border-white/[0.08] bg-white/80 dark:bg-[#0a0a0a]/80 backdrop-blur-xl max-md:shadow-[0_24px_60px_-20px_rgba(15,23,42,0.35)] dark:max-md:shadow-[0_24px_60px_-20px_rgba(0,0,0,0.7)]"
+        class="sidebar-panel fixed bottom-0 left-0 z-30 flex flex-col max-md:top-16 border-r border-blue-950/[0.08] dark:border-white/[0.08] bg-white/80 dark:bg-[#0a0a0a]/80 backdrop-blur-xl max-md:shadow-[0_24px_60px_-20px_rgba(15,23,42,0.35)] dark:max-md:shadow-[0_24px_60px_-20px_rgba(0,0,0,0.7)]"
         :class="[
           asideWidthClass,
+          // The stacked frame drops the panel below the full-width top bar so
+          // the bar's toggle + wordmark own the true top-left corner; other
+          // sections keep the panel flush to the top on desktop.
+          stackedNav ? 'top-16' : 'md:top-0',
           isSidebarCollapsed ? '-translate-x-full pointer-events-none' : 'translate-x-0'
         ]"
         :aria-hidden="isSidebarCollapsed ? 'true' : undefined"
@@ -89,7 +93,8 @@
         <!-- Navbar -->
         <BaseNavbar
           class="navbar-shell fixed top-0 right-0 left-0 z-20 bg-white/80 dark:bg-[#0a0a0a]/80 backdrop-blur-md border-b border-blue-950/[0.08] dark:border-white/[0.08]"
-          :class="isSidebarCollapsed ? '' : navOffsetClass"
+          :class="(isSidebarCollapsed || stackedNav) ? '' : navOffsetClass"
+          :fluid="stackedNav"
         >
           <!-- The permanent show/hide control, pinned to the far left of the
                top bar (before the wordmark) so collapsing the panel never
@@ -165,7 +170,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useAuthStore } from '@/shared/stores/auth'
 import BaseLayout from './BaseLayout.vue'
@@ -186,6 +191,12 @@ const props = withDefaults(defineProps<{
   // When true, this is a full-screen app shell (e.g. the builder workspace):
   // the site footer is dropped so the content fills the viewport exactly.
   appShell?: boolean
+  // When true, the top bar spans the full viewport width with its controls
+  // (toggle + wordmark) pinned to the true top-left corner, and the sidebar
+  // sits *below* the bar rather than beside it — the builder workspace's frame.
+  // app shells always use this; other sections (docs) opt in without adopting
+  // the footer-drop / viewport-clip behaviour that `appShell` also brings.
+  fullWidthNav?: boolean
   // Per-section sizing. Passed as ready-made utility classes so the responsive
   // (md:) variants compose cleanly and there are no scoped-style specificity
   // fights. The content/nav offsets are applied only at md+ — on mobile the
@@ -211,6 +222,11 @@ const props = withDefaults(defineProps<{
 const route = useRoute()
 const router = useRouter()
 const authStore = useAuthStore()
+
+// The builder-style frame: full-width top bar with corner-pinned controls and
+// the sidebar tucked below it. App shells always get it; other sections request
+// it explicitly via fullWidthNav.
+const stackedNav = computed(() => props.appShell || props.fullWidthNav)
 
 // Sidebar state. Initialised synchronously (before first paint) so a
 // mobile-default-collapsed section never flashes its panel open then shut.


### PR DESCRIPTION
## What

Gives the **documentation** section the same top-bar frame as the **build workspace**: a top bar that spans the full width with the sidebar toggle and `Imagi.` wordmark pinned to the true top-left corner, and the sidebar tucked *below* the bar. The docs sidebar is also simplified to a clean, text-only nav.

## Why

The build workspace already reads this way, and it looks great. The ask was to bring that layout — and the corner-pinned toggle — to docs, and to declutter the docs sidebar.

The catch: in the builder those layout behaviors were gated on the `app-shell` flag, which *also* drops the site footer and clips the page to the viewport (no scroll). Docs needs to keep its footer and normal scrolling, so the visual frame had to be decoupled from app-shell.

## Changes

**`DashboardLayout.vue`** (shared)
- New `fullWidthNav` prop and a `stackedNav` computed (`appShell || fullWidthNav`).
- The three "builder frame" behaviors now key off `stackedNav` instead of `appShell` directly:
  - top bar spans full width (no sidebar offset),
  - nav is `fluid` so controls sit in the true corners,
  - sidebar drops below the bar (`top-16`).
- `appShell`'s *other* effects (footer removed, viewport-clipped/no-scroll) remain exclusive to the builder.
- The builder is unchanged — `app-shell` still implies the frame.

**`DocsLayout.vue`**
- Opts into the frame via `full-width-nav` (without `app-shell`, so it keeps footer + scroll).
- Sidebar simplified to text-only: removed the header book icon and all five per-item icons; the uppercase "DOCUMENTATION" eyebrow now aligns with the nav labels. Active item keeps its raised-card treatment.

## Verification

Checked live against the dev server at 1440px:
- **Docs** `/docs`: toggle at x=12 (top-left corner), wordmark at x=52 (right of it), sidebar at `left:0, top:64px` (below the full-width bar), toggle collapses/expands the panel, footer renders and the page scrolls. Sidebar is icon-free with eyebrow + labels aligned at x=24.
- **Builder** `/imagi/workspace/:project`: unaffected — same frame via `app-shell`.
- `vue-tsc` type-check passes.

A temporary unauthenticated harness route was used to inspect the builder layout before login; it has been fully removed (no trace in the diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)