### PR TITLE
Refine project hub cards for a more professional, cohesive look

### DIFF
--- a/frontend/vuejs/src/apps/imagi/project-manager/components/organisms/hub/ToolCategoryCard.vue
+++ b/frontend/vuejs/src/apps/imagi/project-manager/components/organisms/hub/ToolCategoryCard.vue
@@ -8,22 +8,15 @@
   <component
     :is="isBuildLocked ? 'div' : 'router-link'"
     :to="isBuildLocked ? undefined : target"
-    class="crisp-card group relative flex flex-col items-center text-center h-full px-6 pt-8 pb-6 rounded-2xl border backdrop-blur-sm transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
+    class="crisp-card group relative flex flex-col h-full p-6 rounded-2xl border backdrop-blur-sm transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
     :class="[
       isBuildLocked
-        ? 'building-card cursor-progress bg-white/85 dark:bg-white/[0.045] border-blue-300/70 dark:border-blue-300/25'
-        : ['bg-white/85 dark:bg-white/[0.045] hover:-translate-y-1', accent.cardBorder],
+        ? 'building-card items-center text-center cursor-progress bg-white/85 dark:bg-white/[0.045] border-blue-300/70 dark:border-blue-300/25'
+        : ['items-start text-left bg-white/90 dark:bg-white/[0.045] border-slate-200/70 dark:border-white/[0.08] hover:-translate-y-1', accent.border],
     ]"
     :title="isBuildLocked ? 'Imagi is building your app — this card unlocks the moment the build finishes' : tool.name"
     :aria-disabled="isBuildLocked ? 'true' : undefined"
   >
-    <!-- Soft accent glow on hover -->
-    <div
-      v-if="!isBuildLocked"
-      class="pointer-events-none absolute -top-px inset-x-0 mx-auto w-40 h-40 rounded-full blur-3xl opacity-0 group-hover:opacity-100 bg-gradient-to-b to-transparent transition-opacity duration-500"
-      :class="accent.glow"
-    ></div>
-
     <!-- Moving sheen while building -->
     <div v-if="isBuildLocked" class="building-sheen pointer-events-none absolute inset-0 rounded-2xl overflow-hidden"></div>
 
@@ -60,31 +53,36 @@
 
     <!-- ==================== DEFAULT STATE ==================== -->
     <template v-else>
+      <!-- Hairline accent, revealed along the card's top edge on hover -->
+      <span
+        class="pointer-events-none absolute inset-x-6 top-0 h-px bg-gradient-to-r from-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500"
+        :class="accent.bar"
+        aria-hidden="true"
+      ></span>
+
       <!-- Icon -->
       <div
-        class="relative w-14 h-14 rounded-2xl flex items-center justify-center border mb-5 transition-transform duration-300 group-hover:scale-105"
-        :class="[accent.iconWrap]"
+        class="relative w-12 h-12 rounded-xl flex items-center justify-center border mb-6 transition-colors duration-300"
+        :class="accent.iconWrap"
       >
-        <i :class="['fas', tool.icon, accent.iconText]" class="text-xl"></i>
+        <i :class="['fas', tool.icon, accent.iconText]" class="text-lg transition-colors duration-300"></i>
       </div>
 
       <!-- Name + tagline -->
-      <div class="relative flex-1">
-        <h3 class="text-lg font-semibold text-blue-950 dark:text-white mb-1.5 tracking-tight transition-colors duration-300">
-          {{ tool.name }}
-        </h3>
-        <p class="text-sm text-blue-950/65 dark:text-blue-100/65 leading-relaxed transition-colors duration-300">
-          {{ tool.tagline }}
-        </p>
-      </div>
+      <h3 class="relative text-[17px] font-semibold text-blue-950 dark:text-white mb-1.5 tracking-[-0.01em] transition-colors duration-300">
+        {{ tool.name }}
+      </h3>
+      <p class="relative text-sm text-blue-950/60 dark:text-blue-100/60 leading-relaxed transition-colors duration-300">
+        {{ tool.tagline }}
+      </p>
 
       <!-- CTA -->
       <div
-        class="relative flex items-center justify-center gap-1.5 w-full text-sm font-medium mt-6 pt-4 border-t border-blue-200/60 dark:border-white/[0.1] transition-colors duration-300"
+        class="relative flex items-center w-full text-[13px] font-medium mt-auto pt-5 border-t border-slate-200/70 dark:border-white/[0.08] transition-colors duration-300"
         :class="accent.link"
       >
         <span>{{ tool.status === 'available' ? 'Open workspace' : 'Preview' }}</span>
-        <i class="fas fa-arrow-right text-xs group-hover:translate-x-1 transition-transform duration-200"></i>
+        <i class="fas fa-arrow-right text-[11px] ml-auto group-hover:translate-x-0.5 transition-transform duration-200"></i>
       </div>
     </template>
   </component>
@@ -93,7 +91,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { RouteLocationRaw } from 'vue-router'
-import { accentClasses, type BusinessTool } from '../../../utils/businessTools'
+import { hubCardAccents, type BusinessTool } from '../../../utils/businessTools'
 
 const props = defineProps<{
   tool: BusinessTool
@@ -102,7 +100,7 @@ const props = defineProps<{
   buildStatus?: 'pending' | 'generating' | 'completed' | 'failed' | null
 }>()
 
-const accent = computed(() => accentClasses[props.tool.accent])
+const accent = computed(() => hubCardAccents[props.tool.accent])
 
 /**
  * The initial AI build is still running. While it is, the Build card is locked:

--- a/frontend/vuejs/src/apps/imagi/project-manager/utils/businessTools.ts
+++ b/frontend/vuejs/src/apps/imagi/project-manager/utils/businessTools.ts
@@ -129,6 +129,59 @@ export const businessTools: BusinessTool[] = [
   },
 ]
 
+/**
+ * Accent classes for the project-hub cards (ToolCategoryCard).
+ *
+ * These deliberately differ from `accentClasses` below: the hub grid reads as
+ * one composed set at rest — neutral graphite icon tiles on clean cards — and
+ * reveals each module's accent only on hover. That keeps the four cards feeling
+ * professional and cohesive rather than candy-bright, while still letting each
+ * workspace keep its own color identity on interaction.
+ *
+ * Static literal strings for the Tailwind JIT (see note at the top of the file).
+ */
+export const hubCardAccents: Record<ToolAccent, {
+  /** Accent border tint applied to the whole card on hover. */
+  border: string
+  /** Icon tile: neutral graphite at rest, accent tint on hover. */
+  iconWrap: string
+  /** Icon glyph: graphite at rest, accent on hover. */
+  iconText: string
+  /** `via-*` color for the hairline accent line revealed along the card top. */
+  bar: string
+  /** CTA row: muted at rest, accent on hover. */
+  link: string
+}> = {
+  blue: {
+    border: 'group-hover:border-blue-300/70 dark:group-hover:border-blue-300/30',
+    iconWrap: 'bg-slate-100/80 border-slate-200/70 dark:bg-white/[0.05] dark:border-white/[0.08] group-hover:bg-blue-50 group-hover:border-blue-200/70 dark:group-hover:bg-blue-400/10 dark:group-hover:border-blue-400/25',
+    iconText: 'text-slate-500 dark:text-slate-300 group-hover:text-blue-600 dark:group-hover:text-blue-300',
+    bar: 'via-blue-400/70 dark:via-blue-300/50',
+    link: 'text-slate-400 dark:text-blue-100/45 group-hover:text-blue-700 dark:group-hover:text-blue-300',
+  },
+  emerald: {
+    border: 'group-hover:border-emerald-300/70 dark:group-hover:border-emerald-300/30',
+    iconWrap: 'bg-slate-100/80 border-slate-200/70 dark:bg-white/[0.05] dark:border-white/[0.08] group-hover:bg-emerald-50 group-hover:border-emerald-200/70 dark:group-hover:bg-emerald-400/10 dark:group-hover:border-emerald-400/25',
+    iconText: 'text-slate-500 dark:text-slate-300 group-hover:text-emerald-600 dark:group-hover:text-emerald-300',
+    bar: 'via-emerald-400/70 dark:via-emerald-300/50',
+    link: 'text-slate-400 dark:text-blue-100/45 group-hover:text-emerald-700 dark:group-hover:text-emerald-300',
+  },
+  violet: {
+    border: 'group-hover:border-violet-300/70 dark:group-hover:border-violet-300/30',
+    iconWrap: 'bg-slate-100/80 border-slate-200/70 dark:bg-white/[0.05] dark:border-white/[0.08] group-hover:bg-violet-50 group-hover:border-violet-200/70 dark:group-hover:bg-violet-400/10 dark:group-hover:border-violet-400/25',
+    iconText: 'text-slate-500 dark:text-slate-300 group-hover:text-violet-600 dark:group-hover:text-violet-300',
+    bar: 'via-violet-400/70 dark:via-violet-300/50',
+    link: 'text-slate-400 dark:text-blue-100/45 group-hover:text-violet-700 dark:group-hover:text-violet-300',
+  },
+  amber: {
+    border: 'group-hover:border-amber-300/70 dark:group-hover:border-amber-300/30',
+    iconWrap: 'bg-slate-100/80 border-slate-200/70 dark:bg-white/[0.05] dark:border-white/[0.08] group-hover:bg-amber-50 group-hover:border-amber-200/70 dark:group-hover:bg-amber-400/10 dark:group-hover:border-amber-400/25',
+    iconText: 'text-slate-500 dark:text-slate-300 group-hover:text-amber-600 dark:group-hover:text-amber-300',
+    bar: 'via-amber-400/70 dark:via-amber-300/50',
+    link: 'text-slate-400 dark:text-blue-100/45 group-hover:text-amber-700 dark:group-hover:text-amber-300',
+  },
+}
+
 /** Look up a tool by its URL slug (for coming-soon routes). */
 export function getToolBySlug(slug: string): BusinessTool | undefined {
   return businessTools.find(tool => tool.slug === slug)


### PR DESCRIPTION
## What & why

The Build / Sell / Market / Operate cards on the project hub (`ProjectHub.vue`) previously used four saturated pastel accents in a fully-centered layout. Together the four bright colors plus the centered "big colored icon on top" style read as playful/childish rather than professional. This reworks the cards to feel more polished, sleek, and grown-up.

## Changes

- **Cohesive at rest:** icon tiles are now neutral graphite on clean white/dark cards, so the grid reads as one composed set instead of a four-color rainbow. Each module reveals its own accent (blue / emerald / violet / amber) **only on hover** — the icon tint, card border, a thin top hairline, and the CTA color all shift to the accent.
- **Editorial, left-aligned layout** replacing the centered icon-on-top arrangement.
- **Refined details:** tighter type, a bottom CTA row with the arrow pushed to the trailing edge, and the large blurred accent glow blob removed for a cleaner surface.
- Added a dedicated `hubCardAccents` map in `businessTools.ts` for this treatment, leaving the existing `accentClasses` (still consumed by the coming-soon `ToolCategory.vue` page) untouched.

The building/AI-generation state of the Build card is unchanged.

## Files

- `frontend/vuejs/src/apps/imagi/project-manager/components/organisms/hub/ToolCategoryCard.vue`
- `frontend/vuejs/src/apps/imagi/project-manager/utils/businessTools.ts`

## Verification

- `npm run build` (includes `vue-tsc` type-check) passes.
- Confirmed the per-module `group-hover:` accent classes survive Tailwind's JIT purge in the production CSS bundle.
- Rendered the cards against the compiled CSS in light and dark mode to eyeball the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vos25TWUXD6r1QG6UAZNGj)_