### PR TITLE
Keep the frontend dependency store out of the checkout in dev

### DIFF
--- a/backend/django/imagi/settings.py
+++ b/backend/django/imagi/settings.py
@@ -292,7 +292,9 @@ _DEFAULT_PROJECTS_ROOT = (
     if DEBUG
     else os.path.expanduser('~/.imagi/projects')
 )
-PROJECTS_ROOT = os.environ.get('PROJECTS_ROOT', _DEFAULT_PROJECTS_ROOT)
+PROJECTS_ROOT = os.path.expanduser(
+    os.environ.get('PROJECTS_ROOT', _DEFAULT_PROJECTS_ROOT)
+)
 
 # Shared, content-addressed store of installed frontend dependencies. Every
 # generated project ships the same package.json, so instead of installing a
@@ -303,14 +305,17 @@ PROJECTS_ROOT = os.environ.get('PROJECTS_ROOT', _DEFAULT_PROJECTS_ROOT)
 #    persists across deploys. In production the Docker image prewarms it at
 #    build time (see the warm_frontend_deps management command), baking the
 #    install into the image so it survives every redeploy.
-#  - In development it sits beside the generated projects for easy inspection.
+#  - In development it also lives outside the repository. Unlike the generated
+#    projects (small, text, worth browsing), a slot is hundreds of megabytes of
+#    node_modules with nothing to inspect, and keeping it under BASE_DIR
+#    duplicated that per git worktree and left it sitting in the checkout.
 _DEFAULT_FRONTEND_DEP_STORE_ROOT = (
-    str(BASE_DIR / 'apps' / 'Imagi' / 'Build' / 'imagi_frontend_deps')
+    os.path.expanduser('~/.imagi/frontend-deps')
     if DEBUG
     else '/opt/imagi/frontend-deps'
 )
-FRONTEND_DEP_STORE_ROOT = os.environ.get(
-    'FRONTEND_DEP_STORE_ROOT', _DEFAULT_FRONTEND_DEP_STORE_ROOT
+FRONTEND_DEP_STORE_ROOT = os.path.expanduser(
+    os.environ.get('FRONTEND_DEP_STORE_ROOT', _DEFAULT_FRONTEND_DEP_STORE_ROOT)
 )
 
 # Build workspace browser preview. A headless Chromium runs on this host next


### PR DESCRIPTION
## What

In development, the shared frontend-dependency store defaulted to a path **inside the repo**:

```
backend/django/apps/Imagi/Build/imagi_frontend_deps/
```

The first project creation or preview start warms that store, so ~270 MB of `node_modules` lands in the source tree. Each git worktree is its own checkout, so the cost repeats per worktree — I found four copies locally, ~814 MB total.

## Why it doesn't belong there

A store slot is an opaque `npm install` — a content-addressed blob with nothing to read. That's different from `PROJECTS_ROOT`, which holds the generated projects themselves: small text files that are genuinely useful to browse while testing the agent. `PROJECTS_ROOT` stays in-tree in dev for exactly that reason; only the dependency store moves.

Production already placed the store outside the repo (`/opt/imagi/frontend-deps`, baked into the image by `warm_frontend_deps`). The dev default was the odd one out. This points it at `~/.imagi/frontend-deps` so both environments agree.

## Also fixed

`PROJECTS_ROOT` and `FRONTEND_DEP_STORE_ROOT` did not `expanduser` values read from the environment, so a reasonable-looking `PROJECTS_ROOT=~/somewhere` would have created a literal `~` directory in the working directory. Both now expand.

## Notes

- Gitignored either way, so this was never a risk of committing the bytes — it's about not leaving hundreds of MB in a checkout.
- The `.gitignore` entry for the old path is deliberately left in place, as a safety net for checkouts that still have the directory sitting around.
- No migration needed. Existing checkouts can reclaim the space with `rm -rf backend/django/apps/Imagi/Build/imagi_frontend_deps`; the store rebuilds at the new location on the next project creation, costing one `npm install`.

## Testing

- Full backend suite: **433 passed**.
- Verified with no `.env` override that `DEBUG=True` resolves `store_root()` to `~/.imagi/frontend-deps`, outside the repo, and that `PROJECTS_ROOT` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)