### PR TITLE
Fix stale plan key in usage-limit rejection test

### DIFF
--- a/backend/django/apps/Imagi/Build/tests/test_agents.py
+++ b/backend/django/apps/Imagi/Build/tests/test_agents.py
@@ -618,12 +618,13 @@ class AgentStreamEndpointTests(TestCase):
         self.assertEqual(resp.json()['detail'], 'agent_busy')
 
     def test_rejects_run_when_over_usage_limit(self):
-        # Starter-plan 5-hour window exhausted -> refused before the stream
-        # opens, with the same pre-stream JSON contract as agent_busy.
+        # Free-plan 5-hour window exhausted -> refused before the stream opens,
+        # with the same pre-stream JSON contract as agent_busy. The user has no
+        # Subscription row, so their plan is the default 'free' tier.
         UsageEvent.objects.create(
             user=self.user, model_name='gpt-5.6-terra',
-            input_tokens=PLANS['starter']['five_hour_tokens'], output_tokens=0,
-            total_tokens=PLANS['starter']['five_hour_tokens'],
+            input_tokens=PLANS['free']['five_hour_tokens'], output_tokens=0,
+            total_tokens=PLANS['free']['five_hour_tokens'],
         )
         token = Token.objects.create(user=self.user)
         resp = self.client.post(


### PR DESCRIPTION
`test_rejects_run_when_over_usage_limit` referenced `PLANS['starter']` — a tier that no longer exists (the registry is `free` / `pro` / `max_5x` / `max_20x`), so it raised `KeyError: 'starter'` before asserting anything. Pre-existing failure, surfaced while running the Build suite for the tier-guard work (#101).

The test user has no `Subscription` row, so their plan is the default `free` tier. Pointed the exhausting `UsageEvent` at `PLANS['free']['five_hour_tokens']` so `used >= limit` trips and the 429 pre-stream contract is exercised again.

`apps.Imagi.Build` suite: **179/179 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)