### PR TITLE
Give form fields a single-edge focus outline; drop build-card sheen

### DIFF
--- a/frontend/vuejs/src/apps/auth/components/atoms/inputs/PasswordInput.vue
+++ b/frontend/vuejs/src/apps/auth/components/atoms/inputs/PasswordInput.vue
@@ -21,13 +21,11 @@
                text-blue-950 dark:text-white
                placeholder-blue-950/40 dark:placeholder-blue-100/35
                disabled:opacity-50 disabled:cursor-not-allowed
-               transition-all duration-200
-               border bg-white/70 dark:bg-white/[0.04] backdrop-blur-sm
-               focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
-        :class="{
-          'border-red-500/50 dark:border-red-400/40 bg-red-50 dark:bg-red-500/5': hasError,
-          'border-blue-950/[0.12] dark:border-white/[0.14] hover:border-blue-950/25 dark:hover:border-white/25': !hasError
-        }"
+               transition-colors duration-200
+               border bg-white/70 dark:bg-white/[0.04] backdrop-blur-sm"
+        :class="[
+          hasError ? `bg-red-50 dark:bg-red-500/5 ${fieldFocusError}` : `${fieldBorder} ${fieldFocus}`
+        ]"
       >
       <button
         type="button"
@@ -47,6 +45,7 @@
 
 <script setup>
 import { ref, computed } from 'vue'
+import { fieldBorder, fieldFocus, fieldFocusError } from '@/shared/styles/forms'
 
 const isVisible = ref(false)
 

--- a/frontend/vuejs/src/apps/auth/components/molecules/forms/FormCheckbox.vue
+++ b/frontend/vuejs/src/apps/auth/components/molecules/forms/FormCheckbox.vue
@@ -16,10 +16,10 @@
                  border-blue-950/[0.25] dark:border-white/25
                  bg-white/70 dark:bg-white/[0.05]
                  text-blue-950 dark:text-blue-400
-                 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]
                  disabled:opacity-50 disabled:cursor-not-allowed
                  transition-all duration-300
                  checked:bg-blue-950 checked:border-blue-950 dark:checked:bg-blue-400 dark:checked:border-blue-400"
+          :class="controlFocus"
         >
       </Field>
     </div>
@@ -34,6 +34,7 @@
 
 <script setup>
 import { Field, ErrorMessage } from 'vee-validate'
+import { controlFocus } from '@/shared/styles/forms'
 
 defineProps({
   name: {

--- a/frontend/vuejs/src/apps/auth/components/molecules/forms/FormInput.vue
+++ b/frontend/vuejs/src/apps/auth/components/molecules/forms/FormInput.vue
@@ -19,13 +19,11 @@
                text-blue-950 dark:text-white
                placeholder-blue-950/40 dark:placeholder-blue-100/35
                disabled:opacity-50 disabled:cursor-not-allowed
-               transition-all duration-200
-               border bg-white/70 dark:bg-white/[0.04] backdrop-blur-sm
-               focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
-        :class="{
-          'border-red-500/50 dark:border-red-400/40 bg-red-50 dark:bg-red-500/5': hasError,
-          'border-blue-950/[0.12] dark:border-white/[0.14] hover:border-blue-950/25 dark:hover:border-white/25': !hasError
-        }"
+               transition-colors duration-200
+               border bg-white/70 dark:bg-white/[0.04] backdrop-blur-sm"
+        :class="[
+          hasError ? `bg-red-50 dark:bg-red-500/5 ${fieldFocusError}` : `${fieldBorder} ${fieldFocus}`
+        ]"
       >
     </label>
     <ErrorMessage v-if="showError" :name="name" class="mt-2 text-sm text-red-600 dark:text-red-400 flex items-center gap-2">
@@ -37,6 +35,7 @@
 <script setup>
 import { ErrorMessage } from 'vee-validate'
 import { computed } from 'vue'
+import { fieldBorder, fieldFocus, fieldFocusError } from '@/shared/styles/forms'
 
 const props = defineProps({
   modelValue: {

--- a/frontend/vuejs/src/apps/imagi/build/components/molecules/sidebar/CheckInQueue.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/molecules/sidebar/CheckInQueue.vue
@@ -316,17 +316,15 @@ function sendAnswer() {
 }
 
 .answer-textarea {
-  transition: border-color 0.18s ease, box-shadow 0.18s ease;
+  transition: border-color 0.18s ease;
   outline: none;
 }
 
 .answer-textarea:focus {
-  border-color: rgba(59, 130, 246, 0.55);
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+  border-color: rgba(23, 37, 84, 0.45);
 }
 
 .dark .answer-textarea:focus {
-  border-color: rgba(147, 197, 253, 0.5);
-  box-shadow: 0 0 0 3px rgba(147, 197, 253, 0.18);
+  border-color: rgba(255, 255, 255, 0.45);
 }
 </style>

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
@@ -729,17 +729,15 @@ async function handleEffortSelect(effort: ReasoningEffort) {
 <style scoped>
 /* Input shell wraps the textarea + controls toolbar as one field */
 .chat-input-shell {
-  transition: border-color 0.18s ease, box-shadow 0.18s ease;
+  transition: border-color 0.18s ease;
 }
 
 .chat-input-shell:focus-within {
-  border-color: rgba(59, 130, 246, 0.55);
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15);
+  border-color: rgba(23, 37, 84, 0.45);
 }
 
 .dark .chat-input-shell:focus-within {
-  border-color: rgba(147, 197, 253, 0.5);
-  box-shadow: 0 0 0 3px rgba(147, 197, 253, 0.18);
+  border-color: rgba(255, 255, 255, 0.45);
 }
 
 /* Control chip: the compact model / reasoning / usage buttons. Ghost until

--- a/frontend/vuejs/src/apps/imagi/marketing/components/CampaignForm.vue
+++ b/frontend/vuejs/src/apps/imagi/marketing/components/CampaignForm.vue
@@ -70,11 +70,11 @@
       <span :class="ui.label">Audience</span>
       <div class="space-y-2.5">
         <label class="flex items-center gap-2.5 text-sm text-blue-950 dark:text-white cursor-pointer">
-          <input v-model="form.audience_type" type="radio" value="all" class="accent-blue-700 dark:accent-blue-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]" />
+          <input v-model="form.audience_type" type="radio" value="all" class="accent-blue-700 dark:accent-blue-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-950/30 dark:focus-visible:ring-white/35 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]" />
           All subscribed contacts
         </label>
         <label class="flex items-center gap-2.5 text-sm text-blue-950 dark:text-white cursor-pointer">
-          <input v-model="form.audience_type" type="radio" value="tags" class="accent-blue-700 dark:accent-blue-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]" />
+          <input v-model="form.audience_type" type="radio" value="tags" class="accent-blue-700 dark:accent-blue-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-950/30 dark:focus-visible:ring-white/35 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0c0c0e]" />
           Contacts with any of these tags
         </label>
         <div v-if="form.audience_type === 'tags'" class="pl-6">

--- a/frontend/vuejs/src/apps/imagi/marketing/utils/ui.ts
+++ b/frontend/vuejs/src/apps/imagi/marketing/utils/ui.ts
@@ -5,12 +5,14 @@
  * strings for the JIT compiler.
  */
 
+import { fieldShell } from '@/shared/styles/forms'
+
 export const ui = {
   card: 'crisp-card rounded-2xl bg-white/85 dark:bg-white/[0.045] backdrop-blur-sm border border-blue-200/70 dark:border-blue-300/[0.14] transition-colors duration-300',
 
   label: 'block text-xs font-semibold uppercase tracking-[0.14em] text-blue-950/70 dark:text-blue-100/55 mb-1.5 transition-colors duration-300',
 
-  input: 'w-full px-3.5 py-2.5 rounded-xl bg-white dark:bg-white/[0.06] border border-blue-200/70 dark:border-white/[0.12] text-blue-950 dark:text-white text-sm placeholder-blue-950/40 dark:placeholder-blue-100/30 focus:outline-none focus:ring-2 focus:ring-blue-500/40 dark:focus:ring-blue-300/50 focus:border-blue-300 dark:focus:border-blue-400/40 transition-colors duration-200',
+  input: `w-full px-3.5 py-2.5 rounded-xl bg-white dark:bg-white/[0.06] text-blue-950 dark:text-white text-sm placeholder-blue-950/40 dark:placeholder-blue-100/30 ${fieldShell}`,
 
   primaryBtn: 'inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-full bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white text-sm font-medium transition-colors duration-200 shadow-[0_1px_2px_rgba(23,37,84,0.2),0_3px_8px_-2px_rgba(23,37,84,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e] disabled:opacity-50 disabled:cursor-not-allowed',
 

--- a/frontend/vuejs/src/apps/imagi/marketing/views/MarketingAudience.vue
+++ b/frontend/vuejs/src/apps/imagi/marketing/views/MarketingAudience.vue
@@ -182,7 +182,7 @@
         </div>
         <div v-if="editingContact">
           <label class="flex items-center gap-2.5 text-sm text-blue-950 dark:text-white cursor-pointer">
-            <input v-model="form.subscribed" type="checkbox" class="accent-blue-700 dark:accent-blue-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#16161a]" />
+            <input v-model="form.subscribed" type="checkbox" class="accent-blue-700 dark:accent-blue-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-950/30 dark:focus-visible:ring-white/35 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#16161a]" />
             Subscribed to messages
           </label>
         </div>

--- a/frontend/vuejs/src/apps/imagi/operate/utils/ui.ts
+++ b/frontend/vuejs/src/apps/imagi/operate/utils/ui.ts
@@ -5,12 +5,14 @@
  * as full static strings for the JIT compiler.
  */
 
+import { fieldShell } from '@/shared/styles/forms'
+
 export const ui = {
   card: 'crisp-card rounded-2xl bg-white dark:bg-white/[0.05] border border-blue-200/70 dark:border-blue-300/[0.16] transition-colors duration-300',
 
   label: 'block text-xs font-semibold uppercase tracking-[0.14em] text-blue-950/60 dark:text-blue-100/60 mb-1.5 transition-colors duration-300',
 
-  input: 'w-full px-3.5 py-2.5 rounded-xl bg-white dark:bg-white/[0.06] border border-blue-200/70 dark:border-white/[0.12] text-blue-950 dark:text-white text-sm placeholder-blue-950/40 dark:placeholder-blue-100/30 focus:outline-none focus:ring-2 focus:ring-blue-500/40 dark:focus:ring-blue-300/50 focus:border-blue-400/60 dark:focus:border-blue-300/40 transition-colors duration-200',
+  input: `w-full px-3.5 py-2.5 rounded-xl bg-white dark:bg-white/[0.06] text-blue-950 dark:text-white text-sm placeholder-blue-950/40 dark:placeholder-blue-100/30 ${fieldShell}`,
 
   primaryBtn: 'inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-full bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white text-sm font-medium transition-colors duration-200 shadow-[0_1px_2px_rgba(23,37,84,0.2),0_3px_8px_-2px_rgba(23,37,84,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e] disabled:opacity-50 disabled:cursor-not-allowed',
 

--- a/frontend/vuejs/src/apps/imagi/project-manager/components/organisms/hub/ToolCategoryCard.vue
+++ b/frontend/vuejs/src/apps/imagi/project-manager/components/organisms/hub/ToolCategoryCard.vue
@@ -17,9 +17,6 @@
     :title="isBuildLocked ? 'Imagi is building your app — this card unlocks the moment the build finishes' : tool.name"
     :aria-disabled="isBuildLocked ? 'true' : undefined"
   >
-    <!-- Moving sheen while building -->
-    <div v-if="isBuildLocked" class="building-sheen pointer-events-none absolute inset-0 rounded-2xl overflow-hidden"></div>
-
     <!-- ==================== BUILDING STATE ==================== -->
     <template v-if="isBuildLocked">
       <!-- Animated build icon: concentric pulsing rings behind a spinner ring -->
@@ -194,38 +191,6 @@ const target = computed<RouteLocationRaw>(() => {
   }
 }
 
-/* Diagonal sheen sweeping across the card. */
-.building-sheen::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: -60%;
-  width: 45%;
-  height: 100%;
-  background: linear-gradient(
-    100deg,
-    transparent,
-    rgba(255, 255, 255, 0.55),
-    transparent
-  );
-  transform: skewX(-18deg);
-  animation: building-sweep 2.6s ease-in-out infinite;
-}
-
-:global(.dark) .building-sheen::before {
-  background: linear-gradient(
-    100deg,
-    transparent,
-    rgba(147, 197, 253, 0.14),
-    transparent
-  );
-}
-
-@keyframes building-sweep {
-  0% { left: -60%; }
-  60%, 100% { left: 120%; }
-}
-
 /* Indeterminate progress bar that slides back and forth. */
 .building-bar {
   animation: building-bar 1.6s ease-in-out infinite;
@@ -238,7 +203,6 @@ const target = computed<RouteLocationRaw>(() => {
 
 @media (prefers-reduced-motion: reduce) {
   .building-card,
-  .building-sheen::before,
   .building-bar,
   .animate-ping {
     animation: none;

--- a/frontend/vuejs/src/apps/imagi/project-manager/views/Projects.vue
+++ b/frontend/vuejs/src/apps/imagi/project-manager/views/Projects.vue
@@ -87,7 +87,8 @@
                       v-model="newProjectName"
                       type="text"
                       placeholder="Enter your business name..."
-                      class="w-full px-4 py-3 bg-white dark:bg-white/[0.04] border border-blue-200/70 dark:border-white/[0.14] focus:border-blue-400 dark:focus:border-blue-300/50 rounded-xl text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-blue-100/40 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e] disabled:opacity-50 disabled:cursor-not-allowed"
+                      class="w-full px-4 py-3 bg-white dark:bg-white/[0.04] rounded-xl text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-blue-100/40 transition-colors duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+                      :class="fieldShell"
                       :disabled="isCreating"
                     >
                   </div>
@@ -103,7 +104,8 @@
                     <textarea
                       v-model="newProjectDescription"
                       placeholder="What does your business do? Who are its customers? What does the market look like, and how will you sell?"
-                      class="w-full flex-1 min-h-[80px] px-4 py-3 bg-white dark:bg-white/[0.04] border border-blue-200/70 dark:border-white/[0.14] focus:border-blue-400 dark:focus:border-blue-300/50 rounded-xl text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-blue-100/40 transition-all duration-300 resize-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e] disabled:opacity-50 disabled:cursor-not-allowed"
+                      class="w-full flex-1 min-h-[80px] px-4 py-3 bg-white dark:bg-white/[0.04] rounded-xl text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-blue-100/40 transition-colors duration-200 resize-none disabled:opacity-50 disabled:cursor-not-allowed"
+                      :class="fieldShell"
                       :disabled="isCreating"
                     ></textarea>
                   </div>
@@ -121,7 +123,8 @@
                       v-model="newProjectDesign"
                       rows="2"
                       placeholder="e.g. Warm and minimal, earthy palette, lots of whitespace — like a modern coffee brand."
-                      class="w-full min-h-[56px] px-4 py-3 bg-white dark:bg-white/[0.04] border border-blue-200/70 dark:border-white/[0.14] focus:border-blue-400 dark:focus:border-blue-300/50 rounded-xl text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-blue-100/40 transition-all duration-300 resize-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e] disabled:opacity-50 disabled:cursor-not-allowed"
+                      class="w-full min-h-[56px] px-4 py-3 bg-white dark:bg-white/[0.04] rounded-xl text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-blue-100/40 transition-colors duration-200 resize-none disabled:opacity-50 disabled:cursor-not-allowed"
+                      :class="fieldShell"
                       :disabled="isCreating"
                     ></textarea>
                   </div>
@@ -176,7 +179,8 @@
                       v-model="searchQuery"
                       type="text"
                       placeholder="Search projects..."
-                      class="w-full pl-11 pr-4 py-2.5 bg-white dark:bg-white/[0.04] border border-blue-200/70 dark:border-white/[0.14] focus:border-blue-400 dark:focus:border-blue-300/50 rounded-xl text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-blue-100/40 text-sm transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]"
+                      class="w-full pl-11 pr-4 py-2.5 bg-white dark:bg-white/[0.04] rounded-xl text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-blue-100/40 text-sm transition-colors duration-200"
+                      :class="fieldShell"
                     >
                   </div>
                 </div>
@@ -289,6 +293,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, onBeforeUnmount, onMounted, onActivated } from 'vue'
+import { fieldShell } from '@/shared/styles/forms'
 import { useRouter } from 'vue-router'
 import { DefaultLayout } from '@/shared/layouts'
 import { useProjectStore } from '@/apps/imagi/build/stores/projectStore'

--- a/frontend/vuejs/src/apps/imagi/sell/components/ProductForm.vue
+++ b/frontend/vuejs/src/apps/imagi/sell/components/ProductForm.vue
@@ -82,7 +82,7 @@
     </div>
 
     <label class="flex items-center gap-2.5 text-sm text-blue-950/80 dark:text-blue-100/80 cursor-pointer">
-      <input v-model="form.is_active" type="checkbox" class="rounded border-blue-950/30 dark:border-white/30 text-blue-950 dark:text-blue-400 focus:ring-blue-500/40 dark:focus:ring-blue-300/50" />
+      <input v-model="form.is_active" type="checkbox" class="rounded border-blue-950/30 dark:border-white/30 text-blue-950 dark:text-blue-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-950/30 dark:focus-visible:ring-white/35 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e]" />
       Available for purchase
     </label>
 

--- a/frontend/vuejs/src/apps/imagi/sell/utils/ui.ts
+++ b/frontend/vuejs/src/apps/imagi/sell/utils/ui.ts
@@ -7,12 +7,14 @@
  * Keep these as full static strings for the JIT compiler.
  */
 
+import { fieldShell } from '@/shared/styles/forms'
+
 export const ui = {
   card: 'crisp-card rounded-2xl bg-white/85 dark:bg-white/[0.045] backdrop-blur-sm border border-blue-200/70 dark:border-blue-300/[0.14] transition-colors duration-300',
 
   label: 'block text-xs font-semibold uppercase tracking-[0.14em] text-blue-950/70 dark:text-blue-100/55 mb-1.5 transition-colors duration-300',
 
-  input: 'w-full px-3.5 py-2.5 rounded-xl bg-white dark:bg-white/[0.06] border border-blue-950/[0.14] dark:border-white/[0.14] text-blue-950 dark:text-white text-sm placeholder-blue-950/40 dark:placeholder-blue-100/30 focus:outline-none focus:ring-2 focus:ring-blue-500/40 dark:focus:ring-blue-300/50 focus:border-blue-300 dark:focus:border-blue-400/40 transition-colors duration-200',
+  input: `w-full px-3.5 py-2.5 rounded-xl bg-white dark:bg-white/[0.06] text-blue-950 dark:text-white text-sm placeholder-blue-950/40 dark:placeholder-blue-100/30 ${fieldShell}`,
 
   primaryBtn: 'inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-full bg-blue-950 text-[#fdf9f2] hover:bg-blue-900 dark:bg-[#f3ede2] dark:text-blue-950 dark:hover:bg-white text-sm font-medium transition-colors duration-200 shadow-[0_1px_2px_rgba(23,37,84,0.2),0_3px_8px_-2px_rgba(23,37,84,0.25)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.4),0_3px_8px_-2px_rgba(0,0,0,0.45)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] dark:focus-visible:ring-offset-[#0c0c0e] disabled:opacity-50 disabled:cursor-not-allowed',
 

--- a/frontend/vuejs/src/apps/payments/components/atoms/inputs/Input.vue
+++ b/frontend/vuejs/src/apps/payments/components/atoms/inputs/Input.vue
@@ -19,11 +19,11 @@
         :disabled="disabled"
         :readonly="readonly"
         :class="[
-          'w-full px-4 py-3 bg-white dark:bg-white/[0.05] backdrop-blur-sm border border-blue-950/[0.12] dark:border-white/[0.14] rounded-xl text-blue-950 dark:text-white',
-          'transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:border-blue-500/50 dark:focus-visible:border-blue-300/50',
+          'w-full px-4 py-3 bg-white dark:bg-white/[0.05] backdrop-blur-sm border border-blue-950/[0.12] dark:border-white/[0.14] hover:border-blue-950/25 dark:hover:border-white/25 rounded-xl text-blue-950 dark:text-white',
+          'transition-colors duration-200 focus:outline-none focus:border-blue-950/45 dark:focus:border-white/45',
           'disabled:opacity-50 disabled:cursor-not-allowed placeholder:text-blue-950/40 dark:placeholder:text-blue-100/30',
           prefix ? 'pl-8' : '',
-          error ? 'border-red-500/50 dark:border-red-400/50 focus-visible:border-red-500/50 dark:focus-visible:border-red-400/50 focus-visible:ring-red-500/40 dark:focus-visible:ring-red-400/40' : '',
+          error ? 'border-red-500/50 dark:border-red-400/50 focus:border-red-500 dark:focus:border-red-400' : '',
           customClass,
         ]"
         @input="$emit('update:modelValue', ($event.target as HTMLInputElement).value)"

--- a/frontend/vuejs/src/apps/payments/components/molecules/cards/OnDemandCard/OnDemandCard.vue
+++ b/frontend/vuejs/src/apps/payments/components/molecules/cards/OnDemandCard/OnDemandCard.vue
@@ -44,7 +44,7 @@
             placeholder="Custom amount (5-1000)"
             @focus="isCustom = true"
             @input="handleCustomInput"
-            class="w-full pl-8 pr-4 py-3 rounded-xl bg-white dark:bg-white/[0.05] border border-blue-950/[0.12] dark:border-white/[0.14] text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-blue-100/30 text-sm transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:border-blue-500/50 dark:focus-visible:border-blue-300/50"
+            class="w-full pl-8 pr-4 py-3 rounded-xl bg-white dark:bg-white/[0.05] border border-blue-950/[0.12] dark:border-white/[0.14] hover:border-blue-950/25 dark:hover:border-white/25 text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-blue-100/30 text-sm transition-colors duration-200 focus:outline-none focus:border-blue-950/45 dark:focus:border-white/45"
           />
         </div>
 

--- a/frontend/vuejs/src/apps/payments/components/molecules/selectors/PaymentAmountSelector/PaymentAmountSelector.vue
+++ b/frontend/vuejs/src/apps/payments/components/molecules/selectors/PaymentAmountSelector/PaymentAmountSelector.vue
@@ -26,7 +26,7 @@
             :value="customAmount"
             @input="onCustomAmountChange"
             @focus="selectCustomAmount"
-            class="bg-white dark:bg-white/[0.05] border border-blue-950/[0.12] dark:border-white/[0.14] rounded-xl px-3 py-2 w-full text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-blue-100/30 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:border-blue-500/50 dark:focus-visible:border-blue-300/50"
+            class="bg-white dark:bg-white/[0.05] border border-blue-950/[0.12] dark:border-white/[0.14] hover:border-blue-950/25 dark:hover:border-white/25 rounded-xl px-3 py-2 w-full text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-blue-100/30 transition-colors duration-200 focus:outline-none focus:border-blue-950/45 dark:focus:border-white/45"
             placeholder="Enter amount"
           />
         </div>

--- a/frontend/vuejs/src/apps/payments/components/organisms/forms/AddCredits/AddCredits.vue
+++ b/frontend/vuejs/src/apps/payments/components/organisms/forms/AddCredits/AddCredits.vue
@@ -40,8 +40,8 @@
           max="1000"
           step="1"
           placeholder="Enter amount"
-          class="flex-1 p-2 border rounded-xl bg-white dark:bg-white/[0.05] text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-blue-100/30 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:border-blue-500/50 dark:focus-visible:border-blue-300/50"
-          :class="customAmountError ? 'border-red-500/50 dark:border-red-400/50' : 'border-blue-950/[0.12] dark:border-white/[0.14]'"
+          class="flex-1 p-2 border rounded-xl bg-white dark:bg-white/[0.05] text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-blue-100/30 transition-colors duration-200 focus:outline-none focus:border-blue-950/45 dark:focus:border-white/45"
+          :class="customAmountError ? 'border-red-500/50 dark:border-red-400/50 focus:border-red-500 dark:focus:border-red-400' : 'border-blue-950/[0.12] dark:border-white/[0.14] hover:border-blue-950/25 dark:hover:border-white/25'"
         />
       </div>
       <div v-if="customAmountError" class="text-red-600 dark:text-red-400 text-sm mt-1">

--- a/frontend/vuejs/src/apps/payments/components/organisms/forms/PaymentFormSection/PaymentFormSection.vue
+++ b/frontend/vuejs/src/apps/payments/components/organisms/forms/PaymentFormSection/PaymentFormSection.vue
@@ -22,7 +22,7 @@
                 :min="minAmount"
                 :max="maxAmount"
                 :step="step"
-                class="block w-full rounded-xl border border-blue-950/[0.12] dark:border-white/[0.14] bg-white dark:bg-white/[0.05] py-3 pl-8 pr-28 text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-blue-100/30 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:border-blue-500/50 dark:focus-visible:border-blue-300/50"
+                class="block w-full rounded-xl border border-blue-950/[0.12] dark:border-white/[0.14] hover:border-blue-950/25 dark:hover:border-white/25 bg-white dark:bg-white/[0.05] py-3 pl-8 pr-28 text-blue-950 dark:text-white placeholder-blue-950/40 dark:placeholder-blue-100/30 transition-colors duration-200 focus:outline-none focus:border-blue-950/45 dark:focus:border-white/45"
               />
               <div class="absolute inset-y-0 right-12 flex flex-col justify-center py-1 gap-0.5">
                 <button
@@ -71,7 +71,7 @@
               <div
                 id="card-element"
                 ref="cardElement"
-                class="block w-full rounded-xl border border-blue-950/[0.12] dark:border-white/[0.14] bg-white dark:bg-white/[0.05] py-3 px-4 text-blue-950 dark:text-white transition-all duration-300 focus-within:border-blue-500/50 dark:focus-within:border-blue-300/50 focus-within:ring-2 focus-within:ring-blue-500/40 dark:focus-within:ring-blue-300/50 min-h-[45px]"
+                class="block w-full rounded-xl border border-blue-950/[0.12] dark:border-white/[0.14] hover:border-blue-950/25 dark:hover:border-white/25 bg-white dark:bg-white/[0.05] py-3 px-4 text-blue-950 dark:text-white transition-colors duration-200 focus-within:border-blue-950/45 dark:focus-within:border-white/45 min-h-[45px]"
               ></div>
               <div id="card-errors" class="mt-2 text-sm text-red-600 dark:text-red-400"></div>
             </div>

--- a/frontend/vuejs/src/apps/payments/components/organisms/tables/TransactionTable/TransactionTable.vue
+++ b/frontend/vuejs/src/apps/payments/components/organisms/tables/TransactionTable/TransactionTable.vue
@@ -6,7 +6,7 @@
         <span class="text-blue-950/60 dark:text-blue-100/55 mr-2 transition-colors duration-300">Filter:</span>
         <select
           v-model="filter"
-          class="bg-white dark:bg-white/[0.05] border border-blue-950/[0.12] dark:border-white/[0.14] text-blue-950 dark:text-white rounded-lg px-3 py-2 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:border-blue-500/50 dark:focus-visible:border-blue-300/50"
+          class="bg-white dark:bg-white/[0.05] border border-blue-950/[0.12] dark:border-white/[0.14] hover:border-blue-950/25 dark:hover:border-white/25 text-blue-950 dark:text-white rounded-lg px-3 py-2 transition-colors duration-200 focus:outline-none focus:border-blue-950/45 dark:focus:border-white/45"
         >
           <option value="all">All Transactions</option>
           <option value="completed">Completed</option>
@@ -18,7 +18,7 @@
         <span class="text-blue-950/60 dark:text-blue-100/55 mr-2 transition-colors duration-300">Sort:</span>
         <select
           v-model="sort"
-          class="bg-white dark:bg-white/[0.05] border border-blue-950/[0.12] dark:border-white/[0.14] text-blue-950 dark:text-white rounded-lg px-3 py-2 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:border-blue-500/50 dark:focus-visible:border-blue-300/50"
+          class="bg-white dark:bg-white/[0.05] border border-blue-950/[0.12] dark:border-white/[0.14] hover:border-blue-950/25 dark:hover:border-white/25 text-blue-950 dark:text-white rounded-lg px-3 py-2 transition-colors duration-200 focus:outline-none focus:border-blue-950/45 dark:focus:border-white/45"
         >
           <option value="date-desc">Newest First</option>
           <option value="date-asc">Oldest First</option>

--- a/frontend/vuejs/src/shared/layouts/BaseLayout.vue
+++ b/frontend/vuejs/src/shared/layouts/BaseLayout.vue
@@ -4,13 +4,21 @@
        mobile while browser chrome is showing, which adds phantom page scroll
        that drags fixed-navbar layouts out of alignment. -->
   <div class="flex flex-col min-h-dvh bg-white dark:bg-[#0a0a0a] transition-colors duration-300">
-    <!-- Custom scrollbar and focus styles using arbitrary values -->
+    <!-- Custom scrollbar and focus styles using arbitrary values.
+
+         The blanket focus-visible outline covers buttons, links and cards,
+         where a detached blue ring is the right keyboard affordance. Native
+         form fields are excluded: they own their focus treatment (see
+         shared/styles/forms.ts), which deepens the field's single border
+         rather than layering a second edge outside it. Without the :not(),
+         this outline draws over every field on the site and the result reads
+         as two outlines — a grey border inside a blue ring. -->
     <div class="overflow-auto
                 [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar]:h-2
                 [&::-webkit-scrollbar-track]:bg-transparent
                 [&::-webkit-scrollbar-thumb]:bg-blue-950/15 dark:[&::-webkit-scrollbar-thumb]:bg-white/10 [&::-webkit-scrollbar-thumb]:rounded
                 [&::-webkit-scrollbar-thumb:hover]:bg-blue-950/25 dark:[&::-webkit-scrollbar-thumb:hover]:bg-white/20
-                [&_*:focus-visible]:outline-2 [&_*:focus-visible]:outline-blue-500/40 dark:[&_*:focus-visible]:outline-blue-300/50 [&_*:focus-visible]:outline-offset-2
+                [&_*:focus-visible:not(input):not(textarea):not(select)]:outline-2 [&_*:focus-visible:not(input):not(textarea):not(select)]:outline-blue-500/40 dark:[&_*:focus-visible:not(input):not(textarea):not(select)]:outline-blue-300/50 [&_*:focus-visible:not(input):not(textarea):not(select)]:outline-offset-2
                 [scrollbar-width]:thin">
       <slot></slot>
     </div>

--- a/frontend/vuejs/src/shared/styles/forms.ts
+++ b/frontend/vuejs/src/shared/styles/forms.ts
@@ -1,0 +1,57 @@
+/**
+ * forms.ts — the canonical focus/outline treatment for form fields.
+ *
+ * A field draws exactly ONE edge: its border. It stays the same neutral ink
+ * hairline at every state and simply deepens — 12% at rest, 25% on hover,
+ * 45% on focus. No accent colour, and nothing ever layered outside it.
+ *
+ * Both halves of that rule came from watching the alternatives fail:
+ *
+ *   - `ring-*` gives a second edge, always. A ring is a box-shadow drawn
+ *     outside the element, so it composites over the *page* background while
+ *     the border composites over the *field's* background. Even a `ring-1`
+ *     declaring the identical colour as the border lands as a visibly
+ *     different tone — a grey edge inside a blue one.
+ *   - Turning that single border blue on focus still read as two outlines,
+ *     because a saturated accent edge doesn't belong to the same family as
+ *     the calm hairline it replaces; the eye separates them.
+ *
+ * Buttons, cards and links still use an offset ring — those fire on
+ * `focus-visible` (keyboard only), where a detached ring is the point.
+ */
+
+/** The one edge, at rest: a hairline that warms slightly on hover. */
+export const fieldBorder =
+  'border border-blue-950/[0.12] dark:border-white/[0.14] ' +
+  'hover:border-blue-950/25 dark:hover:border-white/25'
+
+/** Focus: the same hairline, one step deeper. No accent, no ring, no halo. */
+export const fieldFocus =
+  'focus:outline-none focus:border-blue-950/45 dark:focus:border-white/45'
+
+/**
+ * Same treatment for a wrapper that hosts a field it doesn't own — the Stripe
+ * card element, for instance, which mounts its own iframe inside our shell.
+ */
+export const fieldFocusWithin =
+  'focus-within:border-blue-950/45 dark:focus-within:border-white/45'
+
+/** Error state: still one border, red instead of ink. */
+export const fieldFocusError =
+  'focus:outline-none ' +
+  'border-red-500/50 dark:border-red-400/40 ' +
+  'focus:border-red-500 dark:focus:border-red-400'
+
+/**
+ * Checkboxes, radios and sliders are too small to carry an edge treatment, so
+ * they keep an offset ring — but in ink rather than stock blue, and only for
+ * keyboard focus.
+ */
+export const controlFocus =
+  'focus-visible:outline-none focus-visible:ring-2 ' +
+  'focus-visible:ring-blue-950/30 dark:focus-visible:ring-white/35 ' +
+  'focus-visible:ring-offset-2 focus-visible:ring-offset-[#fdf9f2] ' +
+  'dark:focus-visible:ring-offset-[#0c0c0e]'
+
+/** Everything a standard text field needs apart from its own sizing/colour. */
+export const fieldShell = `${fieldBorder} ${fieldFocus} transition-colors duration-200`


### PR DESCRIPTION
Two unrelated UI cleanups, both requested against the projects page.

## 1. Remove the diagonal sheen from the locked Build card

While the initial AI build runs, the Build card swept a skewed translucent gradient across itself. It read as decoration rather than signal, and was most obvious in dark mode.

The card still shows the spinner, pulsing rings, indeterminate progress bar and breathing glow, so the "work in progress" state loses nothing.

## 2. Give every form field one outline instead of two

Fields drew a thick, saturated blue ring floating 2px clear of their own border, so every input read as two concentric outlines — a grey edge inside a blue one. The ring was a stock accent that matched no other surface on the site.

**The outer edge was not coming from the fields.** `BaseLayout` applied this to every focusable descendant in the app, on top of whatever each field declared:

```
[&_*:focus-visible]:outline-2 [&_*:focus-visible]:outline-blue-500/40 [&_*:focus-visible]:outline-offset-2
```

Confirmed by capturing computed style at the moment of focus — the field reported `outline: rgba(59,130,246,0.4) solid 2px; outline-offset: 2px`, values that appear nowhere in its own classes. That blanket rule now excludes native form fields, so buttons, links and cards keep the detached blue ring (correct for keyboard focus) while fields own their own treatment.

Fields now draw **exactly one edge** — their border — in a single neutral ink family: 12% at rest, 25% on hover, 45% on focus. No accent colour, no ring, no halo.

The recipe lives in `shared/styles/forms.ts` and is consumed by auth, project creation, payments, and the Sell/Operate/Marketing `ui.input` strings, replacing four near-duplicate copies. The builder chat shell and check-in textarea, which style focus in hand-written CSS, match it.

That file's comment records why `ring-*` can't be used on a field: a ring is a box-shadow drawn outside the element, so it composites over the *page* background while the border composites over the *field's* background. Even a `ring-1` declaring the identical colour as the border lands as a visibly different tone.

## Worth a look during review

Keyboard focus on a field is now the border deepening to 45% rather than a blue ring. Deliberate, but a quieter cue than before — if it feels too subtle when tabbing through a form, the fix is more contrast on that single border, not a second edge.

## Testing

- Verified in the browser in light and dark mode on the sign-in and project-creation forms, including at 3x magnification to confirm a single edge.
- `npm run type-check`, `build-only` and `lint` all pass — 0 errors; the 62 lint warnings are pre-existing and unchanged.
- The locked Build card was not exercised in the browser: it needs a project sitting in `generating` status. The change is a deletion of a self-contained element plus its CSS, with no references left in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)