### PR TITLE
Refine build workspace usage dropdown and auto-name agent threads

### DIFF
--- a/backend/django/apps/Imagi/Build/services/base_agent.py
+++ b/backend/django/apps/Imagi/Build/services/base_agent.py
@@ -69,10 +69,11 @@ RUN_HEARTBEAT_INTERVAL = 60
 HISTORY_MAX_CHARS = 60_000
 COMPACTED_SNIPPET_CHARS = 120
 
-# Model used to auto-name a conversation from its opening exchange. The nano
-# tier keeps this a rounding-error cost — naming a thread should never feel
-# like it competes with the build itself.
-TITLE_MODEL = _BUILDER_SETTINGS.get('TITLE_MODEL', 'gpt-5-nano')
+# Model used to auto-name a conversation from its opening exchange. Always the
+# smallest suite tier (Luna) so naming a thread costs the least usage possible —
+# it should never feel like it competes with the build itself. Resolved through
+# the registry so it tracks Luna's real backend id if that mapping ever changes.
+TITLE_SUITE_MODEL = _BUILDER_SETTINGS.get('TITLE_MODEL', 'gpt-5.6-luna')
 
 
 def _clean_title(raw: str) -> Optional[str]:
@@ -104,6 +105,8 @@ def generate_conversation_title(user_input: str, assistant_reply: str) -> Option
     try:
         from openai import OpenAI
 
+        from .models_service import get_backend_model_id
+
         client = OpenAI(api_key=OPENAI_API_KEY)
         prompt = (
             "Write a short, specific title for this coding-assistant conversation.\n"
@@ -113,7 +116,7 @@ def generate_conversation_title(user_input: str, assistant_reply: str) -> Option
             f"Assistant reply:\n{(assistant_reply or '').strip()[:800]}"
         )
         response = client.responses.create(
-            model=TITLE_MODEL,
+            model=get_backend_model_id(TITLE_SUITE_MODEL),
             input=prompt,
             max_output_tokens=500,
             reasoning={"effort": "minimal"},

--- a/backend/django/apps/Imagi/Build/services/base_agent.py
+++ b/backend/django/apps/Imagi/Build/services/base_agent.py
@@ -9,6 +9,7 @@ compaction), the agent run loop, and extraction of structured run metadata
 
 import json
 import os
+import re
 import logging
 import time
 from typing import Optional, Dict, Any, List
@@ -67,6 +68,60 @@ RUN_HEARTBEAT_INTERVAL = 60
 # without bound.
 HISTORY_MAX_CHARS = 60_000
 COMPACTED_SNIPPET_CHARS = 120
+
+# Model used to auto-name a conversation from its opening exchange. The nano
+# tier keeps this a rounding-error cost — naming a thread should never feel
+# like it competes with the build itself.
+TITLE_MODEL = _BUILDER_SETTINGS.get('TITLE_MODEL', 'gpt-5-nano')
+
+
+def _clean_title(raw: str) -> Optional[str]:
+    """Normalize a model-produced title: take the first line, strip any
+    "Title:" label and wrapping quotes, collapse whitespace, drop trailing
+    punctuation, and cap the length. Returns None when nothing usable remains.
+    """
+    stripped = (raw or "").strip()
+    if not stripped:
+        return None
+    title = stripped.splitlines()[0]
+    # Drop a leading "Title:" / "Title -" style label and any wrapping quotes.
+    title = re.sub(r'^\s*title\s*[:\-]\s*', '', title, flags=re.IGNORECASE)
+    title = title.strip().strip('"\'“”‘’').strip()
+    title = re.sub(r'\s+', ' ', title).rstrip('.!,;:')
+    return title[:80] or None
+
+
+def generate_conversation_title(user_input: str, assistant_reply: str) -> Optional[str]:
+    """Ask a small model for a concise title describing the conversation.
+
+    Draws on the opening request and the agent's reply so the name reflects
+    what the thread is actually about. Returns a cleaned 3-6 word title, or
+    None when unavailable (no key, API error) so the caller can fall back to
+    the provisional first-line title.
+    """
+    if not OPENAI_API_KEY:
+        return None
+    try:
+        from openai import OpenAI
+
+        client = OpenAI(api_key=OPENAI_API_KEY)
+        prompt = (
+            "Write a short, specific title for this coding-assistant conversation.\n"
+            "Rules: 3-6 words, Title Case, no quotes, no ending punctuation, and "
+            "no leading label like 'Title:'. Name the concrete task.\n\n"
+            f"User request:\n{(user_input or '').strip()[:800]}\n\n"
+            f"Assistant reply:\n{(assistant_reply or '').strip()[:800]}"
+        )
+        response = client.responses.create(
+            model=TITLE_MODEL,
+            input=prompt,
+            max_output_tokens=500,
+            reasoning={"effort": "minimal"},
+        )
+        return _clean_title(getattr(response, "output_text", "") or "")
+    except Exception as e:
+        logger.warning(f"Conversation title generation failed: {e}")
+        return None
 
 
 def build_model_settings(reasoning_effort: Optional[str] = None):
@@ -411,6 +466,32 @@ class ImagiAgentService:
             content=content,
             metadata=metadata,
         )
+
+    def autoname_from_first_reply(
+        self,
+        conversation: AgentConversation,
+        user_input: str,
+        response_content: str,
+    ) -> Optional[str]:
+        """Give the thread a concise AI-generated name off its opening exchange.
+
+        Runs once — only when the just-persisted assistant message is the
+        conversation's first reply — so later turns leave the established name
+        alone. Returns the new title, or None to leave the provisional
+        first-line title (set in add_user_message) in place.
+        """
+        try:
+            if conversation.messages.filter(role="assistant").count() != 1:
+                return None
+            title = generate_conversation_title(user_input, response_content)
+            if not title:
+                return None
+            conversation.title = title
+            conversation.save(update_fields=["title", "updated_at"])
+            return title
+        except Exception as e:
+            logger.warning(f"Auto-naming conversation {conversation.id} failed: {e}")
+            return None
 
     def _record_usage_event(
         self,
@@ -811,6 +892,19 @@ class ImagiAgentService:
             await sync_to_async(self._record_usage_event)(
                 user, model, usage, conversation
             )
+
+            # Name the thread from its opening exchange (once). Emitting the
+            # title before "done" lets the sidebar swap the provisional
+            # first-line name for the AI one as the run wraps up.
+            new_title = await sync_to_async(self.autoname_from_first_reply)(
+                conversation, user_input, response_content
+            )
+            if new_title:
+                yield {
+                    "type": "title",
+                    "title": new_title,
+                    "conversation_id": conversation.id,
+                }
 
             done_event = {
                 "type": "done",

--- a/frontend/vuejs/src/apps/imagi/build/components/molecules/sidebar/AgentInstanceCard.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/molecules/sidebar/AgentInstanceCard.vue
@@ -12,19 +12,7 @@
     <!-- Title row -->
     <div class="flex items-start gap-2">
       <div class="flex-1 min-w-0">
-        <input
-          v-if="isEditing"
-          ref="titleInput"
-          v-model="draftTitle"
-          type="text"
-          class="w-full bg-transparent text-xs font-semibold text-blue-950 dark:text-white/90 border-b border-blue-400 dark:border-blue-300/60 outline-none"
-          @click.stop
-          @keydown.enter.prevent="commitRename"
-          @keydown.escape="cancelRename"
-          @blur="commitRename"
-        />
         <div
-          v-else
           :class="[
             'text-xs truncate transition-colors duration-200',
             isActive
@@ -74,18 +62,6 @@
           v-if="menuOpen"
           class="absolute right-0 top-full mt-1 z-50 min-w-[140px] rounded-lg border border-blue-950/[0.08] dark:border-white/[0.14] bg-white/95 dark:bg-[#161616]/95 backdrop-blur-sm shadow-xl shadow-blue-950/10 dark:shadow-black/40 py-1"
         >
-          <button class="menu-item" @click.stop="onRename">
-            <i class="fas fa-pen menu-item-icon"></i>
-            <span>Rename</span>
-          </button>
-          <button v-if="!isArchived" class="menu-item" @click.stop="onArchive">
-            <i class="fas fa-archive menu-item-icon"></i>
-            <span>Archive</span>
-          </button>
-          <button v-else class="menu-item" @click.stop="onUnarchive">
-            <i class="fas fa-box-open menu-item-icon"></i>
-            <span>Unarchive</span>
-          </button>
           <button class="menu-item menu-item--danger" @click.stop="onDelete">
             <i class="fas fa-trash menu-item-icon"></i>
             <span>Delete</span>
@@ -97,10 +73,10 @@
 </template>
 
 <script setup lang="ts">
-import { ref, nextTick, onMounted, onBeforeUnmount } from 'vue'
+import { ref, onMounted, onBeforeUnmount } from 'vue'
 import type { AgentInstance } from '../../../types/services'
 
-const props = defineProps<{
+defineProps<{
   instance: AgentInstance
   isActive: boolean
   isArchived?: boolean
@@ -108,15 +84,8 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: 'select'): void
-  (e: 'archive'): void
-  (e: 'unarchive'): void
   (e: 'delete'): void
-  (e: 'rename', title: string): void
 }>()
-
-const isEditing = ref(false)
-const draftTitle = ref('')
-const titleInput = ref<HTMLInputElement | null>(null)
 
 const menuOpen = ref(false)
 const menuRef = ref<HTMLElement | null>(null)
@@ -127,21 +96,6 @@ function toggleMenu() {
 
 function closeMenu() {
   menuOpen.value = false
-}
-
-function onRename() {
-  closeMenu()
-  startRename()
-}
-
-function onArchive() {
-  closeMenu()
-  emit('archive')
-}
-
-function onUnarchive() {
-  closeMenu()
-  emit('unarchive')
 }
 
 function onDelete() {
@@ -157,27 +111,6 @@ function handleDocumentClick(event: MouseEvent) {
 
 onMounted(() => document.addEventListener('mousedown', handleDocumentClick))
 onBeforeUnmount(() => document.removeEventListener('mousedown', handleDocumentClick))
-
-async function startRename() {
-  draftTitle.value = props.instance.title || ''
-  isEditing.value = true
-  await nextTick()
-  titleInput.value?.focus()
-  titleInput.value?.select()
-}
-
-function commitRename() {
-  if (!isEditing.value) return
-  const newTitle = draftTitle.value.trim()
-  isEditing.value = false
-  if (newTitle && newTitle !== props.instance.title) {
-    emit('rename', newTitle)
-  }
-}
-
-function cancelRename() {
-  isEditing.value = false
-}
 
 /** Compact token count for the meta row: 850, 12.3k, 2M. */
 function formatTokens(total: number): string {

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/AgentManagerPanel.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/AgentManagerPanel.vue
@@ -162,9 +162,7 @@
             :instance="instance"
             :is-active="instance.id === store.activeInstanceId"
             @select="handleSelect(instance.id)"
-            @archive="handleArchive(instance.id)"
             @delete="handleDelete(instance.id)"
-            @rename="handleRename(instance.id, $event)"
           />
         </template>
         <div v-else class="px-2 pb-1 text-[11px] text-blue-950/35 dark:text-white/30">
@@ -314,10 +312,7 @@
               :is-active="instance.id === store.activeInstanceId"
               :is-archived="!!instance.archivedAt"
               @select="handleSelect(instance.id)"
-              @archive="handleArchive(instance.id)"
-              @unarchive="handleUnarchive(instance.id)"
               @delete="handleDelete(instance.id)"
-              @rename="handleRename(instance.id, $event)"
             />
           </template>
         </template>
@@ -593,14 +588,6 @@ async function handleSelect(id: string) {
   await store.switchInstance(id)
 }
 
-async function handleArchive(id: string) {
-  await store.archiveInstance(id)
-}
-
-async function handleUnarchive(id: string) {
-  await store.unarchiveInstance(id)
-}
-
 async function handleDelete(id: string) {
   const instance = store.instances.find(i => i.id === id)
   const name = instance?.title || 'this agent instance'
@@ -626,9 +613,6 @@ async function handleDelete(id: string) {
   }
 }
 
-async function handleRename(id: string, title: string) {
-  await store.renameInstance(id, title)
-}
 </script>
 
 <style scoped>

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
@@ -407,8 +407,8 @@ function toggleEffort() {
  *  no bar) — never as 0%. */
 const usageMeters = computed(() => {
   const rows = [
-    { key: '5h', label: '5-hour window', win: usageStore.fiveHour, percent: usageStore.fiveHourPercent },
-    { key: 'week', label: 'Weekly window', win: usageStore.weekly, percent: usageStore.weeklyPercent },
+    { key: '5h', label: '5-hour limit', win: usageStore.fiveHour, percent: usageStore.fiveHourPercent },
+    { key: 'week', label: 'Weekly limit', win: usageStore.weekly, percent: usageStore.weeklyPercent },
   ]
   return rows.map(({ key, label, win, percent }) => ({
     key,

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
@@ -287,7 +287,7 @@
 <script setup lang="ts">
 import { ref, computed, nextTick, onMounted, onBeforeUnmount } from 'vue'
 import { useAgentStore } from '../../../stores/agentStore'
-import { useUsageStore, formatCompactTokens, formatResetTime } from '@/shared/stores/usage'
+import { useUsageStore, formatResetTime } from '@/shared/stores/usage'
 import { ChatConversation } from '../../organisms/chat'
 import type { AIMessage, AIModel } from '../../../types/index'
 import type { ReasoningEffort, ReasoningEffortOption } from '../../../types/services'
@@ -414,9 +414,9 @@ const usageMeters = computed(() => {
     key,
     label,
     percent,
-    usedText: win && win.used !== null && win.limit !== null
-      ? `${formatCompactTokens(win.used)} / ${formatCompactTokens(win.limit)}${percent !== null ? ` · ${percent}%` : ''}`
-      : '—',
+    // Just the percentage used — no raw token counts (matches Claude Code's
+    // 5-hour / weekly session limits). Unknown usage stays an em-dash.
+    usedText: percent !== null ? `${percent}% used` : '—',
     resetsAt: formatResetTime(win?.resetsAt ?? null),
   }))
 })

--- a/frontend/vuejs/src/apps/imagi/build/services/agentService.ts
+++ b/frontend/vuejs/src/apps/imagi/build/services/agentService.ts
@@ -28,6 +28,9 @@ export interface AgentStreamHandlers {
    *  pattern, query, …) — values are backend-truncated strings. */
   onToolCall?: (name: string, args?: Record<string, string>) => void
   onPlan?: (plan: AgentPlanStep[]) => void
+  /** The backend named the thread from its opening exchange. Fires once, as
+   *  the first run wraps up, so the sidebar can swap the provisional title. */
+  onTitle?: (conversationId: number, title: string) => void
 }
 
 /**
@@ -229,6 +232,9 @@ export const AgentService = {
         case 'plan':
           plan = event.plan || []
           handlers.onPlan?.(plan)
+          break
+        case 'title':
+          handlers.onTitle?.(event.conversation_id, event.title)
           break
         case 'done':
           done = {

--- a/frontend/vuejs/src/apps/imagi/build/stores/agentStore.ts
+++ b/frontend/vuejs/src/apps/imagi/build/stores/agentStore.ts
@@ -417,6 +417,17 @@ export const useAgentStore = defineStore('agent', {
       await this.ensureMessagesLoaded(instance.id)
     },
 
+    /** Apply a title the backend already persisted (e.g. the AI auto-name from
+     *  the first exchange). Local-only — no server write, since the row is
+     *  already saved. Matched by conversationId because the stream reports the
+     *  conversation, not the local instance id. */
+    applyInstanceTitle(conversationId: number, title: string) {
+      const trimmed = (title || '').trim()
+      if (!trimmed) return
+      const instance = this.instances.find(i => i.conversationId === conversationId)
+      if (instance) instance.title = trimmed.slice(0, 120)
+    },
+
     async renameInstance(instanceId: string, title: string) {
       const instance = this._findInstance(instanceId)
       if (!instance || !instance.conversationId) return

--- a/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
+++ b/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
@@ -536,6 +536,11 @@ async function handlePrompt(promptText: string, targetInstanceId?: string) {
             sawPlan = sawPlan || plan.length > 0
             store.setMessagePlan(instanceId, streamingMessageId, plan)
           },
+          onTitle: (conversationId, title) => {
+            // The backend auto-named the thread from its opening exchange;
+            // reflect it in the sidebar without a reload.
+            store.applyInstanceTitle(conversationId, title)
+          },
         },
         abortController.signal
       )


### PR DESCRIPTION
## Summary

Follow-up refinements to the build workspace agent instance, on top of the merged #106. Two areas: the usage dropdown, and how agent instances (threads) are named.

## Usage dropdown

- **Percentage only** — the 5-hour and weekly meters now show just the percentage used (e.g. `24% used`), dropping the raw `used / limit` token counts. This matches how Claude Code surfaces its session and weekly limits. Unknown usage still renders as an em-dash, never `0%`.
- **Clearer labels** — the meters are now labeled **"5-hour limit"** and **"Weekly limit"** instead of "window".

## Agent instance menu + automatic naming

- The instance options menu keeps only **Delete** — **Archive** and **Rename** are removed, along with the now-unused inline-rename editing and archive/unarchive wiring in the instance card and agent manager panel.
- Manual renaming is no longer needed because threads name themselves:
  - After the first exchange, a small model generates a concise 3–6 word title from the opening request and the agent's reply, replacing the provisional first-line title.
  - The title streams to the client as a new `title` event and updates the sidebar live — no reload.
  - Falls back to the provisional first-line title on any error or missing API key, so a thread is never left unnamed.
- Naming always uses **Luna**, the smallest suite tier (resolved through the model registry), with `minimal` reasoning — so it consumes the least usage possible.

## Testing

- `vue-tsc` type check passes with no errors.
- Backend module compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XztpWqEbsPQQcNkvcVBDMc

---
_Generated by [Claude Code](https://claude.ai/code/session_01XztpWqEbsPQQcNkvcVBDMc)_