### PR TITLE
Clear stale Chromium profile lock before preview launch

### DIFF
--- a/backend/django/apps/Imagi/Build/services/browser_preview_service.py
+++ b/backend/django/apps/Imagi/Build/services/browser_preview_service.py
@@ -480,6 +480,7 @@ class BrowserPreviewService:
         # browser that happened to use this port.
         _pool_invalidate(cdp_port)
         os.makedirs(self.profile_dir, exist_ok=True)
+        self._clear_singleton_locks()
 
         # --no-sandbox: the preview renders the user's own generated app, and
         # that same code already runs unsandboxed in this container via the
@@ -532,6 +533,26 @@ class BrowserPreviewService:
                 time.sleep(0.25)
 
         raise BrowserPreviewError('Browser did not expose its DevTools endpoint in time.')
+
+    def _clear_singleton_locks(self):
+        """Remove Chromium's profile lock files before (re)launching.
+
+        Chromium writes ``SingletonLock`` (a symlink to ``<hostname>-<pid>``)
+        into the user-data-dir to stop two instances sharing one profile. We
+        keep the profile across relaunches (``keep_profile=True``), so on a
+        Railway redeploy the new container inherits the previous container's
+        lock. Because the hostname differs, Chromium can't confirm the old pid
+        is dead and refuses to start ("in use by another Chromium process on
+        another computer"). We've already killed any browser we own by the time
+        this runs, so any lock still present is stale and safe to delete.
+        """
+        for name in ('SingletonLock', 'SingletonSocket', 'SingletonCookie'):
+            try:
+                os.unlink(os.path.join(self.profile_dir, name))
+            except OSError:
+                # Missing (the common case) or a directory we didn't create —
+                # either way there's no lock of ours to clear.
+                pass
 
     def _kill_browser(self, keep_profile=False):
         self.servers._kill_from_pid_file(self.pid_file)


### PR DESCRIPTION
## What

Clears Chromium's profile lock files (`SingletonLock`, `SingletonSocket`, `SingletonCookie`) from the preview profile directory just before launching the headless browser in `BrowserPreviewService._launch_chromium`.

## Why

The workspace preview runs a real Chromium next to the project's dev servers, launched with a **persistent** `--user-data-dir`. The profile is deliberately kept across relaunches (`_kill_browser(keep_profile=True)`) so session state survives. Chromium writes a `SingletonLock` symlink (`<hostname>-<pid>`) into that profile to prevent two instances from corrupting it.

On Railway, each container boots with a **new hostname**. After a redeploy, the fresh container inherits the previous container's profile — and its lock. Because the hostname on the lock differs from the current host, Chromium can't verify the old pid is dead and refuses to launch:

> The profile appears to be in use by another Chromium process (82) on another computer (37b00d1509ba). Chromium has locked the profile so that it doesn't get corrupted.

The preview then fails with `Browser exited on startup: ...`. Locally this never surfaces because the hostname is stable, so Chromium can tell the old pid is gone and self-heals.

## Fix

`_launch_chromium` already calls `_kill_browser(keep_profile=True)` before this point, so any browser this service owns is already dead. Any lock still present is therefore a **stale orphan** from a crashed/redeployed container and is safe to remove. The new `_clear_singleton_locks()` unlinks the three singleton files right before launch, on every launch.

## Notes for reviewers

- Only the lock files are removed — the profile itself is untouched, so history / current URL / session storage still persist across relaunches as before.
- `keep_profile` behavior is unchanged.
- Missing lock files are the common case and are ignored (caught `OSError`).
- Not reproducible in local dev by design (stable hostname); the failing path is the first preview launch after a Railway redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)