### PR TITLE
Use the orange brand tone on all project hub cards

### DIFF
--- a/frontend/vuejs/src/apps/imagi/project-manager/components/organisms/hub/ToolCategoryCard.vue
+++ b/frontend/vuejs/src/apps/imagi/project-manager/components/organisms/hub/ToolCategoryCard.vue
@@ -89,14 +89,12 @@ import { hubCardTones, type BusinessTool } from '../../../utils/businessTools'
 const props = defineProps<{
   tool: BusinessTool
   projectSlug: string
-  /** Position in the hub grid; the cards alternate Imagi's blue/orange brand tones. */
-  index: number
   /** The project's generation_status; drives the Build card's "AI building" state. */
   buildStatus?: 'pending' | 'generating' | 'completed' | 'failed' | null
 }>()
 
-// Alternate the brand's two tones down the grid, matching the home feature cards.
-const tone = computed(() => hubCardTones[props.index % 2 === 0 ? 'blue' : 'orange'])
+// Every hub card uses Imagi's orange brand tone (icon tile, border, and CTA).
+const tone = computed(() => hubCardTones.orange)
 
 /**
  * The initial AI build is still running. While it is, the Build card is locked:

--- a/frontend/vuejs/src/apps/imagi/project-manager/utils/businessTools.ts
+++ b/frontend/vuejs/src/apps/imagi/project-manager/utils/businessTools.ts
@@ -134,11 +134,12 @@ export type HubTone = 'blue' | 'orange'
 /**
  * Static two-tone treatment for the project-hub cards (ToolCategoryCard).
  *
- * Imagi's brand runs on blue with an orange counterpart, and the home feature
- * cards alternate the two. The hub cards follow the same rhythm so the page
- * feels of a piece with the rest of the site. These are fixed at rest — there
- * is deliberately no hover/click color change — and mirror the exact tile,
- * ring, icon, and border values used by the home KeyFeatures cards.
+ * Imagi's brand runs on blue with an orange counterpart. The hub cards use the
+ * orange tone so the page feels of a piece with the rest of the site while
+ * staying visually calm. These are fixed at rest — there is deliberately no
+ * hover/click color change — and mirror the exact tile, ring, icon, and border
+ * values used by the home KeyFeatures cards. The blue tone is kept available
+ * should the hub want to alternate tones again.
  *
  * Static literal strings for the Tailwind JIT (see note at the top of the file).
  */

--- a/frontend/vuejs/src/apps/imagi/project-manager/views/ProjectHub.vue
+++ b/frontend/vuejs/src/apps/imagi/project-manager/views/ProjectHub.vue
@@ -76,10 +76,9 @@
             <section class="rise-item" style="animation-delay: 90ms">
               <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5 sm:gap-6">
                 <ToolCategoryCard
-                  v-for="(tool, index) in businessTools"
+                  v-for="tool in businessTools"
                   :key="tool.id"
                   :tool="tool"
-                  :index="index"
                   :project-slug="projectSlug"
                   :build-status="buildStatus"
                 />


### PR DESCRIPTION
## What & why

Follow-up to #108, which alternated Imagi's blue and orange tones down the project-hub cards (Build / Sell / Market / Operate). Per feedback, this makes **every** hub card use the **orange** tone for a calmer, uniform look.

## Changes

- All four hub cards now use the orange brand tone (icon tile, ring, border, and CTA), instead of alternating blue/orange by grid position.
- The blue tone stays defined in `hubCardTones` so the hub can alternate again later if wanted.
- Removed the now-unused grid `index` prop that drove the alternation (dropped from `ToolCategoryCard` and its usage in `ProjectHub.vue`).

Behavior is otherwise unchanged: the tones are static (no hover/click color change) and mirror the exact values used by the home page's KeyFeatures cards. The coming-soon `ToolCategory` page and the Build card's AI-building state are untouched.

## Files

- `frontend/vuejs/src/apps/imagi/project-manager/components/organisms/hub/ToolCategoryCard.vue`
- `frontend/vuejs/src/apps/imagi/project-manager/utils/businessTools.ts`
- `frontend/vuejs/src/apps/imagi/project-manager/views/ProjectHub.vue`

## Verification

- `npm run build` (includes `vue-tsc` type-check) passes.
- Rendered the grid against the compiled CSS to confirm all four cards read as orange in light and dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vos25TWUXD6r1QG6UAZNGj)_