### PR TITLE
Fix intermittent blank dev-server page from Vite dep re-optimize

### DIFF
--- a/frontend/vuejs/src/App.vue
+++ b/frontend/vuejs/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="app" class="min-h-screen bg-light-50 dark:bg-dark-950 text-gray-900 dark:text-white flex flex-col transition-colors duration-300">
+  <div class="min-h-screen bg-light-50 dark:bg-dark-950 text-gray-900 dark:text-white flex flex-col transition-colors duration-300">
     <router-view v-slot="{ Component }" class="flex-grow">
       <transition name="fade" mode="out-in">
         <component :is="Component" />

--- a/frontend/vuejs/vite.config.ts
+++ b/frontend/vuejs/vite.config.ts
@@ -29,4 +29,18 @@ export default defineConfig({
     },
     extensions: ['.ts', '.js', '.vue', '.json'],
   },
+  optimizeDeps: {
+    // Pre-bundle these at server startup instead of letting Vite discover them
+    // mid-load. The vee-validate rule/i18n packages are pulled in by the
+    // validation plugin but aren't reliably caught by Vite's dep scanner, so on
+    // a cold optimize cache they were discovered on the first page load —
+    // triggering a re-optimize + full reload that intermittently rendered a
+    // blank page (fixed only by a manual refresh). Listing them here removes the
+    // mid-load reload entirely.
+    include: [
+      'vee-validate',
+      '@vee-validate/rules',
+      '@vee-validate/i18n',
+    ],
+  },
 })


### PR DESCRIPTION
## What

- Add the vee-validate packages (`vee-validate`, `@vee-validate/rules`, `@vee-validate/i18n`) to `optimizeDeps.include` in `frontend/vuejs/vite.config.ts`.
- Remove the redundant `id="app"` from the root `<div>` in `frontend/vuejs/src/App.vue`.

## Why

The Vite dev server occasionally rendered a **blank page on first load**, fixable only by clicking refresh.

**Root cause:** the vee-validate rule/i18n packages — pulled in by the auth validation plugin loaded in `main.ts` — weren't caught by Vite's startup dependency scan, so they were discovered *mid-load*. Vite then re-bundled and forced a full page reload:

```
[vite] (client) ✨ new dependencies optimized: @vee-validate/rules, @vee-validate/i18n
[vite] (client) ✨ optimized dependencies changed. reloading
```

The chunks the browser had already fetched pointed at the now-stale optimize hash and returned `504 (Outdated Optimize Dep)`; the forced reload intermittently landed on a blank page. It only reproduced on a **cold optimize cache** (fresh server start, `npm install`, branch switch), which is why it felt random.

Declaring the packages in `optimizeDeps.include` pre-bundles them at startup, before any page is served, eliminating the mid-load re-optimize and reload.

The `id="app"` cleanup is unrelated housekeeping spotted along the way: `index.html` already has `<div id="app">` as the mount target, and the App.vue root re-declared the same id, producing a duplicate id in the DOM after mount. Harmless, but now gone.

## Verification

Reproduced the failure on a cold cache, then confirmed the fix on a cold cache:

- Server log no longer prints "optimized dependencies changed. reloading".
- Network: every request `200`/`304`, **zero 504s**, all deps served with a single stable optimize hash — one clean optimize pass.
- Page renders on first load (no manual refresh).
- Exactly one `#app` in the DOM, still populated and rendering identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)