### PR TITLE
Project-deletion in-library banner + Railway deploy consistency tooling

### DIFF
--- a/backend/django/api/urls.py
+++ b/backend/django/api/urls.py
@@ -2,6 +2,9 @@ from django.urls import include, path
 
 urlpatterns = [
     path('home/', include('apps.Home.api.urls')),
+    # Diagnostic routes; two of these are nginx-routed to different tiers so
+    # you can compare deployed commits across the split deployment.
+    path('ops/', include('apps.Home.api.ops_urls')),
     path('auth/', include('apps.Auth.api.urls')),
     path('payments/', include('apps.Payments.api.urls')),
     path('marketing/', include('apps.Imagi.Marketing.api.urls')),

--- a/backend/django/apps/Home/api/ops_urls.py
+++ b/backend/django/apps/Home/api/ops_urls.py
@@ -1,0 +1,20 @@
+"""Ops/diagnostic routes mounted at /api/v1/ops/.
+
+The web and workspace tiers run the same Django image, so the same view is
+exposed under two prefixes that the nginx $api_upstream map routes to the two
+different tiers. Hitting both and comparing the reported `commit` confirms the
+tiers deployed from the same push are on the same code. See
+apps.Home.api.views.version_info and frontend/vuejs/nginx.conf.
+"""
+from django.urls import path
+
+from . import views
+
+app_name = 'home_ops'
+
+urlpatterns = [
+    # Routed to the web (backend) tier by nginx (the map's default).
+    path('web/version/', views.version_info, name='version_web'),
+    # Routed to the workspace tier by nginx's ~^/api/v1/ops/workspace/ entry.
+    path('workspace/version/', views.version_info, name='version_workspace'),
+]

--- a/backend/django/apps/Home/api/views.py
+++ b/backend/django/apps/Home/api/views.py
@@ -1,22 +1,60 @@
+import os
+
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 
 
+def _database_status():
+    """Cheap connectivity probe shared by the health and version endpoints."""
+    try:
+        User = get_user_model()
+        User.objects.exists()
+        return 'connected'
+    except Exception as e:
+        return f'error: {str(e)}'
+
+
 @api_view(['GET'])
 @permission_classes([AllowAny])
 def health_check(request):
     """Health check endpoint for monitoring and Railway health checks."""
-    try:
-        User = get_user_model()
-        User.objects.exists()
-        db_status = 'connected'
-    except Exception as e:
-        db_status = f'error: {str(e)}'
-
     return Response({
         'status': 'healthy',
         'service': 'imagi-backend',
-        'database': db_status,
+        'database': _database_status(),
+    })
+
+
+@api_view(['GET'])
+@permission_classes([AllowAny])
+def version_info(request):
+    """Report which build THIS process is running, for the split deployment.
+
+    The web and workspace tiers are the same Django image deployed as two
+    Railway services (see settings.IMAGI_ROLE), so they can drift onto
+    different commits when one redeploys and the other does not — the usual
+    cause of "my change isn't live in prod". This view reports the running
+    tier's role and deployed commit; it is mounted at a web-routed path AND a
+    workspace-routed path (see api/ops_urls.py + the nginx $api_upstream map),
+    so you can hit both and compare `commit`:
+
+        curl https://<app>/api/v1/ops/web/version/
+        curl https://<app>/api/v1/ops/workspace/version/
+
+    Matching commits => the tiers are in sync. Different => the stale tier
+    needs a redeploy. Values come from Railway's injected build vars.
+    """
+    commit = os.environ.get('RAILWAY_GIT_COMMIT_SHA', '') or ''
+    return Response({
+        'status': 'healthy',
+        'service': 'imagi-backend',
+        'role': settings.IMAGI_ROLE or 'unset',
+        'commit': commit or 'unknown',
+        'commit_short': commit[:7] if commit else 'unknown',
+        'branch': os.environ.get('RAILWAY_GIT_BRANCH') or 'unknown',
+        'deployment_id': os.environ.get('RAILWAY_DEPLOYMENT_ID') or 'unknown',
+        'database': _database_status(),
     })

--- a/frontend/vuejs/nginx.conf
+++ b/frontend/vuejs/nginx.conf
@@ -13,6 +13,10 @@ map $uri $api_upstream {
     ~^/api/v1/builder/                                       "http://workspace.railway.internal:8000";
     ~^/api/v1/agents/                                        "http://workspace.railway.internal:8000";
     ~^/api/v1/project-manager/                               "http://workspace.railway.internal:8000";
+    # Diagnostic: force the version probe onto the workspace tier so it can be
+    # compared against /api/v1/ops/web/version/ (which hits the default backend
+    # tier). See apps/Home/api/ops_urls.py.
+    ~^/api/v1/ops/workspace/                                 "http://workspace.railway.internal:8000";
     # The one Sell endpoint that writes a page into the project on disk; the
     # rest of Sell (Stripe, public storefront, webhooks) stays on the web tier.
     ~^/api/v1/sell/projects/[0-9]+/templates/[^/]+/install/  "http://workspace.railway.internal:8000";

--- a/frontend/vuejs/src/apps/imagi/project-manager/views/Projects.vue
+++ b/frontend/vuejs/src/apps/imagi/project-manager/views/Projects.vue
@@ -181,6 +181,42 @@
                   </div>
                 </div>
 
+                <!-- Deletion result banner — anchored in the library instead of a bottom-right toast -->
+                <Transition
+                  enter-active-class="transition-all duration-300 ease-out"
+                  enter-from-class="opacity-0 -translate-y-1"
+                  enter-to-class="opacity-100 translate-y-0"
+                  leave-active-class="transition-all duration-200 ease-in"
+                  leave-from-class="opacity-100 translate-y-0"
+                  leave-to-class="opacity-0 -translate-y-1"
+                >
+                  <div
+                    v-if="deleteBanner"
+                    :key="deleteBanner.id"
+                    role="status"
+                    aria-live="polite"
+                    class="mb-4 flex-shrink-0 flex items-center gap-3 px-4 py-3 rounded-xl border text-sm transition-colors duration-300"
+                    :class="deleteBanner.type === 'success'
+                      ? 'border-emerald-200/70 dark:border-emerald-400/25 bg-emerald-50/85 dark:bg-emerald-400/10 text-emerald-800 dark:text-emerald-200'
+                      : 'border-red-200/70 dark:border-red-400/25 bg-red-50/85 dark:bg-red-400/10 text-red-800 dark:text-red-200'"
+                  >
+                    <i
+                      class="text-base"
+                      :class="deleteBanner.type === 'success'
+                        ? 'fas fa-check-circle text-emerald-500 dark:text-emerald-300'
+                        : 'fas fa-exclamation-circle text-red-500 dark:text-red-300'"
+                    ></i>
+                    <span class="flex-1 font-medium">{{ deleteBanner.message }}</span>
+                    <button
+                      @click="dismissDeleteBanner"
+                      aria-label="Dismiss notification"
+                      class="shrink-0 w-6 h-6 flex items-center justify-center rounded-md opacity-60 hover:opacity-100 hover:bg-black/[0.04] dark:hover:bg-white/[0.08] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-current/30"
+                    >
+                      <i class="fas fa-times text-xs"></i>
+                    </button>
+                  </div>
+                </Transition>
+
                 <!-- Content Section -->
                 <div class="flex-1 flex flex-col min-h-0">
                   <!-- Loading State -->
@@ -293,13 +329,25 @@ const canCreate = computed(() =>
 )
 const isInitializing = ref(true)
 
-// Show a global toast confirming a project was deleted.
-const showDeleteSuccess = (projectName: string) => {
-  showNotification({
-    type: 'delete',
-    message: `"${projectName}" deleted successfully`,
-    duration: 4000
-  })
+// Deletion outcomes surface as an inline banner anchored in the Project
+// Library panel (see template) rather than a bottom-right toast, so the
+// confirmation reads as part of the library the project was removed from.
+type DeleteBanner = { type: 'success' | 'error'; message: string; id: number }
+const deleteBanner = ref<DeleteBanner | null>(null)
+let deleteBannerTimer: ReturnType<typeof setTimeout> | null = null
+
+const showDeleteBanner = (type: DeleteBanner['type'], message: string) => {
+  if (deleteBannerTimer) clearTimeout(deleteBannerTimer)
+  deleteBanner.value = { type, message, id: Date.now() }
+  // Success auto-dismisses; errors stay until dismissed so they aren't missed.
+  deleteBannerTimer = type === 'success'
+    ? setTimeout(() => { deleteBanner.value = null; deleteBannerTimer = null }, 5000)
+    : null
+}
+
+const dismissDeleteBanner = () => {
+  if (deleteBannerTimer) { clearTimeout(deleteBannerTimer); deleteBannerTimer = null }
+  deleteBanner.value = null
 }
 
 // Computed
@@ -491,7 +539,7 @@ const confirmDelete = async (project: Project) => {
     await projectStore.deleteProject(String(project.id))
 
     // Confirm the deletion right away, independent of any background refresh.
-    showDeleteSuccess(projectName)
+    showDeleteBanner('success', `"${projectName}" deleted successfully`)
 
     // If the user was in the workspace for this project, navigate away from it.
     if (isCurrentlyInWorkspace) {
@@ -503,11 +551,7 @@ const confirmDelete = async (project: Project) => {
     // A real failure (the store already treats 404 as success). The optimistic
     // removal leaves the project missing from the list, so reconcile with the
     // server to bring it back, then report the error.
-    showNotification({
-      message: error?.message || `Failed to delete "${projectName}"`,
-      type: 'error',
-      duration: 5000
-    })
+    showDeleteBanner('error', error?.message || `Failed to delete "${projectName}"`)
 
     try {
       await fetchProjects(true)
@@ -561,6 +605,8 @@ onBeforeUnmount(() => {
   // Clear dashboard-specific notifications when leaving
   const notificationStore = useNotificationStore()
   notificationStore.clear()
+  // Drop any pending deletion-banner auto-dismiss timer.
+  if (deleteBannerTimer) clearTimeout(deleteBannerTimer)
 })
 
 // Watch auth store authentication status

--- a/railway.backend.json
+++ b/railway.backend.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "backend/django/Dockerfile",
+    "watchPatterns": ["backend/django/**"]
+  },
+  "deploy": {
+    "restartPolicyType": "ON_FAILURE",
+    "healthcheckPath": "/api/v1/home/health/"
+  }
+}

--- a/railway.frontend.json
+++ b/railway.frontend.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "frontend/vuejs/Dockerfile",
+    "watchPatterns": ["frontend/vuejs/**"]
+  },
+  "deploy": {
+    "restartPolicyType": "ON_FAILURE"
+  }
+}

--- a/railway.workspace.json
+++ b/railway.workspace.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "backend/django/Dockerfile",
+    "watchPatterns": ["backend/django/**"]
+  },
+  "deploy": {
+    "restartPolicyType": "ON_FAILURE",
+    "healthcheckPath": "/api/v1/home/health/"
+  }
+}


### PR DESCRIPTION
Two independent changes from one session.

## 1. Project-deletion result shows in the Project Library, not a corner toast

Deleting a project fired a bottom-right toast that slid in and vanished, disconnected from the library the project was removed from. The Projects view also calls `notificationStore.clear()` on unmount, so that toast could disappear on navigation.

Now the outcome renders as an inline banner **inside the Project Library panel** ([Projects.vue](frontend/vuejs/src/apps/imagi/project-manager/views/Projects.vue)):

- **Success** (emerald) — auto-dismisses after 5s, and stays visible even when deleting the last project flips the panel to the "No projects yet" empty state.
- **Failure** (red) — persists until dismissed so it isn't missed.
- Dismissible, animated, theme-aware (light/dark), announced via `role="status"` / `aria-live`.
- Auto-dismiss timer cleared on unmount. The auth-precondition error ("Please log in") keeps using the existing toast.

## 2. Deploy-consistency tooling for the three-service prod topology

Prod runs **three Railway services from this one repo**: `frontend` (nginx + SPA + `/api` proxy), `backend` (web tier), and `workspace` (same Django image, `IMAGI_ROLE=workspace`, owns on-disk project copies). nginx routes `/api` by path — `builder/`, `agents/`, `project-manager/` go to the workspace tier. The services don't deploy in lockstep, so a push that redeploys one tier but not the other leaves the stale tier serving old code. That's the likely cause of *"my change isn't live in prod, sometimes"* — and project-manager changes specifically only go live when **workspace** redeploys.

**Version endpoint to detect drift** ([views.py](backend/django/apps/Home/api/views.py), [ops_urls.py](backend/django/apps/Home/api/ops_urls.py), [nginx.conf](frontend/vuejs/nginx.conf)) — same view mounted at two nginx-routed paths:

\`\`\`bash
curl https://<app>/api/v1/ops/web/version/        # -> backend tier
curl https://<app>/api/v1/ops/workspace/version/  # -> workspace tier
\`\`\`

Each reports its `role` + deployed `commit` (from Railway's `RAILWAY_GIT_*` vars). Matching `commit` = tiers in sync; different = the stale tier needs a redeploy. Existing `/api/v1/home/health/` is unchanged; both new endpoints verified returning 200 locally.

**Config-as-code** — `railway.{frontend,backend,workspace}.json` at repo root pin each service's Dockerfile + `watchPatterns`. `backend` and `workspace` are intentionally identical (both watch `backend/django/**`) so a backend push redeploys both, ending dashboard trigger drift.

### ⚠️ Reviewer / deployer note
The `railway.*.json` files require a **one-time per-service step**: set each service's *Config file path* in the Railway dashboard to its file. `IMAGI_ROLE` stays a per-service env var. Config-as-code stops *persistent* trigger drift but does **not** make deploys atomic — brief mid-rollout skew is still possible; the version endpoint is how you catch it.

## Testing
- New version endpoints return 200 with expected payload (local: `role: "unset"`, `commit: "unknown"` since no Railway vars); existing health endpoint unchanged.
- Frontend `npm run type-check` passes for the Projects.vue change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)