### PR TITLE
Make the main agent a coordinator that delegates all work to subagents

### DIFF
--- a/backend/django/apps/Imagi/Build/services/base_agent.py
+++ b/backend/django/apps/Imagi/Build/services/base_agent.py
@@ -324,11 +324,29 @@ def extract_usage(result, model_id: str) -> Optional[Dict[str, Any]]:
     return payload
 
 
+def dispatch_task_refs(dispatched: Optional[List[Dict[str, Any]]]) -> Optional[List[Dict[str, Any]]]:
+    """Display-safe refs to a run's dispatched tasks, for persisted metadata.
+
+    Keeps just enough to render the transcript's subagent link after a reload
+    (the conversation id and title) — the brief already lives on the task
+    conversation itself.
+    """
+    if not dispatched:
+        return None
+    refs = [
+        {"conversation_id": t.get("conversation_id"), "title": t.get("title") or ""}
+        for t in dispatched
+        if t.get("conversation_id")
+    ]
+    return refs or None
+
+
 def build_message_metadata(
     tool_calls: Optional[List[Dict[str, Any]]] = None,
     files_changed: Optional[List[str]] = None,
     plan: Optional[List[Dict[str, str]]] = None,
     usage: Optional[Dict[str, Any]] = None,
+    dispatched_tasks: Optional[List[Dict[str, Any]]] = None,
 ) -> Optional[Dict[str, Any]]:
     """Assemble AgentMessage.metadata from a run's artifacts.
 
@@ -345,6 +363,8 @@ def build_message_metadata(
         metadata["plan"] = plan
     if usage:
         metadata["usage"] = usage
+    if dispatched_tasks:
+        metadata["dispatched_tasks"] = dispatched_tasks
     return metadata or None
 
 
@@ -1000,6 +1020,7 @@ class ImagiAgentService:
                     files_changed=metadata["files_changed"],
                     plan=list(context.plan),
                     usage=usage,
+                    dispatched_tasks=dispatch_task_refs(context.dispatched_tasks),
                 ),
             )
             persisted = True
@@ -1103,6 +1124,12 @@ class ImagiAgentService:
                             tool_calls=extract_tool_call_records(result),
                             files_changed=extract_run_metadata(result)["files_changed"],
                             plan=list(context.plan) if context is not None else None,
+                            # A dispatch that happened before the interruption
+                            # is real — its subagents are running — so the
+                            # transcript keeps their links.
+                            dispatched_tasks=dispatch_task_refs(
+                                context.dispatched_tasks if context is not None else None
+                            ),
                         )
                         await sync_to_async(self.add_assistant_message)(
                             conversation, partial, partial_metadata
@@ -1184,6 +1211,7 @@ class ImagiAgentService:
                     files_changed=metadata["files_changed"],
                     plan=list(context.plan),
                     usage=usage,
+                    dispatched_tasks=dispatch_task_refs(context.dispatched_tasks),
                 ),
             )
             self._finalize_task_run(conversation, context, response_content)

--- a/backend/django/apps/Imagi/Build/services/coding_agent.py
+++ b/backend/django/apps/Imagi/Build/services/coding_agent.py
@@ -34,6 +34,7 @@ from apps.Imagi.Build.services.models_service import (
 from .base_agent import build_model_settings
 from .tools import (
     CODING_AGENT_TOOLS,
+    LEAD_AGENT_READONLY_TOOLS,
     LEAD_AGENT_EXTRA_TOOLS,
     TASK_AGENT_EXTRA_TOOLS,
 )
@@ -52,18 +53,26 @@ DEFAULT_MODEL = _BUILDER_SETTINGS.get('DEFAULT_MODEL', 'gpt-5.6-terra')
 PROJECT_MEMORY_FILES = ('AGENTS.md', 'CLAUDE.md')
 PROJECT_MEMORY_MAX_CHARS = 6000
 
-# Imagi agent system instructions
-CODING_AGENT_INSTRUCTIONS = """You are Imagi, an AI agent that builds web applications with the user. You chat naturally AND edit the project's files directly — decide for yourself when a message needs tools and when it just needs an answer.
+# --- Instruction building blocks --------------------------------------------
+# Roles share the project knowledge below but differ in how they work: the
+# chat/task roles edit files directly, while the lead thread is a coordinator
+# that only reads and delegates. Each full prompt is composed from these pieces.
 
-Working style:
+# Builder intro — used by the chat and task roles, which actually edit files.
+CODING_AGENT_INTRO = """You are Imagi, an AI agent that builds web applications with the user. You chat naturally AND edit the project's files directly — decide for yourself when a message needs tools and when it just needs an answer."""
+
+# How the builder roles work once they have decided to make a change.
+BUILDER_WORKING_STYLE = """Working style:
 - For multi-step tasks, call update_plan with your steps first and keep it updated as you work. Skip planning for trivial requests.
 - Find code before reading it (glob_files, grep_files, get_project_tree), and always read_file before editing. read_file output is line-numbered like `cat -n`; strip the prefix when copying text for edits.
 - Prefer targeted edit_file replacements over full-file rewrites (update_file); use create_file for new files. old_string must match the file exactly and be unique (or pass replace_all).
 - Make minimal edits that match the style and idiom of the surrounding code.
 - When a change spans several files (e.g. a new view plus its route), finish ALL of them before summarizing.
-- Afterward, briefly summarize what you changed and why. If a tool returned an error or "success": false, say so — never claim success when an operation failed. If edit_file fails, re-read the file and retry with the exact current text.
+- Afterward, briefly summarize what you changed and why. If a tool returned an error or "success": false, say so — never claim success when an operation failed. If edit_file fails, re-read the file and retry with the exact current text."""
 
-Project layout (every Imagi project is a dual-stack monorepo):
+# Project knowledge shared by every role. The lead uses it to answer questions
+# and to write accurate briefs; the builders use it to make correct changes.
+SHARED_PROJECT_GUIDANCE = """Project layout (every Imagi project is a dual-stack monorepo):
 - Frontend (Vue 3 + TypeScript) lives under 'frontend/vuejs/'; backend (Django) under 'backend/django/'. Every path you touch MUST include one of those prefixes — never bare paths like 'src/views/About.vue'.
 - The frontend is app-based: each app (home, auth, ...) lives at 'frontend/vuejs/src/apps/{app_name}/' with views/, router/, stores/, and components/ inside. Shared code is in 'frontend/vuejs/src/shared/'.
 - The root router auto-imports each app's 'router/index.ts', so a new page needs exactly two things: the view file in the app's views/ directory, and a route added to that app's router/index.ts (plus the views/index.ts barrel export if the app has one).
@@ -78,21 +87,33 @@ Payments (important):
 - NEVER hand-build payment, checkout, or subscription-billing flows, and never add Stripe (or any payment provider) keys, SDKs, or card forms to the project. Payments come from Imagi's prebuilt pages: the user installs them from their project's Sell workspace (Sell -> Payments tab), which adds secure pages like 'apps/store' (one-time checkout) and 'apps/pricing' (subscription plans) backed by Stripe-hosted checkout.
 - If the user asks for payments, a store, or subscriptions, point them to the Sell workspace instead of writing payment code. If those prebuilt apps are already installed, you may restyle their pages (layout, copy, colors) but keep the checkout logic in 'services/storefront.ts' intact.
 
-Technology stack: Django + REST framework, Vue 3 (Composition API + TypeScript), TailwindCSS, Pinia, Vite, Axios.
-"""
+Technology stack: Django + REST framework, Vue 3 (Composition API + TypeScript), TailwindCSS, Pinia, Vite, Axios."""
+
+# Full prompt for the file-editing roles (chat and task).
+CODING_AGENT_INSTRUCTIONS = "\n\n".join(
+    (CODING_AGENT_INTRO, BUILDER_WORKING_STYLE, SHARED_PROJECT_GUIDANCE)
+)
 
 # Appended to the instructions only when the hosted web-search tool is attached.
 WEB_SEARCH_INSTRUCTIONS = """
 Web search: you can search the web. Use it when a task needs current outside information — real-world facts about the user's business or industry, up-to-date library or API usage — not for things you already know or that live in the project itself."""
 
-# Appended for lead-thread runs: the lead is the user's single main thread and
-# can delegate self-contained work to parallel background subagents.
-LEAD_AGENT_INSTRUCTIONS = """
-Delegating work (you are the user's main thread):
-- You are the one thread the user drives everything from. For a well-scoped, self-contained feature or fix — or when the user asks for several independent things at once, or for alternative takes on one thing — call dispatch_task to hand the work to a background subagent. Each subagent builds in its own isolated copy of the project, in parallel with you.
-- Do the work yourself when it is quick, depends on this conversation's context, or the user is iterating on something you just changed. Dispatch when the work is chunky and independent. Never dispatch a task just to answer a question.
-- Write each brief like a ticket for an engineer who has not read this conversation: the goal, relevant files or pages if known, and what "done" looks like. Use drafts=2 or 3 only when the user wants variants to compare.
-- After dispatching, keep going: tell the user what you kicked off and finish your reply. Subagent results and questions come back into this thread as check-ins for the user — never wait or poll for them, and never pretend to know their outcome."""
+# Lead intro — the main thread is a coordinator that never edits files itself.
+LEAD_AGENT_INTRO = """You are Imagi, the user's main thread for building their web application — a coordinator, not a builder. You talk with the user and hand every piece of real building work to background subagents. You have no file-editing tools and never change the project yourself; you can read the project to answer questions and to scope the work you delegate."""
+
+# How the lead works: triage every message, then either answer or delegate.
+LEAD_WORKING_STYLE = """Working style (triage every message first):
+- Decide what kind of message this is: a reply or a job.
+- A REPLY is anything you can answer yourself — a question about the app or how something works, a clarification, a decision, or ordinary conversation. Answer it directly and stop. Use your read tools (get_project_tree, glob_files, grep_files, read_file) to look at the project whenever that helps you answer accurately.
+- A JOB is any request to build, change, fix, style, restructure, or add something to the app — "improve the home page", "add a contact form", "fix the nav on mobile". You do NOT do this work yourself and you have no tools to. Call dispatch_task to hand it to a background subagent, which builds it in an isolated copy of the project, in parallel, while this thread stays free for the user.
+- Write each brief like a ticket for an engineer who has not read this conversation: the goal, the relevant files or pages (read the project first if you need to find them), and what "done" looks like. When the user asks for several independent things, dispatch one task for each; use drafts=2 or 3 only when they want variants of one thing to compare.
+- Keep this thread clean: after dispatching, reply with ONE short sentence confirming what you kicked off (e.g. "On it — kicking off a subagent to redesign your home page.") and end your turn. Do not restate the brief, list steps, or describe what the subagent will do — the workspace shows a link to the subagent's thread where the user can watch the work happen.
+- Subagent results and questions come back here as check-ins for the user to review and merge — never wait or poll for them, and never claim work is finished or describe changes you have not seen."""
+
+# Full prompt for the lead thread.
+LEAD_AGENT_INSTRUCTIONS = "\n\n".join(
+    (LEAD_AGENT_INTRO, LEAD_WORKING_STYLE, SHARED_PROJECT_GUIDANCE)
+)
 
 # Appended for task runs: the subagent works one dispatched brief in isolation
 # and reports back through the review flow.
@@ -129,10 +150,19 @@ def load_project_memory(project_path: Optional[str]) -> Optional[str]:
     return None
 
 
-def get_dynamic_coding_instructions(context: RunContextWrapper, agent: Agent) -> str:
-    """Generate dynamic instructions for the coding agent based on context."""
+def get_dynamic_coding_instructions(
+    context: RunContextWrapper,
+    agent: Agent,
+    base_instructions: str = CODING_AGENT_INSTRUCTIONS,
+) -> str:
+    """Generate dynamic instructions for the agent based on context.
+
+    base_instructions is the role's static prompt (the builder prompt by
+    default, or the lead's coordinator prompt); the per-run project context
+    and memory are appended to it.
+    """
     ctx = context.context
-    instructions = CODING_AGENT_INSTRUCTIONS
+    instructions = base_instructions
 
     if ctx:
         project_name = getattr(ctx, 'project_name', None)
@@ -169,28 +199,34 @@ def create_coding_agent(
     kind: str = 'chat',
 ) -> Agent:
     """
-    Create the Imagi agent: a single agent that chats and edits project files.
+    Create the Imagi agent for a given conversation role.
 
     Args:
         model: The public suite model id (mapped to the real OpenAI model)
         reasoning_effort: How much reasoning to use ('low', 'medium', 'high')
-        kind: The conversation role this agent runs as. 'lead' adds the
-            dispatch_task delegation tool; 'task' adds ask_user (and stops the
-            run when it is called, handing the question back to the user).
+        kind: The conversation role this agent runs as. 'chat' and 'task' get
+            the full file-editing toolset; 'task' also gets ask_user (and stops
+            the run when it is called, handing the question back to the user).
+            'lead' is a coordinator: read-only project tools plus dispatch_task,
+            with no file-editing tools — it delegates all building to subagents.
 
     Returns:
-        Agent: The configured agent with file tools
+        Agent: The configured agent for that role
     """
     backend_model = get_backend_model_id(model)
     effort = resolve_reasoning_effort(model, reasoning_effort)
     identity = get_model_identity_instructions(model)
 
     tools = list(CODING_AGENT_TOOLS)
+    base_instructions = CODING_AGENT_INSTRUCTIONS
     role_instructions = ""
     kwargs = {}
     if kind == 'lead':
-        tools.extend(LEAD_AGENT_EXTRA_TOOLS)
-        role_instructions = LEAD_AGENT_INSTRUCTIONS
+        # The lead coordinates but never builds: read-only tools plus
+        # dispatch_task, and no file-editing tools at all. This structurally
+        # keeps every change on a background subagent and the main thread free.
+        tools = list(LEAD_AGENT_READONLY_TOOLS) + list(LEAD_AGENT_EXTRA_TOOLS)
+        base_instructions = LEAD_AGENT_INSTRUCTIONS
     elif kind == 'task':
         tools.extend(TASK_AGENT_EXTRA_TOOLS)
         role_instructions = TASK_AGENT_INSTRUCTIONS
@@ -208,7 +244,7 @@ def create_coding_agent(
         tools.append(WebSearchTool())
 
     def instructions_with_identity(context: RunContextWrapper, agent: Agent) -> str:
-        instructions = get_dynamic_coding_instructions(context, agent)
+        instructions = get_dynamic_coding_instructions(context, agent, base_instructions)
         if role_instructions:
             instructions += "\n" + role_instructions
         if web_search_enabled:

--- a/backend/django/apps/Imagi/Build/services/tools.py
+++ b/backend/django/apps/Imagi/Build/services/tools.py
@@ -829,8 +829,20 @@ CODING_AGENT_TOOLS = [
     delete_directory,
 ]
 
-# Role-specific extras layered on top of CODING_AGENT_TOOLS by
-# coding_agent.create_coding_agent: the lead thread can delegate, a task
-# subagent can hand a question back to the user.
+# Read-only surface for the lead thread. The lead coordinates but never edits:
+# it can discover and read the project (to answer questions and scope briefs)
+# but gets none of the file-writing tools, so all building happens on
+# background subagents and the main thread stays free.
+LEAD_AGENT_READONLY_TOOLS = [
+    get_project_tree,
+    list_project_files,
+    glob_files,
+    grep_files,
+    read_file,
+]
+
+# Role-specific extras. The chat/task roles build on CODING_AGENT_TOOLS; the
+# lead builds on LEAD_AGENT_READONLY_TOOLS (above). The lead can delegate, and
+# a task subagent can hand a question back to the user.
 LEAD_AGENT_EXTRA_TOOLS = [dispatch_task]
 TASK_AGENT_EXTRA_TOOLS = [ask_user]

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/chat/ChatConversation.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/chat/ChatConversation.vue
@@ -59,6 +59,32 @@
                 v-if="message.content && message.content.trim().length > 0"
                 v-html="formatMessage(message, index)"
               />
+              <!-- Subagents this reply kicked off. The work streams in their
+                   own threads — the main thread keeps just these cards, each
+                   one click from watching the subagent build. -->
+              <div v-if="message.dispatchedTasks?.length" class="mt-2 flex flex-col gap-1.5">
+                <button
+                  v-for="task in message.dispatchedTasks"
+                  :key="task.conversationId"
+                  type="button"
+                  class="dispatch-card group flex items-center gap-2.5 w-full rounded-xl border border-blue-950/[0.08] dark:border-white/[0.12] bg-blue-50/50 dark:bg-white/[0.04] px-3 py-2 text-left transition-colors hover:bg-blue-100/60 dark:hover:bg-white/[0.07]"
+                  :title="`Open this subagent's thread`"
+                  @click="emit('open-task', task.conversationId)"
+                >
+                  <span class="dispatch-chip flex items-center justify-center w-6 h-6 rounded-lg shrink-0">
+                    <i class="fas fa-robot text-[10px]"></i>
+                  </span>
+                  <span class="flex-1 min-w-0">
+                    <span class="block text-[12px] font-semibold text-blue-950/85 dark:text-white/85 truncate">
+                      {{ task.title || 'Background subagent' }}
+                    </span>
+                    <span class="block text-[10px] text-blue-950/45 dark:text-white/40">
+                      {{ dispatchStatus(task.conversationId) }}
+                    </span>
+                  </span>
+                  <i class="fas fa-chevron-right text-[10px] text-blue-950/30 dark:text-white/30 group-hover:text-blue-950/60 dark:group-hover:text-white/60 transition-colors shrink-0"></i>
+                </button>
+              </div>
               <div v-if="message.filesChanged?.length" class="mt-2">
                 <span
                   class="inline-flex items-center gap-1.5 rounded-full border border-blue-100 dark:border-white/[0.08] bg-blue-50/60 dark:bg-white/[0.04] px-2.5 py-1 text-[11px] font-medium text-blue-950/70 dark:text-white/60"
@@ -118,6 +144,7 @@ import { ref, nextTick, watch, onMounted, onBeforeUnmount, computed } from 'vue'
 import type { AIMessage } from '@/apps/imagi/build/types/services'
 import AgentActivityFeed from '@/apps/imagi/build/components/molecules/chat/AgentActivityFeed.vue'
 import AgentPlanChecklist from '@/apps/imagi/build/components/molecules/chat/AgentPlanChecklist.vue'
+import { useAgentStore } from '@/apps/imagi/build/stores/agentStore'
 
 marked.setOptions({
   gfm: true,
@@ -161,7 +188,28 @@ const showActivityIndicator = computed(() => {
 const emit = defineEmits<{
   (e: 'apply-code', code: string): void
   (e: 'restore-checkpoint', message: AIMessage): void
+  /** A dispatch card was clicked — open that subagent's thread */
+  (e: 'open-task', conversationId: number): void
 }>()
+
+// Dispatch cards show the subagent's live state, so the store is read
+// directly — the card in an old reply keeps telling the truth as the task
+// progresses (working → finished → added), without threading props through.
+const agentStore = useAgentStore()
+
+/** Status line for a dispatch card. Mirrors the manager's card wording. */
+function dispatchStatus(conversationId: number): string {
+  const instance = agentStore.instances.find(i => i.conversationId === conversationId)
+  if (!instance) return 'Subagent'
+  if (instance.isProcessing) return 'Working in the background…'
+  switch (instance.reviewStatus) {
+    case 'input': return 'Asked you a question'
+    case 'ready': return 'Finished — waiting on you'
+    case 'accepted': return 'Added to your app'
+    case 'dismissed': return 'Discarded'
+    default: return 'Starting…'
+  }
+}
 
 // Refs and reactive state
 const messagesContainer = ref<HTMLElement | null>(null)
@@ -352,6 +400,19 @@ const copyToClipboard = (code: string) => {
    user bubble opens a turn with extra breathing room above it. */
 .msg-row + .msg-row {
   margin-top: 1rem;
+}
+
+/* Dispatch-card chip: same navy-ink / cream pairing as the check-in queue. */
+.dispatch-chip {
+  background: rgba(23, 37, 84, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(23, 37, 84, 0.06);
+  color: rgba(23, 37, 84, 0.8);
+}
+
+.dark .dispatch-chip {
+  background: rgba(243, 237, 226, 0.12);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  color: rgba(243, 237, 226, 0.9);
 }
 
 .msg-row + .user-row {

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
@@ -33,6 +33,7 @@
         :status-text="activeInstance?.statusText || ''"
         :can-restore="canRestoreCheckpoints"
         @restore-checkpoint="emit('restore-checkpoint', $event)"
+        @open-task="onOpenTask"
         class="flex-1"
       />
     </div>
@@ -405,6 +406,13 @@ function onSkipCheckIn(checkIn: CheckInDto) {
 /** Open the task's read-only thread to see what it actually did. */
 async function onViewCheckIn(checkIn: CheckInDto) {
   const instance = store.instances.find(i => i.conversationId === checkIn.task.id)
+  if (instance) await store.switchInstance(instance.id)
+}
+
+/** A dispatch card in the transcript was clicked — open that subagent's
+ *  thread so the user can watch it work (the main thread stays clean). */
+async function onOpenTask(conversationId: number) {
+  const instance = store.instances.find(i => i.conversationId === conversationId)
   if (instance) await store.switchInstance(instance.id)
 }
 

--- a/frontend/vuejs/src/apps/imagi/build/services/agentService.ts
+++ b/frontend/vuejs/src/apps/imagi/build/services/agentService.ts
@@ -7,6 +7,7 @@ import type {
   CheckInDto,
   ConversationKind,
   DispatchedTaskDto,
+  DispatchedTaskRef,
   VersionControlResponse,
   ConversationDto
 } from '../types/services'
@@ -90,6 +91,8 @@ export function labelForTool(name: string, args?: Record<string, string>): strin
     case 'create_app': return 'Created an app'
     case 'create_directory':
     case 'delete_directory': return 'Organized project folders'
+    case 'dispatch_task': return 'Kicked off a subagent'
+    case 'ask_user': return 'Asked you a question'
     default: return 'Worked on the project'
   }
 }
@@ -111,6 +114,8 @@ interface PersistedMessageMetadata {
   files_changed?: string[]
   plan?: AgentPlanStep[]
   usage?: { input_tokens?: number; output_tokens?: number; cost_usd?: number }
+  /** Subagents the lead dispatched during this reply (id + title refs) */
+  dispatched_tasks?: Array<{ conversation_id?: number; title?: string }>
   /** Pre-run project snapshot, stamped on user messages only */
   checkpoint?: string
 }
@@ -124,6 +129,7 @@ export interface ConversationMessageDto {
   plan?: AgentPlanStep[]
   activity?: AgentActivityStep[]
   filesChanged?: string[]
+  dispatchedTasks?: DispatchedTaskRef[]
   usage?: { costUsd?: number; inputTokens?: number; outputTokens?: number }
   checkpoint?: string
 }
@@ -545,6 +551,12 @@ export const AgentService = {
       }
       if (Array.isArray(meta.files_changed) && meta.files_changed.length > 0) {
         dto.filesChanged = meta.files_changed
+      }
+      if (Array.isArray(meta.dispatched_tasks) && meta.dispatched_tasks.length > 0) {
+        const refs = meta.dispatched_tasks
+          .filter(t => typeof t?.conversation_id === 'number')
+          .map(t => ({ conversationId: t.conversation_id!, title: t.title || '' }))
+        if (refs.length > 0) dto.dispatchedTasks = refs
       }
       // Hydrate whatever usage fields were captured — tokens can exist
       // without cost and vice versa. No fields at all means unknown, so the

--- a/frontend/vuejs/src/apps/imagi/build/stores/agentStore.ts
+++ b/frontend/vuejs/src/apps/imagi/build/stores/agentStore.ts
@@ -516,6 +516,7 @@ export const useAgentStore = defineStore('agent', {
           plan: m.plan,
           activity: m.activity,
           filesChanged: m.filesChanged,
+          dispatchedTasks: m.dispatchedTasks,
           usage: m.usage,
           dbId: m.id,
           checkpoint: m.checkpoint,

--- a/frontend/vuejs/src/apps/imagi/build/types/services.ts
+++ b/frontend/vuejs/src/apps/imagi/build/types/services.ts
@@ -223,6 +223,13 @@ export interface DispatchedTaskDto {
   model_name: string;
 }
 
+/** A transcript's link to a subagent the lead kicked off during that reply —
+ *  just enough to render the card and jump to the task's thread. */
+export interface DispatchedTaskRef {
+  conversationId: number;
+  title: string;
+}
+
 export interface ConversationDto {
   id: number;
   title: string;
@@ -303,6 +310,9 @@ export interface AIMessage {
   activity?: AgentActivityStep[];
   /** Project files the agent changed during this reply */
   filesChanged?: string[];
+  /** Subagents the lead kicked off during this reply — rendered as links
+   *  into their threads so the work is one click away from the main thread */
+  dispatchedTasks?: DispatchedTaskRef[];
   /** Run usage, when the backend reported it (absent means unknown, never free) */
   usage?: { costUsd?: number; inputTokens?: number; outputTokens?: number };
   /** Backend AgentMessage id, once known (hydration or the start event) */

--- a/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
+++ b/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
@@ -159,7 +159,7 @@ defineOptions({ name: 'Workspace' })
 // Types
 import type { ProjectFile } from '../types/components'
 import type { AIMessage } from '../types/index'
-import type { CheckInDto, ReasoningEffort } from '../types/services'
+import type { CheckInDto, DispatchedTaskRef, ReasoningEffort } from '../types/services'
 import { matchesSlug, toSlug } from '../utils/slug'
 
 // Ensure all services use the shared API client with proper timeout configurations
@@ -525,6 +525,9 @@ async function handlePrompt(promptText: string, targetInstanceId?: string) {
     let sawActivity = false
     let sawPlan = false
     let sawFileEdit = false
+    // Subagent links accumulated across this run's dispatch events, rendered
+    // as clickable cards on the reply (patchMessage replaces the field whole).
+    let dispatchedRefs: DispatchedTaskRef[] = []
 
     // A run interrupted by Stop or the turn cap has still edited files on
     // disk (and the backend persisted its files_changed metadata) — without
@@ -616,6 +619,16 @@ async function handlePrompt(promptText: string, targetInstanceId?: string) {
             // in parallel, while this run keeps streaming. They edit their own
             // worktrees, so they neither block nor are blocked by this one.
             store.startDispatchedTasks(tasks)
+            // Link the subagents into the reply itself, so the work is one
+            // click away and the main thread stays a clean summary.
+            ensureAssistantMessage()
+            dispatchedRefs = [
+              ...dispatchedRefs,
+              ...tasks.map(t => ({ conversationId: t.conversation_id, title: t.title || '' }))
+            ]
+            store.patchMessage(instanceId, streamingMessageId, {
+              dispatchedTasks: dispatchedRefs
+            })
           },
         },
         abortController.signal


### PR DESCRIPTION
## What & why

Reshapes the build workspace's **main agent** so it works the way a coordinator should: every prompt is triaged as either a **reply** (a question, clarification, chit-chat — answered inline) or a **job** (build / change / fix — handed to a background subagent). All real building work now happens on subagents, so the main thread stays clean and free the moment the lead's short dispatch turn ends.

Example flow this now supports:
- "hi" → lead replies inline.
- "improve the home page design" → lead posts one short line ("On it — kicking off a subagent…") **plus a clickable card** that opens the subagent's thread where the work streams.
- Subagent finishes → its result comes back to the main thread as a check-in ("Home page design updated" → Add to app / Discard), or a question you answer inline to send it back to work.

## Backend

- **Lead is read-only + dispatch.** Stripped every file-editing tool from the lead role; it gets read-only discovery/reading tools plus `dispatch_task` (`LEAD_AGENT_READONLY_TOOLS`). It structurally *cannot* build on the main thread — enforcement, not just prompting.
- **Instruction refactor.** Split the agent prompt into shared project guidance + role-specific working styles. The lead gets a coordinator prompt that triages every message and keeps the dispatch reply to a single short sentence (no restating the brief).
- **Dispatch persistence.** Reply metadata now carries lightweight `dispatched_tasks` refs (id + title) via `dispatch_task_refs()`, wired into the stream, sync, and interrupted-partial persist paths, so the transcript's subagent links survive a reload.

## Frontend

- **Subagent cards in the transcript.** Each dispatched subagent renders as a clickable card on the lead's reply, showing the subagent's **live status** ("Working in the background…" → "Finished — waiting on you" → "Added to your app"), read from the store so old cards stay truthful. Clicking opens that subagent's thread.
- Hydrate `dispatchedTasks` from both persisted metadata and live dispatch events; added the `DispatchedTaskRef` type and `dispatch_task` / `ask_user` tool labels.

The "main thread stays free" goal was already structurally satisfied by the backend busy-guard (it only serializes lead runs; subagent tasks never block it), so no orchestration changes were needed there.

## Verification

- Full Build test suite passes (196 tests).
- Frontend `vue-tsc` type-check passes (including the new template bindings).
- Not visually exercised end-to-end: the dispatch card needs an authenticated workspace session + a live LLM dispatch, which couldn't be driven in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)