### PR TITLE
Refine project-hub cards with an ink-and-porcelain treatment

### DIFF
--- a/frontend/vuejs/src/apps/imagi/project-manager/components/organisms/hub/ToolCategoryCard.vue
+++ b/frontend/vuejs/src/apps/imagi/project-manager/components/organisms/hub/ToolCategoryCard.vue
@@ -8,7 +8,7 @@
   <component
     :is="isBuildLocked ? 'div' : 'router-link'"
     :to="isBuildLocked ? undefined : target"
-    class="crisp-card group relative flex flex-col h-full p-6 rounded-2xl border backdrop-blur-sm transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
+    class="crisp-card group relative flex flex-col h-full p-7 rounded-2xl border backdrop-blur-sm transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
     :class="[
       isBuildLocked
         ? 'building-card items-center text-center cursor-progress bg-white/85 dark:bg-white/[0.045] border-blue-300/70 dark:border-blue-300/25'
@@ -53,26 +53,26 @@
 
     <!-- ==================== DEFAULT STATE ==================== -->
     <template v-else>
-      <!-- Icon -->
+      <!-- Icon chip: solid ink with a porcelain glyph and a soft top sheen -->
       <div
-        class="relative w-12 h-12 rounded-xl flex items-center justify-center mb-6"
+        class="card-tile relative w-12 h-12 rounded-xl flex items-center justify-center mb-7 transition-transform duration-300"
         :class="tone.tile"
       >
-        <i :class="['fas', tool.icon, tone.icon]" class="text-lg"></i>
+        <span class="tile-sheen pointer-events-none absolute inset-0 rounded-xl" aria-hidden="true"></span>
+        <i :class="['fas', tool.icon, tone.glyph]" class="relative text-lg"></i>
       </div>
 
       <!-- Name + tagline -->
       <h3 class="relative text-[17px] font-semibold text-blue-950 dark:text-white mb-1.5 tracking-[-0.01em] transition-colors duration-300">
         {{ tool.name }}
       </h3>
-      <p class="relative text-sm text-blue-950/60 dark:text-blue-100/60 leading-relaxed transition-colors duration-300">
+      <p class="relative text-sm text-blue-950/55 dark:text-blue-100/55 leading-relaxed transition-colors duration-300">
         {{ tool.tagline }}
       </p>
 
-      <!-- CTA -->
+      <!-- CTA: muted ink at rest, resolves to full ink on hover -->
       <div
-        class="relative flex items-center w-full text-[13px] font-medium mt-auto pt-5 border-t border-blue-950/[0.06] dark:border-white/[0.07]"
-        :class="tone.icon"
+        class="relative flex items-center w-full text-[13px] font-medium mt-auto pt-5 border-t border-blue-950/[0.06] dark:border-white/[0.07] text-blue-950/55 dark:text-blue-100/50 group-hover:text-blue-950 dark:group-hover:text-white transition-colors duration-200"
       >
         <span>{{ tool.status === 'available' ? 'Open workspace' : 'Preview' }}</span>
         <i class="fas fa-arrow-right text-[11px] ml-auto group-hover:translate-x-0.5 transition-transform duration-200"></i>
@@ -93,8 +93,9 @@ const props = defineProps<{
   buildStatus?: 'pending' | 'generating' | 'completed' | 'failed' | null
 }>()
 
-// Every hub card uses Imagi's orange brand tone (icon tile, border, and CTA).
-const tone = computed(() => hubCardTones.orange)
+// Every hub card wears the restrained ink tone (solid ink chip, neutral border,
+// muted ink CTA) so the four repeated cards stay calm and professional.
+const tone = computed(() => hubCardTones.ink)
 
 /**
  * The initial AI build is still running. While it is, the Build card is locked:
@@ -155,6 +156,21 @@ const target = computed<RouteLocationRaw>(() => {
     0 2px 4px rgba(0, 0, 0, 0.55),
     0 8px 18px -4px rgba(0, 0, 0, 0.5),
     0 20px 40px -12px rgba(0, 0, 0, 0.6);
+}
+
+/* ---- Icon chip ---- */
+/* Glossy top highlight so the solid ink chip reads as a polished object. */
+.tile-sheen {
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0) 60%);
+}
+
+:global(.dark) .tile-sheen {
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 60%);
+}
+
+/* Chip lifts subtly with the card on hover. */
+.crisp-card:hover .card-tile {
+  transform: scale(1.06);
 }
 
 /* ---- Building state ---- */
@@ -230,6 +246,10 @@ const target = computed<RouteLocationRaw>(() => {
 
   /* No hover lift for users who prefer reduced motion */
   .crisp-card:hover {
+    transform: none;
+  }
+
+  .crisp-card:hover .card-tile {
     transform: none;
   }
 }

--- a/frontend/vuejs/src/apps/imagi/project-manager/utils/businessTools.ts
+++ b/frontend/vuejs/src/apps/imagi/project-manager/utils/businessTools.ts
@@ -129,37 +129,39 @@ export const businessTools: BusinessTool[] = [
   },
 ]
 
-export type HubTone = 'blue' | 'orange'
+export type HubTone = 'ink' | 'blue'
 
 /**
- * Static two-tone treatment for the project-hub cards (ToolCategoryCard).
+ * Static treatment for the project-hub cards (ToolCategoryCard).
  *
- * Imagi's brand runs on blue with an orange counterpart. The hub cards use the
- * orange tone so the page feels of a piece with the rest of the site while
- * staying visually calm. These are fixed at rest — there is deliberately no
- * hover/click color change — and mirror the exact tile, ring, icon, and border
- * values used by the home KeyFeatures cards. The blue tone is kept available
- * should the hub want to alternate tones again.
+ * The hub is the most utilitarian surface in the product, so it wears the
+ * brand's most restrained, professional face: navy ink on porcelain — the same
+ * ink as the `Imagi.` wordmark — rather than a warm accent. Each card carries a
+ * solid ink icon chip with a porcelain glyph; the blue brand color is held back
+ * and appears only as a whisper on hover (see the card's border/CTA). This keeps
+ * four repeated cards calm and premium instead of loud. The `blue` tone is kept
+ * available should a surface want the softer cool treatment used on the home
+ * KeyFeatures cards.
  *
  * Static literal strings for the Tailwind JIT (see note at the top of the file).
  */
 export const hubCardTones: Record<HubTone, {
-  /** Card border. */
+  /** Card border (with hover accent). */
   card: string
-  /** Icon tile background + ring. */
+  /** Icon chip background + ring. */
   tile: string
-  /** Icon glyph + CTA color. */
-  icon: string
+  /** Icon glyph color (sits on the chip). */
+  glyph: string
 }> = {
+  ink: {
+    card: 'border-blue-950/[0.08] dark:border-white/[0.08] group-hover:border-blue-300/60 dark:group-hover:border-blue-300/25',
+    tile: 'bg-blue-950 dark:bg-white ring-1 ring-blue-950/10 dark:ring-white/10',
+    glyph: 'text-[#fdf9f2] dark:text-blue-950',
+  },
   blue: {
     card: 'border-blue-200/70 dark:border-blue-300/[0.14]',
     tile: 'bg-gradient-to-br from-[#dbeeff] to-[#9ecdf3] dark:from-blue-400/[0.18] dark:to-blue-500/[0.22] ring-1 ring-blue-900/[0.08] dark:ring-blue-300/[0.18]',
-    icon: 'text-blue-600 dark:text-blue-300',
-  },
-  orange: {
-    card: 'border-orange-200/70 dark:border-orange-300/[0.14]',
-    tile: 'bg-orange-100 dark:bg-orange-400/[0.14] ring-1 ring-orange-900/[0.08] dark:ring-orange-300/[0.18]',
-    icon: 'text-orange-600 dark:text-orange-300',
+    glyph: 'text-blue-600 dark:text-blue-300',
   },
 }
 


### PR DESCRIPTION
## What & why

The four cards on the project workspace hub (`/imagi/project/:name` — Build / Sell / Market / Operate) all wore an identical **peach/orange** tone. Against the warm porcelain canvas it read muddy, and four repeated orange tiles with an orange CTA looked flat and "default" rather than premium.

This swaps that tone for the brand's most professional face: **navy ink on porcelain** — the same ink as the `Imagi.` wordmark — so the hub reads sleek, clean, and minimal while staying fully consistent with the existing home/About card system.

## Changes

- **Icon chips** → solid ink with a porcelain glyph and a subtle glossy top sheen (inverts to a clean white chip in dark mode).
- **Borders** → neutral ink hairlines instead of colored ones.
- **CTA** → muted ink at rest, resolving to full ink on hover (dropped the loud orange).
- **Blue held back as an accent**: the brand blue now appears *only* on hover — the border picks up a soft blue tint and the card + chip lift together.
- Slightly more padding (`p-6` → `p-7`) for a more premium, airy feel.

Implementation: retuned `hubCardTones` (`orange` → `ink`, split glyph/CTA colors) in `businessTools.ts` and updated `ToolCategoryCard.vue`.

## Scope

Applies to **every** project's workspace hub, since it's the shared `ToolCategoryCard` component — not just the one project. Nice side effect: the "AI is building your app" card stays blue, giving the page a clear language of **ink at rest, blue when actively working**.

## Reviewer notes

- No behavior/routing changes — purely presentational.
- Kept the `crisp-card` shadow recipe, radii, serif header, grain/wash, and reveal animations unchanged for consistency.
- `hubCardTones` is consumed only by `ToolCategoryCard.vue`; the softer `blue` tone remains exported for reuse.

## Verification

- Rendered on `/imagi/project/saturn`; hover lift + blue border accent confirmed.
- `npm run type-check` (vue-tsc) passes clean.
- No new console errors (pre-existing backend health-check 500s are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)