### PR TITLE
Fix blank page on every in-app navigation from stuck out-in transition

### DIFF
--- a/frontend/vuejs/src/App.vue
+++ b/frontend/vuejs/src/App.vue
@@ -1,7 +1,10 @@
 <template>
-  <div class="min-h-screen bg-light-50 dark:bg-dark-950 text-gray-900 dark:text-white flex flex-col transition-colors duration-300">
+  <div class="relative min-h-screen bg-light-50 dark:bg-dark-950 text-gray-900 dark:text-white flex flex-col transition-colors duration-300">
+    <!-- No mode="out-in" here: with vue-router 5 + Vue 3.5 the out-in resume
+         callback never fires, so <router-view> latches on an empty placeholder
+         and every in-app navigation renders a blank page until a full reload. -->
     <router-view v-slot="{ Component }" class="flex-grow">
-      <transition name="fade" mode="out-in">
+      <transition name="fade">
         <component :is="Component" />
       </transition>
     </router-view>
@@ -21,3 +24,33 @@ const themeStore = useThemeStore()
 // pre-paint inline script in index.html without a repaint in between.
 themeStore.initializeTheme()
 </script>
+
+<style scoped>
+/* Crossfade between routed pages. Without mode="out-in" both pages are in the
+   DOM together for the duration, so the outgoing one is taken out of flow —
+   otherwise it stacks above the incoming page and the document height (and
+   scrollbar) visibly jumps on every navigation. */
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.25s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+
+.fade-leave-active {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fade-enter-active,
+  .fade-leave-active {
+    transition: none;
+  }
+}
+</style>


### PR DESCRIPTION
## What was wrong

`App.vue` wrapped `<router-view>` in `<transition name="fade" mode="out-in">`. With **Vue 3.5.29 + vue-router 5.0.3**, Vue's internal resume-after-leave callback for `out-in` never fires — only `performRemove` invokes the `afterLeave` that clears the transition's `isLeaving` latch, and that path was never reached. `isLeaving` stayed `true`, so `<router-view>` rendered an empty comment placeholder from then on.

**This was not intermittent.** The first client-side navigation blanked the page and every subsequent route stayed blank, since the latch is never released. A full page reload bypasses the transition entirely — which is why refreshing appeared to fix it, and why clicking any link broke it again.

Instrumenting the transition hooks showed it precisely:

```
before-leave → leave → after-leave     (before-enter / enter NEVER fire)
```

The outgoing page was removed at ~400ms and nothing ever replaced it. Reproduced on `/about`, `/privacy`, `/docs/models`, `/auth/signin` and `/`.

### Ruled out

- The nested `DefaultLayout` transition — removed it, still broke
- The `class="flex-grow"` attribute fallthrough on `<router-view>` — removed it, still broke
- Commit 8f5138f — it only dropped a redundant `id` attribute

Note this is a **separate bug** from the one 8f5138f fixed. That commit addressed a genuine Vite dep re-optimize issue on first load; its `optimizeDeps.include` fix is still in place and working. This bug was always there, underneath it.

## The fix

Drop `mode="out-in"` so the crossfade runs simultaneously. The nested `out-in` transition in `AuthLayout` works correctly and is left untouched — only the top-level one was affected.

Without `out-in`, both pages are briefly in the DOM together, which stacked them and made the document height jump `6664 → 11833 → 5169` on every navigation, visibly flickering the scrollbar. So the outgoing page is taken out of flow for the duration — height now holds steady at `6664` through the crossfade, then settles to `5169`.

## Verification

- All 8 routes render: `/about`, `/auth/signin`, `/auth/register`, `/docs/models`, `/docs/plans`, `/payments/pricing`, `/imagi/projects`, `/`
- Real UI clicks: Home → Sign In → Create an account → Home, all rendering
- `signin ↔ register` toggled 3× with correct content each time
- `npm run type-check` passes clean

## Reviewer notes

- The `.fade-*` CSS is `scoped`, so it lands on the routed page's root element only. It does not reach the identically-named `fade` transition nested inside `AuthLayout` (verified by the signin/register toggle still working).
- The root element gains `relative` to act as the containing block for the out-of-flow outgoing page.
- `prefers-reduced-motion` is honored.
- Unrelated: the `Health check failed ... 500` errors in the dev console are stale, from page loads while Django was still installing deps and running migrations at startup. `/api/v1/home/health/` returns `200` on every request, direct and through the Vite proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)