### PR TITLE
Use static blue/orange brand tones on project hub cards

### DIFF
--- a/frontend/vuejs/src/apps/imagi/project-manager/components/organisms/hub/ToolCategoryCard.vue
+++ b/frontend/vuejs/src/apps/imagi/project-manager/components/organisms/hub/ToolCategoryCard.vue
@@ -12,7 +12,7 @@
     :class="[
       isBuildLocked
         ? 'building-card items-center text-center cursor-progress bg-white/85 dark:bg-white/[0.045] border-blue-300/70 dark:border-blue-300/25'
-        : ['items-start text-left bg-white/90 dark:bg-white/[0.045] border-slate-200/70 dark:border-white/[0.08] hover:-translate-y-1', accent.border],
+        : ['items-start text-left bg-white/90 dark:bg-white/[0.045] hover:-translate-y-1', tone.card],
     ]"
     :title="isBuildLocked ? 'Imagi is building your app — this card unlocks the moment the build finishes' : tool.name"
     :aria-disabled="isBuildLocked ? 'true' : undefined"
@@ -53,19 +53,12 @@
 
     <!-- ==================== DEFAULT STATE ==================== -->
     <template v-else>
-      <!-- Hairline accent, revealed along the card's top edge on hover -->
-      <span
-        class="pointer-events-none absolute inset-x-6 top-0 h-px bg-gradient-to-r from-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500"
-        :class="accent.bar"
-        aria-hidden="true"
-      ></span>
-
       <!-- Icon -->
       <div
-        class="relative w-12 h-12 rounded-xl flex items-center justify-center border mb-6 transition-colors duration-300"
-        :class="accent.iconWrap"
+        class="relative w-12 h-12 rounded-xl flex items-center justify-center mb-6"
+        :class="tone.tile"
       >
-        <i :class="['fas', tool.icon, accent.iconText]" class="text-lg transition-colors duration-300"></i>
+        <i :class="['fas', tool.icon, tone.icon]" class="text-lg"></i>
       </div>
 
       <!-- Name + tagline -->
@@ -78,8 +71,8 @@
 
       <!-- CTA -->
       <div
-        class="relative flex items-center w-full text-[13px] font-medium mt-auto pt-5 border-t border-slate-200/70 dark:border-white/[0.08] transition-colors duration-300"
-        :class="accent.link"
+        class="relative flex items-center w-full text-[13px] font-medium mt-auto pt-5 border-t border-blue-950/[0.06] dark:border-white/[0.07]"
+        :class="tone.icon"
       >
         <span>{{ tool.status === 'available' ? 'Open workspace' : 'Preview' }}</span>
         <i class="fas fa-arrow-right text-[11px] ml-auto group-hover:translate-x-0.5 transition-transform duration-200"></i>
@@ -91,16 +84,19 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { RouteLocationRaw } from 'vue-router'
-import { hubCardAccents, type BusinessTool } from '../../../utils/businessTools'
+import { hubCardTones, type BusinessTool } from '../../../utils/businessTools'
 
 const props = defineProps<{
   tool: BusinessTool
   projectSlug: string
+  /** Position in the hub grid; the cards alternate Imagi's blue/orange brand tones. */
+  index: number
   /** The project's generation_status; drives the Build card's "AI building" state. */
   buildStatus?: 'pending' | 'generating' | 'completed' | 'failed' | null
 }>()
 
-const accent = computed(() => hubCardAccents[props.tool.accent])
+// Alternate the brand's two tones down the grid, matching the home feature cards.
+const tone = computed(() => hubCardTones[props.index % 2 === 0 ? 'blue' : 'orange'])
 
 /**
  * The initial AI build is still running. While it is, the Build card is locked:

--- a/frontend/vuejs/src/apps/imagi/project-manager/utils/businessTools.ts
+++ b/frontend/vuejs/src/apps/imagi/project-manager/utils/businessTools.ts
@@ -129,56 +129,36 @@ export const businessTools: BusinessTool[] = [
   },
 ]
 
+export type HubTone = 'blue' | 'orange'
+
 /**
- * Accent classes for the project-hub cards (ToolCategoryCard).
+ * Static two-tone treatment for the project-hub cards (ToolCategoryCard).
  *
- * These deliberately differ from `accentClasses` below: the hub grid reads as
- * one composed set at rest — neutral graphite icon tiles on clean cards — and
- * reveals each module's accent only on hover. That keeps the four cards feeling
- * professional and cohesive rather than candy-bright, while still letting each
- * workspace keep its own color identity on interaction.
+ * Imagi's brand runs on blue with an orange counterpart, and the home feature
+ * cards alternate the two. The hub cards follow the same rhythm so the page
+ * feels of a piece with the rest of the site. These are fixed at rest — there
+ * is deliberately no hover/click color change — and mirror the exact tile,
+ * ring, icon, and border values used by the home KeyFeatures cards.
  *
  * Static literal strings for the Tailwind JIT (see note at the top of the file).
  */
-export const hubCardAccents: Record<ToolAccent, {
-  /** Accent border tint applied to the whole card on hover. */
-  border: string
-  /** Icon tile: neutral graphite at rest, accent tint on hover. */
-  iconWrap: string
-  /** Icon glyph: graphite at rest, accent on hover. */
-  iconText: string
-  /** `via-*` color for the hairline accent line revealed along the card top. */
-  bar: string
-  /** CTA row: muted at rest, accent on hover. */
-  link: string
+export const hubCardTones: Record<HubTone, {
+  /** Card border. */
+  card: string
+  /** Icon tile background + ring. */
+  tile: string
+  /** Icon glyph + CTA color. */
+  icon: string
 }> = {
   blue: {
-    border: 'group-hover:border-blue-300/70 dark:group-hover:border-blue-300/30',
-    iconWrap: 'bg-slate-100/80 border-slate-200/70 dark:bg-white/[0.05] dark:border-white/[0.08] group-hover:bg-blue-50 group-hover:border-blue-200/70 dark:group-hover:bg-blue-400/10 dark:group-hover:border-blue-400/25',
-    iconText: 'text-slate-500 dark:text-slate-300 group-hover:text-blue-600 dark:group-hover:text-blue-300',
-    bar: 'via-blue-400/70 dark:via-blue-300/50',
-    link: 'text-slate-400 dark:text-blue-100/45 group-hover:text-blue-700 dark:group-hover:text-blue-300',
+    card: 'border-blue-200/70 dark:border-blue-300/[0.14]',
+    tile: 'bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] dark:from-blue-400/[0.18] dark:to-blue-500/[0.22] ring-1 ring-blue-900/[0.08] dark:ring-blue-300/[0.18]',
+    icon: 'text-blue-600 dark:text-blue-300',
   },
-  emerald: {
-    border: 'group-hover:border-emerald-300/70 dark:group-hover:border-emerald-300/30',
-    iconWrap: 'bg-slate-100/80 border-slate-200/70 dark:bg-white/[0.05] dark:border-white/[0.08] group-hover:bg-emerald-50 group-hover:border-emerald-200/70 dark:group-hover:bg-emerald-400/10 dark:group-hover:border-emerald-400/25',
-    iconText: 'text-slate-500 dark:text-slate-300 group-hover:text-emerald-600 dark:group-hover:text-emerald-300',
-    bar: 'via-emerald-400/70 dark:via-emerald-300/50',
-    link: 'text-slate-400 dark:text-blue-100/45 group-hover:text-emerald-700 dark:group-hover:text-emerald-300',
-  },
-  violet: {
-    border: 'group-hover:border-violet-300/70 dark:group-hover:border-violet-300/30',
-    iconWrap: 'bg-slate-100/80 border-slate-200/70 dark:bg-white/[0.05] dark:border-white/[0.08] group-hover:bg-violet-50 group-hover:border-violet-200/70 dark:group-hover:bg-violet-400/10 dark:group-hover:border-violet-400/25',
-    iconText: 'text-slate-500 dark:text-slate-300 group-hover:text-violet-600 dark:group-hover:text-violet-300',
-    bar: 'via-violet-400/70 dark:via-violet-300/50',
-    link: 'text-slate-400 dark:text-blue-100/45 group-hover:text-violet-700 dark:group-hover:text-violet-300',
-  },
-  amber: {
-    border: 'group-hover:border-amber-300/70 dark:group-hover:border-amber-300/30',
-    iconWrap: 'bg-slate-100/80 border-slate-200/70 dark:bg-white/[0.05] dark:border-white/[0.08] group-hover:bg-amber-50 group-hover:border-amber-200/70 dark:group-hover:bg-amber-400/10 dark:group-hover:border-amber-400/25',
-    iconText: 'text-slate-500 dark:text-slate-300 group-hover:text-amber-600 dark:group-hover:text-amber-300',
-    bar: 'via-amber-400/70 dark:via-amber-300/50',
-    link: 'text-slate-400 dark:text-blue-100/45 group-hover:text-amber-700 dark:group-hover:text-amber-300',
+  orange: {
+    card: 'border-orange-200/70 dark:border-orange-300/[0.14]',
+    tile: 'bg-orange-100 dark:bg-orange-400/[0.14] ring-1 ring-orange-900/[0.08] dark:ring-orange-300/[0.18]',
+    icon: 'text-orange-600 dark:text-orange-300',
   },
 }
 

--- a/frontend/vuejs/src/apps/imagi/project-manager/views/ProjectHub.vue
+++ b/frontend/vuejs/src/apps/imagi/project-manager/views/ProjectHub.vue
@@ -76,9 +76,10 @@
             <section class="rise-item" style="animation-delay: 90ms">
               <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5 sm:gap-6">
                 <ToolCategoryCard
-                  v-for="tool in businessTools"
+                  v-for="(tool, index) in businessTools"
                   :key="tool.id"
                   :tool="tool"
+                  :index="index"
                   :project-slug="projectSlug"
                   :build-status="buildStatus"
                 />


### PR DESCRIPTION
## What & why

Follow-up to #107. That PR made the project-hub cards (Build / Sell / Market / Operate) neutral graphite at rest and revealed a per-module accent (blue / emerald / violet / amber) only on hover. Per feedback, this drops the gray and the hover/click color mechanics in favor of Imagi's actual brand palette, applied statically.

## Changes

- **Brand-consistent tones:** the cards now alternate Imagi's **blue and orange** down the grid (Build & Market blue, Sell & Operate orange), reusing the exact tile, ring, icon, and border values from the home page's KeyFeatures cards so the hub reads as part of the site.
- **No hover/click color change:** the tile, border, and CTA colors are fixed. The only remaining hover behavior is the site-wide card lift/shadow (shared by `ProjectCard` and the home cards) and the small arrow nudge — no color shifts.
- Replaced the four-accent hover map (`hubCardAccents`) with a static two-tone map (`hubCardTones`); the card picks its tone by grid index. `ProjectHub.vue` now passes that index.

The existing `accentClasses` map (used by the coming-soon `ToolCategory` page) and the Build card's AI-building state are unchanged.

## Files

- `frontend/vuejs/src/apps/imagi/project-manager/components/organisms/hub/ToolCategoryCard.vue`
- `frontend/vuejs/src/apps/imagi/project-manager/utils/businessTools.ts`
- `frontend/vuejs/src/apps/imagi/project-manager/views/ProjectHub.vue`

## Verification

- `npm run build` (includes `vue-tsc` type-check) passes.
- Confirmed the blue/orange brand classes survive Tailwind's JIT purge in the production CSS bundle.
- Rendered the cards against the compiled CSS in both light and dark mode to confirm the tones match the home page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vos25TWUXD6r1QG6UAZNGj)_