### PR TITLE
Run the initial build as a dispatched subagent, gated on a working frontend

### DIFF
--- a/backend/django/apps/Imagi/Build/services/base_agent.py
+++ b/backend/django/apps/Imagi/Build/services/base_agent.py
@@ -450,7 +450,12 @@ class ImagiAgentService:
     construction, and the run loop around that agent.
     """
 
-    def __init__(self, model: str = DEFAULT_MODEL, reasoning_effort: Optional[str] = None):
+    def __init__(
+        self,
+        model: str = DEFAULT_MODEL,
+        reasoning_effort: Optional[str] = None,
+        agent_kind: Optional[str] = None,
+    ):
         """
         Initialize the agent service.
 
@@ -458,9 +463,16 @@ class ImagiAgentService:
             model: The OpenAI model to use (default: gpt-5.6-terra)
             reasoning_effort: How much reasoning the model should use
                 ('low', 'medium', 'high'). None uses the model default.
+            agent_kind: Run the agent in this role regardless of the
+                conversation's own kind. The initial build uses it to get the
+                first-build persona (INITIAL_BUILD_INSTRUCTIONS) while its
+                conversation stays an ordinary kind='task' — so it keeps the
+                worktree isolation, review lifecycle and check-in routing every
+                other dispatched task has. None follows the conversation.
         """
         self.model = model
         self.reasoning_effort = reasoning_effort
+        self.agent_kind = agent_kind
         # Agents cached per conversation kind: lead runs carry the delegation
         # tool, task runs carry ask_user (+ its stop behavior).
         self._agents: Dict[str, Agent] = {}
@@ -786,8 +798,10 @@ class ImagiAgentService:
             current_file=current_file,
         )
         # The `agent` property builds the kind-matched variant (delegation
-        # tools for lead, ask_user for task) from here on.
-        self._run_kind = conversation.kind
+        # tools for lead, ask_user for task) from here on. An explicit
+        # agent_kind wins: it selects the persona while the conversation keeps
+        # its own kind for isolation and lifecycle.
+        self._run_kind = self.agent_kind or conversation.kind
 
         # Build (compacted) conversation history, excluding the message we
         # just persisted — it is appended as the current input below.
@@ -942,15 +956,18 @@ class ImagiAgentService:
 
         Returns True when the changes were applied (the task is now
         'accepted'); False when we deliberately leave it for a manual review —
-        a live canonical run we must not merge across, a merge conflict, a
-        stale base, or any git-level failure. Best-effort by contract: it never
-        raises, so any trouble simply parks the task at 'ready' for the user.
+        a broken frontend import graph, a live canonical run we must not merge
+        across, a merge conflict, a stale base, or any git-level failure.
+        Best-effort by contract: it never raises, so any trouble simply parks
+        the task at 'ready' for the user.
         """
         user = getattr(conversation, 'user', None)
         project_id = getattr(conversation, 'project_id', None)
         # The merge rewrites the canonical tree, so it must not race a chat or
         # lead run editing it — the same guard the accept endpoint applies.
         if user is not None and self._project_has_live_canonical_run(user, project_id):
+            return False
+        if self._worktree_import_problems(conversation):
             return False
         try:
             from ..api.views import _apply_task_worktree, _conversation_project
@@ -961,6 +978,36 @@ class ImagiAgentService:
         except Exception as e:  # pragma: no cover - best effort
             logger.warning(f"Could not auto-apply task worktree: {e}")
             return False
+
+    def _worktree_import_problems(self, conversation) -> List[Dict[str, str]]:
+        """Frontend imports in the task's worktree that point at missing files.
+
+        A run cut short by its turn or cost cap routinely leaves a view or
+        route referencing a component it never wrote. Merging that would take
+        the project's preview down with a "Failed to resolve import" error, so
+        such a task is parked for review instead of applied. Best-effort: if
+        the check itself cannot run, it reports no problems rather than
+        blocking an otherwise fine merge.
+        """
+        worktree_path = getattr(conversation, 'worktree_path', '') or ''
+        if not worktree_path:
+            return []
+        try:
+            from .frontend_integrity import find_unresolved_imports
+            problems = find_unresolved_imports(worktree_path)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning(f"Could not check frontend imports before applying: {e}")
+            return []
+        if problems:
+            logger.warning(
+                "Not auto-applying conversation %s: %d unresolved frontend import(s), "
+                "first is %s -> %s",
+                getattr(conversation, 'id', None),
+                len(problems),
+                problems[0]['file'],
+                problems[0]['import'],
+            )
+        return problems
 
     def _clear_run_started(self, conversation) -> None:
         """Best-effort: mark the conversation's run as finished.
@@ -1269,6 +1316,7 @@ class ImagiAgentService:
             return {"success": False, "error": "Project ID is required"}
 
         conversation = None
+        context = None
         run_state: Dict[str, Any] = {}
         try:
             if not user_input:
@@ -1347,6 +1395,11 @@ class ImagiAgentService:
                     self.add_assistant_message(conversation, capped_note)
                 except Exception:  # pragma: no cover - best effort persistence
                     logger.warning("Could not persist capped-run note", exc_info=True)
+                # A capped run is a finished run: its files are on disk, so it
+                # routes back to the main thread like any other. Without this a
+                # capped task would sit at 'active' forever — never applied,
+                # never reviewed, and never reported to the user.
+                self._finalize_task_run(conversation, context, capped_note)
             return {
                 "success": True,
                 "capped": True,

--- a/backend/django/apps/Imagi/Build/services/coding_agent.py
+++ b/backend/django/apps/Imagi/Build/services/coding_agent.py
@@ -126,6 +126,7 @@ INITIAL_BUILD_GUIDANCE = """Building the first version:
 - Authentication is already done for you: the auth app (sign-in and register pages plus its backend) is prebuilt and secure. Do NOT rebuild, restyle, or modify the auth app beyond leaving its links in place.
 - Do NOT build payment, checkout, cart, or subscription-billing functionality even if the business sells something — the founder installs secure, prebuilt payment pages later from their Sell workspace. Design the marketing/product pages with a clear call-to-action instead of wiring real payments.
 - Work efficiently on a tight build budget: build a cohesive set of pages that looks great and covers the core of the business, then stop. Don't pad it out with dozens of pages or half-finished features — a strong, complete first impression beats a sprawling unfinished one.
+- Finish each page completely before starting the next one, and never leave a reference dangling: every file you import and every component you register must already exist by the time you move on. A single import of a file you didn't write makes the whole app fail to load with a "Failed to resolve import" error, and a build in that state is discarded rather than shown to the founder. If you are running low on budget, stop cleanly — a smaller app that loads beats a bigger one that doesn't.
 - When you finish, briefly summarize what you built. The founder reads it as the first message in their workspace."""
 
 # Full prompt for the initial build role.

--- a/backend/django/apps/Imagi/Build/services/frontend_integrity.py
+++ b/backend/django/apps/Imagi/Build/services/frontend_integrity.py
@@ -1,0 +1,141 @@
+"""
+Static integrity check for a generated project's Vue frontend.
+
+Vite resolves imports when a module is first requested, so a single import
+pointing at a file that was never written takes the whole preview down with
+an "Failed to resolve import ..." internal server error — the page the user
+was about to see is simply blank. An agent run that is cut short (turn or
+cost cap) leaves exactly that state: a view or route referencing a component
+it did not get around to creating.
+
+This module finds those dangling references without booting anything, so a
+run's output can be checked before it reaches the tree the preview serves.
+The scan is deliberately conservative — it only follows import specifiers
+that name a file inside the project (``@/...`` alias or a relative path) and
+resolves them the way Vite's resolver does, so a clean project always scans
+clean.
+"""
+
+import logging
+import os
+import re
+
+logger = logging.getLogger(__name__)
+
+FRONTEND_SRC = os.path.join('frontend', 'vuejs', 'src')
+
+# Files whose import graph Vite serves.
+SCANNED_EXTENSIONS = ('.vue', '.ts', '.tsx', '.js', '.jsx', '.mjs')
+
+# Extensions Vite's resolver appends when an import omits one. Order does not
+# matter here — we only care whether *some* file answers the specifier.
+RESOLVED_EXTENSIONS = (
+    '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.vue', '.json',
+    '.css', '.scss', '.sass', '.svg', '.png', '.jpg', '.jpeg', '.webp', '.gif',
+)
+
+# Directories that never hold project source.
+SKIPPED_DIRS = {'node_modules', 'dist', '.vite-cache', '.git', '__pycache__'}
+
+# `import x from '...'`, `export { x } from '...'`, bare `import '...'`, and
+# dynamic `import('...')`. Anchored on a word boundary before the keyword so a
+# CSS `@import` (or an identifier ending in "import") is not mistaken for one.
+_IMPORT_RE = re.compile(
+    r"(?:^|[\s;{}()])(?:import|export)\s+(?:[\w*{}$,\s]+\s+from\s+)?"
+    r"['\"](?P<static>[^'\"]+)['\"]"
+    r"|(?:^|[^\w.$])import\s*\(\s*['\"](?P<dynamic>[^'\"]+)['\"]\s*\)",
+    re.MULTILINE,
+)
+
+# Specifiers that name a file in this project (everything else is an npm
+# package, which the shared dependency store owns).
+_LOCAL_PREFIXES = ('@/', './', '../')
+
+# A specifier built at runtime is not statically resolvable, and neither is a
+# glob — never report those.
+_DYNAMIC_MARKERS = ('*', '?', '${')
+
+# Bound on what a single report hands back to the agent, so a badly broken
+# tree can't blow up a prompt.
+MAX_REPORTED_PROBLEMS = 25
+
+
+def _iter_source_files(src_root):
+    """Yield every frontend source file Vite would serve, as absolute paths."""
+    for dirpath, dirnames, filenames in os.walk(src_root):
+        dirnames[:] = [d for d in dirnames if d not in SKIPPED_DIRS]
+        for filename in filenames:
+            if filename.endswith(SCANNED_EXTENSIONS):
+                yield os.path.join(dirpath, filename)
+
+
+def _resolves(spec, source_file, src_root):
+    """Whether an import specifier names a file that exists, as Vite resolves it."""
+    if spec.startswith('@/'):
+        target = os.path.join(src_root, spec[2:])
+    else:
+        target = os.path.normpath(os.path.join(os.path.dirname(source_file), spec))
+
+    if os.path.isfile(target):
+        return True
+    for ext in RESOLVED_EXTENSIONS:
+        if os.path.isfile(target + ext):
+            return True
+    # A directory import resolves to its index file.
+    for ext in RESOLVED_EXTENSIONS:
+        if os.path.isfile(os.path.join(target, 'index' + ext)):
+            return True
+    return False
+
+
+def find_unresolved_imports(root):
+    """Find imports in a project's frontend that point at files that don't exist.
+
+    Args:
+        root: The project tree to scan (a project_path or a task worktree).
+
+    Returns:
+        list[dict]: ``{'file': <project-relative path>, 'import': <specifier>}``
+        in a stable order, empty when the frontend's import graph is whole.
+        An unreadable or absent frontend yields [] — this check exists to catch
+        broken references, not to police project layout.
+    """
+    src_root = os.path.join(root or '', FRONTEND_SRC)
+    if not os.path.isdir(src_root):
+        return []
+
+    problems = []
+    for source_file in sorted(_iter_source_files(src_root)):
+        try:
+            with open(source_file, 'r', encoding='utf-8') as f:
+                source = f.read()
+        except (OSError, UnicodeDecodeError) as e:
+            logger.warning(f"Could not read {source_file} for import check: {e}")
+            continue
+
+        seen = set()
+        for match in _IMPORT_RE.finditer(source):
+            spec = match.group('static') or match.group('dynamic')
+            if not spec or spec in seen:
+                continue
+            seen.add(spec)
+            if not spec.startswith(_LOCAL_PREFIXES):
+                continue
+            if any(marker in spec for marker in _DYNAMIC_MARKERS):
+                continue
+            if _resolves(spec, source_file, src_root):
+                continue
+            problems.append({
+                'file': os.path.relpath(source_file, root).replace(os.sep, '/'),
+                'import': spec,
+            })
+    return problems
+
+
+def describe_unresolved_imports(problems):
+    """Render unresolved imports as a bulleted list for an agent prompt."""
+    shown = problems[:MAX_REPORTED_PROBLEMS]
+    lines = [f"- {p['file']} imports '{p['import']}', which does not exist" for p in shown]
+    if len(problems) > len(shown):
+        lines.append(f"- ... and {len(problems) - len(shown)} more")
+    return "\n".join(lines)

--- a/backend/django/apps/Imagi/Build/tests/test_frontend_integrity.py
+++ b/backend/django/apps/Imagi/Build/tests/test_frontend_integrity.py
@@ -1,0 +1,150 @@
+"""
+Tests for the frontend import-integrity check.
+
+The check gates what reaches the tree the preview serves, so both directions
+matter: it must catch a reference to a file that was never written, and it
+must never flag a project that is actually fine — a false positive would
+discard a perfectly good build.
+"""
+
+import os
+import shutil
+import tempfile
+
+from django.test import TestCase
+
+from apps.Imagi.Build.services.frontend_integrity import (
+    describe_unresolved_imports,
+    find_unresolved_imports,
+)
+
+
+class FrontendIntegrityTests(TestCase):
+    def setUp(self):
+        self.root = tempfile.mkdtemp(prefix='imagi-integrity-')
+        self.src = os.path.join(self.root, 'frontend', 'vuejs', 'src')
+        os.makedirs(self.src)
+        self.addCleanup(shutil.rmtree, self.root, True)
+
+    def _write(self, rel_path, content):
+        path = os.path.join(self.src, rel_path)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, 'w') as f:
+            f.write(content)
+        return path
+
+    def _imports(self):
+        return find_unresolved_imports(self.root)
+
+    def test_no_frontend_is_not_a_problem(self):
+        self.assertEqual(find_unresolved_imports(tempfile.mkdtemp()), [])
+
+    def test_missing_aliased_file_is_reported(self):
+        self._write(
+            'apps/home/views/HomeView.vue',
+            "<script setup lang=\"ts\">\n"
+            "import SiteHeader from '@/shared/components/SiteHeader.vue'\n"
+            "</script>\n",
+        )
+        self.assertEqual(self._imports(), [{
+            'file': 'frontend/vuejs/src/apps/home/views/HomeView.vue',
+            'import': '@/shared/components/SiteHeader.vue',
+        }])
+
+    def test_missing_relative_file_is_reported(self):
+        self._write('apps/home/views/HomeView.vue', "import X from './Missing.vue'\n")
+        self.assertEqual(
+            [p['import'] for p in self._imports()], ['./Missing.vue']
+        )
+
+    def test_missing_lazy_route_component_is_reported(self):
+        # The most common shape a cut-short build leaves behind: a route
+        # pointing at a page the agent never got around to writing.
+        self._write(
+            'apps/home/router/index.ts',
+            "const routes = [\n"
+            "  { path: '/pricing', component: () => import('../views/Pricing.vue') },\n"
+            "]\n",
+        )
+        self.assertEqual(
+            [p['import'] for p in self._imports()], ['../views/Pricing.vue']
+        )
+
+    def test_resolved_imports_are_not_reported(self):
+        self._write('shared/components/SiteHeader.vue', '<template><header /></template>\n')
+        self._write('apps/home/views/Pricing.vue', '<template><div /></template>\n')
+        self._write('apps/home/stores/index.ts', "export const useHome = () => {}\n")
+        self._write('assets/css/main.css', 'body { margin: 0; }\n')
+        self._write(
+            'apps/home/views/HomeView.vue',
+            "<script setup lang=\"ts\">\n"
+            "import SiteHeader from '@/shared/components/SiteHeader.vue'\n"
+            "import { useHome } from '../stores'\n"  # directory -> index.ts
+            "const Pricing = () => import('./Pricing.vue')\n"
+            "</script>\n",
+        )
+        self._write('main.ts', "import './assets/css/main.css'\n")
+        self.assertEqual(self._imports(), [])
+
+    def test_package_imports_are_ignored(self):
+        # npm packages live in the shared dependency store, not the project.
+        self._write(
+            'main.ts',
+            "import { createApp } from 'vue'\n"
+            "import axios from 'axios'\n"
+            "import { faUser } from '@fortawesome/free-solid-svg-icons'\n",
+        )
+        self.assertEqual(self._imports(), [])
+
+    def test_extensionless_and_index_imports_resolve(self):
+        self._write('shared/services/api.ts', 'export default {}\n')
+        self._write('shared/stores/index.ts', 'export const s = 1\n')
+        self._write(
+            'apps/home/views/HomeView.vue',
+            "import api from '@/shared/services/api'\n"
+            "import { s } from '@/shared/stores'\n",
+        )
+        self.assertEqual(self._imports(), [])
+
+    def test_css_at_import_is_not_treated_as_a_module_import(self):
+        self._write(
+            'apps/home/views/HomeView.vue',
+            "<style>\n@import './nowhere.css';\n</style>\n",
+        )
+        self.assertEqual(self._imports(), [])
+
+    def test_dynamic_specifiers_are_skipped(self):
+        # A runtime-built path can't be checked statically; reporting it would
+        # discard a build over something that may well be fine.
+        self._write(
+            'apps/home/views/HomeView.vue',
+            "const load = (n) => import(`../views/${n}.vue`)\n",
+        )
+        self.assertEqual(self._imports(), [])
+
+    def test_node_modules_is_not_scanned(self):
+        self._write('../node_modules/pkg/index.js', "import x from './missing.js'\n")
+        self.assertEqual(self._imports(), [])
+
+    def test_each_broken_specifier_is_reported_once_per_file(self):
+        self._write(
+            'apps/home/views/HomeView.vue',
+            "import A from './Missing.vue'\n"
+            "import B from './Missing.vue'\n",
+        )
+        self.assertEqual(len(self._imports()), 1)
+
+    def test_description_lists_every_problem(self):
+        problems = [
+            {'file': 'a.vue', 'import': './x.vue'},
+            {'file': 'b.vue', 'import': '@/y.vue'},
+        ]
+        described = describe_unresolved_imports(problems)
+        self.assertIn('a.vue', described)
+        self.assertIn('./x.vue', described)
+        self.assertIn('@/y.vue', described)
+
+    def test_description_truncates_a_badly_broken_tree(self):
+        problems = [{'file': f'{i}.vue', 'import': './x.vue'} for i in range(40)]
+        described = describe_unresolved_imports(problems)
+        self.assertIn('and 15 more', described)

--- a/backend/django/apps/Imagi/Build/tests/test_task_worktrees.py
+++ b/backend/django/apps/Imagi/Build/tests/test_task_worktrees.py
@@ -717,6 +717,93 @@ class TaskCheckInTests(GitRepoTestMixin, TestCase):
         self.assertNotEqual(task.worktree_path, '')
         self.assertFalse(os.path.exists(os.path.join(self.repo, 'feature.txt')))
 
+    def _worktree_with_frontend(self, task, home_view_source):
+        """Give a task a worktree whose frontend holds one generated view."""
+        worktree = VersionControlService().create_task_worktree(
+            self.repo, task.id
+        )['worktree_path']
+        views_dir = os.path.join(
+            worktree, 'frontend', 'vuejs', 'src', 'apps', 'home', 'views'
+        )
+        os.makedirs(views_dir, exist_ok=True)
+        with open(os.path.join(views_dir, 'HomeView.vue'), 'w') as f:
+            f.write(home_view_source)
+        task.worktree_path = worktree
+        task.save(update_fields=['worktree_path'])
+        return worktree
+
+    def test_auto_apply_defers_to_review_when_the_frontend_has_dangling_imports(self):
+        # A run cut short by its turn or cost cap leaves a page importing a
+        # component it never wrote. Merging that takes the project's preview
+        # down with a "Failed to resolve import" error, so it is parked for
+        # review and the canonical tree keeps what already works.
+        task = self._task()
+        self._worktree_with_frontend(
+            task,
+            "<script setup lang=\"ts\">\n"
+            "import SiteHeader from '@/shared/components/SiteHeader.vue'\n"
+            "</script>\n",
+        )
+
+        self.service._finalize_task_run(task, self._context(), 'Built the landing page.')
+
+        task.refresh_from_db()
+        self.assertEqual(task.review_status, 'ready')
+        self.assertNotEqual(task.worktree_path, '')
+        self.assertFalse(
+            os.path.exists(os.path.join(self.repo, 'frontend', 'vuejs', 'src'))
+        )
+
+    def test_auto_apply_proceeds_when_every_import_resolves(self):
+        task = self._task()
+        worktree = self._worktree_with_frontend(
+            task,
+            "<script setup lang=\"ts\">\n"
+            "import SiteHeader from '@/shared/components/SiteHeader.vue'\n"
+            "import { ref } from 'vue'\n"
+            "</script>\n",
+        )
+        shared_dir = os.path.join(worktree, 'frontend', 'vuejs', 'src', 'shared', 'components')
+        os.makedirs(shared_dir, exist_ok=True)
+        with open(os.path.join(shared_dir, 'SiteHeader.vue'), 'w') as f:
+            f.write('<template><header /></template>\n')
+
+        self.service._finalize_task_run(task, self._context(), 'Built the landing page.')
+
+        task.refresh_from_db()
+        self.assertEqual(task.review_status, 'accepted')
+        self.assertTrue(os.path.exists(os.path.join(
+            self.repo, 'frontend', 'vuejs', 'src', 'shared', 'components', 'SiteHeader.vue'
+        )))
+
+    def test_capped_run_still_routes_the_task_back(self):
+        # A run stopped by its turn or cost cap has already written files; if
+        # it did not finalize, the task would sit at 'active' forever — never
+        # applied, never reviewed, and never reported to the user.
+        from agents import MaxTurnsExceeded
+
+        task = self._task()
+        self._worktree_with_change(task)
+
+        with patch.object(
+            self.service, '_prepare_run',
+            return_value=(task, self._context(), [{'role': 'user', 'content': 'go'}]),
+        ), patch(
+            'apps.Imagi.Build.services.base_agent.Runner.run_sync',
+            side_effect=MaxTurnsExceeded('out of turns'),
+        ):
+            result = self.service.process(
+                user_input='go', user=self.user, project_id=self.project.id,
+                conversation_id=task.id,
+            )
+
+        self.assertTrue(result.get('capped'))
+        task.refresh_from_db()
+        self.assertEqual(task.review_status, 'accepted')
+        self.assertTrue(
+            AgentCheckIn.objects.filter(conversation=task, status='pending').exists()
+        )
+
     def test_auto_apply_defers_to_review_while_a_canonical_run_is_live(self):
         task = self._task()
         self._worktree_with_change(task)

--- a/backend/django/apps/Imagi/ProjectManager/services/initial_build_service.py
+++ b/backend/django/apps/Imagi/ProjectManager/services/initial_build_service.py
@@ -7,9 +7,22 @@ agent. The build runs in a background thread so project creation stays
 fast; by the time the user enters build mode the workspace already has a
 tailored starting point instead of the generic scaffold.
 
+It runs the same way every other piece of building work does: the project's
+main thread (the 'lead' conversation) opens with the founder's brief and
+dispatches it to a background subagent (a 'task' conversation). That gives
+the first build the machinery every task already has — it builds in its own
+git worktree, so the project the preview serves is never half-written, and
+its result is merged in one step when it is finished and sound.
+
+"Sound" is enforced, not hoped for: a build cut short by its turn or cost cap
+routinely leaves a page importing a component it never wrote, and Vite serves
+that as a "Failed to resolve import" error instead of the app. Before the
+worktree is merged, the frontend's import graph is checked; a build with
+dangling references gets follow-up repair runs, and one that still doesn't
+resolve is never merged — the project keeps its clean, working scaffold.
+
 Build progress is tracked on the existing Project.generation_status field
-('generating' -> 'completed'/'failed'), and the run is persisted as an
-"Initial build" agent conversation so it shows up in the workspace chat.
+('generating' -> 'completed'/'failed').
 """
 
 import logging
@@ -20,6 +33,18 @@ from django.db import close_old_connections
 from django.utils import timezone
 
 logger = logging.getLogger(__name__)
+
+# Shown in the workspace as the subagent's thread name.
+TASK_TITLE = 'Initial build'
+
+# The lead thread's one-line acknowledgement, mirroring how it reports any
+# dispatch it makes. Written directly rather than generated: the lead's only
+# job here is to hand the brief over, and a model call to produce one fixed
+# sentence would just add latency and cost to project creation.
+LEAD_ACK = (
+    "On it — I've kicked off a subagent to build the first version of your app. "
+    "You can watch it work in its thread; I'll let you know when it's done."
+)
 
 
 def build_initial_prompt(name: str, description: str, design_preferences: str = "") -> str:
@@ -48,6 +73,23 @@ Business description (written by the founder):
         "what you built."
     )
     return prompt
+
+
+def build_repair_prompt(problems) -> str:
+    """Ask the subagent to fix imports that point at files it never created."""
+    from apps.Imagi.Build.services.frontend_integrity import describe_unresolved_imports
+
+    return (
+        "Your build is not finished: the frontend imports files that do not "
+        "exist, so the app fails to load with a \"Failed to resolve import\" "
+        "error. Fix every one of these:\n\n"
+        f"{describe_unresolved_imports(problems)}\n\n"
+        "For each: either create the missing file properly, or remove the "
+        "import and whatever depends on it (including its route entry). Do not "
+        "start any new pages or features — this run is only to make what you "
+        "already built load cleanly. Verify with grep_files/read_file that every "
+        "path you reference exists, then summarize what you fixed."
+    )
 
 
 def start_initial_build(project, user) -> bool:
@@ -82,60 +124,121 @@ def start_initial_build(project, user) -> bool:
     return True
 
 
+def _ensure_lead_conversation(service, user, project_id, model):
+    """The project's main thread, created if this is its first use.
+
+    The workspace converges on the same row (its create endpoint returns an
+    existing live lead rather than making a second one), so opening it here
+    means the founder finds the first build already in their main thread
+    instead of an empty workspace.
+    """
+    from apps.Imagi.Build.models import AgentConversation
+
+    lead = AgentConversation.objects.filter(
+        user=user, project_id=project_id, kind='lead', archived_at__isnull=True
+    ).order_by('created_at').first()
+    if lead is not None:
+        return lead
+    return service.create_conversation(
+        user, model, project_id=project_id, title='Main thread', kind='lead'
+    )
+
+
+def _open_lead_thread(service, lead, prompt, task):
+    """Record the dispatch in the main thread, the way a real one reads.
+
+    The founder's brief becomes the opening user message and the lead's
+    acknowledgement carries a reference to the subagent's thread, so the
+    transcript and its "watch the subagent" link match every later dispatch.
+    """
+    from apps.Imagi.Build.services.base_agent import (
+        build_message_metadata,
+        dispatch_task_refs,
+    )
+
+    service.add_user_message(lead, prompt)
+    service.add_assistant_message(
+        lead,
+        LEAD_ACK,
+        build_message_metadata(
+            dispatched_tasks=dispatch_task_refs(
+                [{'conversation_id': task.id, 'title': task.title}]
+            )
+        ),
+    )
+
+
+def _create_build_task(user, lead, project_id, model, prompt):
+    """Create the subagent conversation the first build runs in.
+
+    An ordinary kind='task' child of the lead: it gets a git worktree of its
+    own, auto-applies when it finishes cleanly, and reports back through the
+    lead's check-in queue — all of it existing machinery.
+    """
+    from apps.Imagi.Build.models import AgentConversation, SystemPrompt
+    from apps.Imagi.Build.services.coding_agent import INITIAL_BUILD_INSTRUCTIONS
+
+    task = AgentConversation.objects.create(
+        user=user,
+        model_name=model,
+        project_id=project_id,
+        mode='agent',
+        title=TASK_TITLE,
+        kind='task',
+        parent=lead,
+        review_status='active',
+        queued_prompt=prompt,
+    )
+    SystemPrompt.objects.create(
+        conversation=task, content=INITIAL_BUILD_INSTRUCTIONS
+    )
+    return task
+
+
 def _run_initial_build(project_id: int, user_id: int) -> None:
-    """Thread body: run the coding agent with the business description prompt."""
+    """Thread body: dispatch the first build to a subagent and land its work."""
     close_old_connections()
     from ..models import Project
 
     try:
         from django.contrib.auth import get_user_model
         from apps.Imagi.Build.services.base_agent import ImagiAgentService
-        from apps.Imagi.Build.services.coding_agent import INITIAL_BUILD_INSTRUCTIONS
 
         project = Project.objects.get(pk=project_id)
         user = get_user_model().objects.get(pk=user_id)
 
         builder = getattr(settings, 'IMAGI_BUILDER', {})
+        model = builder.get('INITIAL_BUILD_MODEL') or builder.get('DEFAULT_MODEL')
 
-        service = ImagiAgentService()
-        conversation = service.create_conversation(
-            user,
-            service.model,
-            project_id=project_id,
-            title='Initial build',
-            kind='initial_build',
-            system_prompt=INITIAL_BUILD_INSTRUCTIONS,
+        # agent_kind pins the first-build persona (its prompt and design
+        # direction) onto what is otherwise a plain background task.
+        service = ImagiAgentService(model=model, agent_kind='initial_build')
+
+        prompt = build_initial_prompt(
+            project.name,
+            project.description,
+            getattr(project, 'design_preferences', ''),
         )
 
-        result = service.process(
-            user_input=build_initial_prompt(
-                project.name,
-                project.description,
-                getattr(project, 'design_preferences', ''),
-            ),
-            user=user,
-            project_id=project_id,
-            conversation_id=conversation.id,
-            max_turns=builder.get('INITIAL_BUILD_MAX_TURNS'),
-            cost_budget_usd=builder.get('INITIAL_BUILD_COST_BUDGET_USD'),
-        )
+        lead = _ensure_lead_conversation(service, user, project_id, model)
+        task = _create_build_task(user, lead, project_id, model, prompt)
+        _open_lead_thread(service, lead, prompt, task)
 
-        if result.get('success'):
+        applied = _build_and_apply(service, task, user, project_id, prompt, builder)
+
+        if applied:
             Project.objects.filter(pk=project_id).update(
                 generation_status='completed',
                 last_generated_at=timezone.now(),
             )
-            logger.info(
-                "Initial AI build completed for project %s (files changed: %s)",
-                project_id,
-                result.get('files_changed'),
-            )
+            logger.info("Initial AI build completed and applied for project %s", project_id)
         else:
+            # The project still holds its complete, working scaffold — the
+            # unmerged build sits in the workspace for the user to look at.
             Project.objects.filter(pk=project_id).update(generation_status='failed')
             logger.error(
-                "Initial AI build failed for project %s: %s",
+                "Initial AI build for project %s was not applied; project kept its scaffold",
                 project_id,
-                result.get('error'),
             )
     except Exception:
         logger.exception("Initial AI build crashed for project %s", project_id)
@@ -145,3 +248,76 @@ def _run_initial_build(project_id: int, user_id: int) -> None:
             pass
     finally:
         close_old_connections()
+
+
+def _build_and_apply(service, task, user, project_id, prompt, builder):
+    """Run the build, repairing dangling imports until the work can be applied.
+
+    Each run ends in the usual task finalization, which merges the worktree
+    only when its frontend actually resolves. So "was it applied?" is read
+    back off the conversation, and anything left unmerged with unresolved
+    imports gets a targeted repair run. Returns whether the work landed in
+    the project.
+    """
+    from apps.Imagi.Build.services.frontend_integrity import find_unresolved_imports
+
+    attempts = builder.get('INITIAL_BUILD_REPAIR_ATTEMPTS', 2)
+    user_input = prompt
+    max_turns = builder.get('INITIAL_BUILD_MAX_TURNS')
+    cost_budget = builder.get('INITIAL_BUILD_COST_BUDGET_USD')
+
+    for attempt in range(attempts + 1):
+        result = service.process(
+            user_input=user_input,
+            user=user,
+            project_id=project_id,
+            conversation_id=task.id,
+            max_turns=max_turns,
+            cost_budget_usd=cost_budget,
+        )
+        if not result.get('success'):
+            logger.error(
+                "Initial AI build run failed for project %s: %s",
+                project_id,
+                result.get('error'),
+            )
+            return False
+
+        task.refresh_from_db()
+        if task.review_status == 'accepted':
+            return True
+
+        # Not applied. Unresolved imports are the one cause worth another run;
+        # anything else (a merge conflict, a git failure) needs the user.
+        problems = find_unresolved_imports(task.worktree_path)
+        if not problems:
+            logger.error(
+                "Initial AI build for project %s finished but could not be applied "
+                "(review status %r)",
+                project_id,
+                task.review_status,
+            )
+            return False
+        if attempt >= attempts:
+            logger.error(
+                "Initial AI build for project %s still has %d unresolved import(s) "
+                "after %d repair attempt(s)",
+                project_id,
+                len(problems),
+                attempts,
+            )
+            return False
+
+        logger.warning(
+            "Initial AI build for project %s left %d unresolved import(s); "
+            "starting repair run %d/%d",
+            project_id,
+            len(problems),
+            attempt + 1,
+            attempts,
+        )
+        user_input = build_repair_prompt(problems)
+        max_turns = builder.get('INITIAL_BUILD_REPAIR_MAX_TURNS')
+        cost_budget = builder.get('INITIAL_BUILD_REPAIR_COST_BUDGET_USD')
+
+    return False

--- a/backend/django/apps/Imagi/ProjectManager/tests.py
+++ b/backend/django/apps/Imagi/ProjectManager/tests.py
@@ -403,59 +403,136 @@ class InitialBuildServiceTests(TestCase):
         mock_thread.assert_called_once()
         mock_thread.return_value.start.assert_called_once()
 
-    def _run_with_agent_result(self, result):
-        from unittest.mock import Mock
+    def _run_build(self, outcomes, unresolved=()):
+        """Drive a full initial build with the agent run itself stubbed out.
+
+        Everything around the model call is real — the lead and task
+        conversations, their messages, and the applied/not-applied decision
+        read back off the task — so these tests exercise the actual wiring.
+
+        Args:
+            outcomes: one entry per expected run. 'accept' stands in for a run
+                whose worktree merged cleanly (the real finalization sets
+                review_status='accepted'), 'leave' for one that finished
+                without being applied, and 'fail' for a failed run.
+            unresolved: dangling imports the integrity check should report on
+                an unapplied worktree, which is what triggers a repair run.
+
+        Returns the kwargs of every process() call made.
+        """
         from apps.Imagi.ProjectManager.services import initial_build_service
+        from apps.Imagi.Build.models import AgentConversation
         from apps.Imagi.Build.services.base_agent import ImagiAgentService
 
-        # spec= the real class so this test fails if the service API drifts
-        # (a bare Mock once hid a rename that broke every initial build).
-        fake_service = Mock(spec=ImagiAgentService)
-        fake_service.model = 'gpt-5.6-sol'
-        fake_service.create_conversation.return_value = Mock(id=42)
-        fake_service.process.return_value = result
+        calls = []
+        pending = list(outcomes)
 
-        with patch(
-            'apps.Imagi.Build.services.base_agent.ImagiAgentService',
-            return_value=fake_service,
+        def fake_process(_self, **kwargs):
+            calls.append(kwargs)
+            outcome = pending.pop(0) if pending else 'leave'
+            if outcome == 'fail':
+                return {'success': False, 'error': 'model error'}
+            if outcome == 'accept':
+                AgentConversation.objects.filter(
+                    id=kwargs['conversation_id']
+                ).update(review_status='accepted')
+            else:
+                AgentConversation.objects.filter(
+                    id=kwargs['conversation_id']
+                ).update(review_status='ready')
+            return {'success': True, 'files_changed': []}
+
+        with patch.object(ImagiAgentService, 'process', fake_process), patch(
+            'apps.Imagi.Build.services.frontend_integrity.find_unresolved_imports',
+            return_value=list(unresolved),
         ):
             initial_build_service._run_initial_build(self.project.pk, self.user.pk)
-        return fake_service
+        return calls
 
-    def test_run_success_marks_completed_and_prompts_with_business_details(self):
-        fake_service = self._run_with_agent_result(
-            {'success': True, 'files_changed': ['frontend/vuejs/src/apps/home/views/Home.vue']}
-        )
+    def test_applied_build_marks_completed_and_prompts_with_business_details(self):
+        calls = self._run_build(['accept'])
 
         self.project.refresh_from_db()
         self.assertEqual(self.project.generation_status, 'completed')
         self.assertIsNotNone(self.project.last_generated_at)
 
         # The prompt must carry the business name and description into the agent.
-        prompt = fake_service.process.call_args.kwargs['user_input']
+        self.assertEqual(len(calls), 1)
+        prompt = calls[0]['user_input']
         self.assertIn('Beanline', prompt)
         self.assertIn('coffee roastery', prompt)
 
-        # The conversation runs as the dedicated initial-build role, carrying
-        # the initial-build system prompt.
-        from apps.Imagi.Build.services.coding_agent import INITIAL_BUILD_INSTRUCTIONS
-        conv_kwargs = fake_service.create_conversation.call_args.kwargs
-        self.assertEqual(fake_service.create_conversation.call_args.args,
-                         (self.user, 'gpt-5.6-sol'))
-        self.assertEqual(conv_kwargs['project_id'], self.project.pk)
-        self.assertEqual(conv_kwargs['title'], 'Initial build')
-        self.assertEqual(conv_kwargs['kind'], 'initial_build')
-        self.assertEqual(conv_kwargs['system_prompt'], INITIAL_BUILD_INSTRUCTIONS)
-
         # The run must be bounded by the initial-build turn and cost caps.
-        proc_kwargs = fake_service.process.call_args.kwargs
-        self.assertEqual(proc_kwargs['cost_budget_usd'],
+        self.assertEqual(calls[0]['cost_budget_usd'],
                          settings.IMAGI_BUILDER['INITIAL_BUILD_COST_BUDGET_USD'])
-        self.assertEqual(proc_kwargs['max_turns'],
+        self.assertEqual(calls[0]['max_turns'],
                          settings.IMAGI_BUILDER['INITIAL_BUILD_MAX_TURNS'])
 
+    def test_build_runs_as_a_subagent_dispatched_from_the_main_thread(self):
+        from apps.Imagi.Build.models import AgentConversation
+        from apps.Imagi.Build.services.coding_agent import INITIAL_BUILD_INSTRUCTIONS
+
+        calls = self._run_build(['accept'])
+
+        lead = AgentConversation.objects.get(
+            user=self.user, project_id=self.project.pk, kind='lead'
+        )
+        task = AgentConversation.objects.get(
+            user=self.user, project_id=self.project.pk, kind='task'
+        )
+        # The build is an ordinary background task of the project's main
+        # thread, so it inherits the worktree isolation and review lifecycle
+        # every dispatched task has.
+        self.assertEqual(task.parent_id, lead.id)
+        self.assertEqual(task.title, 'Initial build')
+        self.assertEqual(task.system_prompt.content, INITIAL_BUILD_INSTRUCTIONS)
+        self.assertEqual(calls[0]['conversation_id'], task.id)
+
+        # The main thread opens with the founder's brief and a one-line
+        # acknowledgement linking to the subagent's thread.
+        messages = list(lead.messages.order_by('created_at'))
+        self.assertEqual([m.role for m in messages], ['user', 'assistant'])
+        self.assertIn('Beanline', messages[0].content)
+        self.assertEqual(
+            messages[1].metadata['dispatched_tasks'],
+            [{'conversation_id': task.id, 'title': 'Initial build'}],
+        )
+
+    def test_build_runs_on_the_configured_initial_build_model(self):
+        from apps.Imagi.Build.models import AgentConversation
+
+        self._run_build(['accept'])
+
+        task = AgentConversation.objects.get(
+            user=self.user, project_id=self.project.pk, kind='task'
+        )
+        self.assertEqual(
+            task.model_name, settings.IMAGI_BUILDER['INITIAL_BUILD_MODEL']
+        )
+
+    def test_reuses_an_existing_main_thread(self):
+        from apps.Imagi.Build.models import AgentConversation
+        from apps.Imagi.Build.services.base_agent import ImagiAgentService
+
+        existing = ImagiAgentService().create_conversation(
+            self.user, 'gpt-5.6-terra', project_id=self.project.pk, kind='lead'
+        )
+        self._run_build(['accept'])
+
+        # A second live lead would violate the single-lead invariant.
+        self.assertEqual(
+            AgentConversation.objects.filter(
+                user=self.user, project_id=self.project.pk, kind='lead'
+            ).count(),
+            1,
+        )
+        task = AgentConversation.objects.get(
+            user=self.user, project_id=self.project.pk, kind='task'
+        )
+        self.assertEqual(task.parent_id, existing.id)
+
     def test_run_failure_marks_failed(self):
-        self._run_with_agent_result({'success': False, 'error': 'model error'})
+        self._run_build(['fail'])
         self.project.refresh_from_db()
         self.assertEqual(self.project.generation_status, 'failed')
 
@@ -463,20 +540,57 @@ class InitialBuildServiceTests(TestCase):
         self.project.design_preferences = 'Warm, earthy palette; minimal, lots of whitespace'
         self.project.save(update_fields=['design_preferences'])
 
-        fake_service = self._run_with_agent_result({'success': True, 'files_changed': []})
+        calls = self._run_build(['accept'])
 
-        prompt = fake_service.process.call_args.kwargs['user_input']
-        self.assertIn('Warm, earthy palette', prompt)
+        self.assertIn('Warm, earthy palette', calls[0]['user_input'])
 
-    def test_capped_run_still_marks_completed(self):
-        # A run stopped by the turn/cost cap returns success with capped=True;
-        # the files it produced are on disk, so the build counts as completed.
-        fake_service = self._run_with_agent_result(
-            {'success': True, 'capped': True, 'files_changed': []}
+    def test_dangling_imports_trigger_a_repair_run_before_applying(self):
+        # A build cut short by its cost cap can leave a page importing a
+        # component it never wrote. That must not reach the project: the
+        # subagent gets a repair run naming the broken references first.
+        calls = self._run_build(
+            ['leave', 'accept'],
+            unresolved=[{
+                'file': 'frontend/vuejs/src/apps/home/views/HomeView.vue',
+                'import': '@/shared/components/SiteHeader.vue',
+            }],
         )
+
+        self.assertEqual(len(calls), 2)
+        repair_prompt = calls[1]['user_input']
+        self.assertIn('@/shared/components/SiteHeader.vue', repair_prompt)
+        self.assertIn('HomeView.vue', repair_prompt)
+        # Repairs run on their own tighter budget.
+        self.assertEqual(calls[1]['cost_budget_usd'],
+                         settings.IMAGI_BUILDER['INITIAL_BUILD_REPAIR_COST_BUDGET_USD'])
+        self.assertEqual(calls[1]['max_turns'],
+                         settings.IMAGI_BUILDER['INITIAL_BUILD_REPAIR_MAX_TURNS'])
+
         self.project.refresh_from_db()
         self.assertEqual(self.project.generation_status, 'completed')
-        self.assertTrue(fake_service.process.called)
+
+    def test_unrepairable_build_is_not_applied(self):
+        # After the repair budget is spent the build is abandoned rather than
+        # merged, so the project keeps the scaffold its preview can serve.
+        attempts = settings.IMAGI_BUILDER['INITIAL_BUILD_REPAIR_ATTEMPTS']
+        calls = self._run_build(
+            ['leave'] * (attempts + 1),
+            unresolved=[{
+                'file': 'frontend/vuejs/src/apps/home/views/HomeView.vue',
+                'import': '@/shared/components/SiteHeader.vue',
+            }],
+        )
+
+        self.assertEqual(len(calls), attempts + 1)
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.generation_status, 'failed')
+
+    def test_unapplied_build_without_dangling_imports_is_not_retried(self):
+        # A merge conflict or git failure is not something another run fixes.
+        calls = self._run_build(['leave'], unresolved=[])
+        self.assertEqual(len(calls), 1)
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.generation_status, 'failed')
 
 
 @override_settings(PROJECTS_ROOT=_TMP_PROJECTS_ROOT)

--- a/backend/django/imagi/settings.py
+++ b/backend/django/imagi/settings.py
@@ -263,13 +263,23 @@ IMAGI_BUILDER = {
     'DEFAULT_REASONING_EFFORT': 'medium',
     # Upper bound on agent-loop iterations for a single request.
     'MAX_AGENT_TURNS': 30,
-    # Initial build (the one-shot first build of a new project) runs headless
-    # and unattended, so it gets its own tighter caps. The cost budget is the
-    # primary bound: the run stops once its token cost reaches this many
+    # Initial build (the first build of a new project, dispatched from the
+    # project's main thread to a background subagent) runs headless and
+    # unattended, so it gets its own model and tighter caps. The cost budget is
+    # the primary bound: the run stops once its token cost reaches this many
     # dollars. The turn cap is a backstop against a run that spins without
     # spending much. Together they keep a first build from running away.
+    'INITIAL_BUILD_MODEL': 'gpt-5.6-terra',
     'INITIAL_BUILD_COST_BUDGET_USD': 0.50,
     'INITIAL_BUILD_MAX_TURNS': 24,
+    # A build that stops at one of those caps can leave a page importing a
+    # component it never wrote, which takes the whole preview down. Such a
+    # build is not merged into the project; instead the subagent gets up to
+    # this many follow-up runs to repair the dangling references, each on a
+    # smaller budget (repair is a short, targeted job).
+    'INITIAL_BUILD_REPAIR_ATTEMPTS': 2,
+    'INITIAL_BUILD_REPAIR_COST_BUDGET_USD': 0.20,
+    'INITIAL_BUILD_REPAIR_MAX_TURNS': 12,
     # Attach OpenAI's hosted web-search tool to the agent.
     'ENABLE_WEB_SEARCH': True,
     # Apps scaffolded into every new project. Payment pages are deliberately


### PR DESCRIPTION
## What was broken

**The preview error.** The initial build edited the *canonical* project tree — the same tree the preview's Vite dev server serves. The agent writes `HomeView.vue` containing `import SiteHeader from '@/shared/components/SiteHeader.vue'`, and until it writes that component, Vite answers with a 500. A build cut short by its `$0.50` cost budget or 24-turn cap leaves that dangling import *permanently*. Reproduced against a real generated project:

```
[vite:load-fallback] Could not load .../src/shared/components/SiteHeader.vue
  (imported by src/apps/home/views/HomeView.vue)
```

**A production-only crash.** The build created its conversation with `kind='initial_build'` — 13 characters into a `CharField(max_length=10)` whose choices are only `chat`/`lead`/`task`. SQLite ignores varchar length, so development worked; Railway runs Postgres, where every initial build died on insert.

**Capped runs went silent.** The turn/cost-cap branch of `process()` never called `_finalize_task_run`, so a capped task sat at `active` forever — never applied, never reviewed, never reported.

## What changed

**The build is now a real dispatch.** `start_initial_build` opens the project's main thread (`kind='lead'`), posts the founder's brief, and dispatches one subagent (`kind='task'`, child of the lead). That inherits the existing task machinery: its own git worktree, atomic merge on completion, check-in back to the lead's queue. The preview never sees a half-written tree because the build no longer happens in it. This also removes the invalid `initial_build` kind — the first-build persona now rides on a new `ImagiAgentService(agent_kind=...)` override while the conversation stays an ordinary task.

**Correctness is enforced, not hoped for.** New `frontend_integrity.py` resolves every `@/…` and relative import the way Vite does (alias, extension inference, directory `index` files). `_auto_apply_task` refuses to merge a worktree that fails it — so this protects **every** subagent, not just the first build. The initial build then gets up to 2 repair runs naming the exact broken references; if it still doesn't resolve, it is never merged and the project keeps its clean scaffold.

**Terra is pinned explicitly** via `INITIAL_BUILD_MODEL`. Note this is a no-op in behaviour — the build already ran Terra through `DEFAULT_MODEL`, and Luna only ever named conversation titles. Pinning it means a future `DEFAULT_MODEL` change can't silently move it.

## Verification

- Full backend suite: **454 tests, all passing**. 13 new for the scanner, 3 for the merge gate and capped-run routing, and the initial-build tests rewritten around the real lead/task wiring (conversations and messages are real ORM rows; only the model call is stubbed).
- Scanner precision checked both ways: **zero** false positives on a freshly scaffolded project, and it correctly found 7 genuinely dangling imports in orphaned `apps/payments/` components in Imagi's own frontend (unreferenced, so they never broke the build — tracked separately).
- End-to-end against real git worktrees and a real `vite build`: broken build stayed out and the canonical tree kept building; after repair it merged and still built clean.

## For the reviewer

One deliberate tradeoff: an unrepairable build marks `generation_status='failed'` and the founder lands on the plain scaffold. A working generic app beats a tailored broken one, and the unmerged work still sits in their workspace as a review card — but if "failed" reads too harshly for what is really "partial", a distinct status is an easy follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)