### PR TITLE
Bound the initial build by time, and gate what it may change

### DIFF
--- a/backend/django/apps/Imagi/Build/services/base_agent.py
+++ b/backend/django/apps/Imagi/Build/services/base_agent.py
@@ -24,7 +24,7 @@ try:  # ModelSettings location can vary across SDK versions
 except ImportError:  # pragma: no cover - defensive fallback
     ModelSettings = None
 
-try:  # Run lifecycle hooks (used for the initial build's cost cap)
+try:  # Run lifecycle hooks (used for the initial build's cost/time caps)
     from agents import RunHooks
 except ImportError:  # pragma: no cover - defensive fallback
     RunHooks = None
@@ -73,6 +73,9 @@ RUN_HEARTBEAT_INTERVAL = 60
 # without bound.
 HISTORY_MAX_CHARS = 60_000
 COMPACTED_SNIPPET_CHARS = 120
+
+# How many file paths a capped run's note lists before summarizing the rest.
+CAPPED_NOTE_MAX_FILES = 12
 
 # Model used to auto-name a conversation from its opening exchange. Always the
 # smallest suite tier (Luna) so naming a thread costs the least usage possible —
@@ -149,27 +152,64 @@ class RunBudgetExceeded(Exception):
         )
 
 
-def make_cost_budget_hook(model_id: str, budget_usd: Optional[float]):
-    """A RunHooks that stops a run once cumulative token cost hits budget_usd.
+class RunDeadlineExceeded(Exception):
+    """Raised by the run-bounds hook when a run runs out of wall-clock time.
 
-    Checks the run's aggregated usage after each model turn and raises
-    RunBudgetExceeded when the priced cost reaches the cap. Returns None when
-    hooks or a usable budget/pricing aren't available, so callers transparently
-    fall back to the turn cap alone.
+    The initial build is bounded primarily by time, not turns: the founder is
+    waiting on it, so "how long until I can see my app" is the number that
+    matters. Like RunBudgetExceeded this is a partial result, not a failure —
+    every file written before the deadline is already on disk.
     """
-    if RunHooks is None or not budget_usd or budget_usd <= 0:
+
+    def __init__(self, elapsed_s: float, limit_s: float):
+        self.elapsed_s = elapsed_s
+        self.limit_s = limit_s
+        super().__init__(
+            f"Run took {elapsed_s:.1f}s, reaching its {limit_s:.0f}s time limit"
+        )
+
+
+def make_run_bounds_hook(
+    model_id: str,
+    budget_usd: Optional[float] = None,
+    deadline_at: Optional[float] = None,
+):
+    """A RunHooks that stops a run at its cost and/or wall-clock bound.
+
+    Both are checked after each model turn — the only point the SDK hands us
+    control — so a run overshoots by at most the turn in flight.
+
+    deadline_at is an absolute time.monotonic() value, so a multi-run build can
+    share one deadline across its runs instead of giving each a fresh budget.
+
+    Returns None when hooks are unavailable or neither bound is usable, so
+    callers transparently fall back to the turn cap alone.
+    """
+    has_budget = bool(budget_usd) and budget_usd > 0
+    has_deadline = deadline_at is not None
+    if RunHooks is None or not (has_budget or has_deadline):
         return None
 
-    class _CostBudgetHook(RunHooks):
-        async def on_llm_end(self, context, agent, response):  # noqa: ANN001
-            usage = getattr(context, 'usage', None)
-            input_tokens = getattr(usage, 'input_tokens', 0) or 0
-            output_tokens = getattr(usage, 'output_tokens', 0) or 0
-            cost = compute_cost_usd(model_id, input_tokens, output_tokens)
-            if cost is not None and cost >= budget_usd:
-                raise RunBudgetExceeded(cost, budget_usd)
+    # The hook is built immediately before its run, so this is the run's start.
+    started_at = time.monotonic()
 
-    return _CostBudgetHook()
+    class _RunBoundsHook(RunHooks):
+        async def on_llm_end(self, context, agent, response):  # noqa: ANN001
+            if has_deadline:
+                now = time.monotonic()
+                if now >= deadline_at:
+                    raise RunDeadlineExceeded(
+                        now - started_at, deadline_at - started_at
+                    )
+            if has_budget:
+                usage = getattr(context, 'usage', None)
+                input_tokens = getattr(usage, 'input_tokens', 0) or 0
+                output_tokens = getattr(usage, 'output_tokens', 0) or 0
+                cost = compute_cost_usd(model_id, input_tokens, output_tokens)
+                if cost is not None and cost >= budget_usd:
+                    raise RunBudgetExceeded(cost, budget_usd)
+
+    return _RunBoundsHook()
 
 
 def build_model_settings(reasoning_effort: Optional[str] = None):
@@ -367,6 +407,30 @@ def extract_usage(result, model_id: str) -> Optional[Dict[str, Any]]:
     if cost is not None:
         payload["cost_usd"] = cost
     return payload
+
+
+def _capped_run_note(files_changed: List[str]) -> str:
+    """The message a capped run leaves in its thread.
+
+    A build stopped at its cap is the normal way a time-bounded first build
+    ends, so the note reports what landed rather than only that a limit was
+    hit — that text is what the user reads in the subagent's thread.
+    """
+    if not files_changed:
+        return (
+            "I ran out of build time before I could change anything. Tell me "
+            "what you'd like me to focus on and I'll get straight to it."
+        )
+    shown = files_changed[:CAPPED_NOTE_MAX_FILES]
+    listed = "\n".join(f"- {path}" for path in shown)
+    remaining = len(files_changed) - len(shown)
+    if remaining > 0:
+        listed += f"\n- …and {remaining} more file{'s' if remaining > 1 else ''}"
+    return (
+        "I reached this build's time limit and stopped cleanly. Here's what "
+        f"I built:\n\n{listed}\n\n"
+        "Tell me what you'd like to refine or add next."
+    )
 
 
 def dispatch_task_refs(dispatched: Optional[List[Dict[str, Any]]]) -> Optional[List[Dict[str, Any]]]:
@@ -956,8 +1020,9 @@ class ImagiAgentService:
 
         Returns True when the changes were applied (the task is now
         'accepted'); False when we deliberately leave it for a manual review —
-        a broken frontend import graph, a live canonical run we must not merge
-        across, a merge conflict, a stale base, or any git-level failure.
+        a broken frontend import graph, an app router that stopped exporting its
+        routes, a live canonical run we must not merge across, a merge conflict,
+        a stale base, or any git-level failure.
         Best-effort by contract: it never raises, so any trouble simply parks
         the task at 'ready' for the user.
         """
@@ -969,6 +1034,8 @@ class ImagiAgentService:
             return False
         if self._worktree_import_problems(conversation):
             return False
+        if self._worktree_router_problems(conversation):
+            return False
         try:
             from ..api.views import _apply_task_worktree, _conversation_project
             project = _conversation_project(conversation)
@@ -978,6 +1045,25 @@ class ImagiAgentService:
         except Exception as e:  # pragma: no cover - best effort
             logger.warning(f"Could not auto-apply task worktree: {e}")
             return False
+
+    def _capped_run_files(self, conversation) -> List[str]:
+        """Files a capped run wrote, read back off its working tree.
+
+        A capped run loses the SDK result object that normally reports
+        files_changed, but the work itself is on disk — so the tree is the
+        record. Only task runs have a worktree to read; a capped chat run
+        reports nothing rather than diffing the canonical project. Best-effort:
+        never raises into the capped path it is reporting on.
+        """
+        worktree_path = getattr(conversation, 'worktree_path', '') or ''
+        if not worktree_path:
+            return []
+        try:
+            from .version_control_service import VersionControlService
+            return VersionControlService().list_worktree_changes(worktree_path)
+        except Exception as e:  # pragma: no cover - best effort
+            logger.warning(f"Could not list files from a capped run: {e}")
+            return []
 
     def _worktree_import_problems(self, conversation) -> List[Dict[str, str]]:
         """Frontend imports in the task's worktree that point at missing files.
@@ -1006,6 +1092,36 @@ class ImagiAgentService:
                 len(problems),
                 problems[0]['file'],
                 problems[0]['import'],
+            )
+        return problems
+
+    def _worktree_router_problems(self, conversation) -> List[Dict[str, str]]:
+        """App router modules in the task's worktree that broke their contract.
+
+        An app router that stops exporting its ``routes`` array — most often by
+        being rewritten as a standalone ``createRouter(...)`` — compiles and
+        type-checks cleanly, then resolves to no routes at all, so every page
+        including the home page 404s. Nothing downstream would catch it, which
+        is exactly why it is gated here. Best-effort, like the import check: an
+        error reports no problems rather than blocking a fine merge.
+        """
+        worktree_path = getattr(conversation, 'worktree_path', '') or ''
+        if not worktree_path:
+            return []
+        try:
+            from .frontend_integrity import find_router_contract_problems
+            problems = find_router_contract_problems(worktree_path)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning(f"Could not check app routers before applying: {e}")
+            return []
+        if problems:
+            logger.warning(
+                "Not auto-applying conversation %s: %d app router(s) broke the "
+                "routes contract, first is %s (%s)",
+                getattr(conversation, 'id', None),
+                len(problems),
+                problems[0]['file'],
+                problems[0]['detail'],
             )
         return problems
 
@@ -1297,6 +1413,7 @@ class ImagiAgentService:
         reasoning_effort: Optional[str] = None,
         max_turns: Optional[int] = None,
         cost_budget_usd: Optional[float] = None,
+        deadline_at: Optional[float] = None,
     ) -> Dict[str, Any]:
         """
         Process a message with the Imagi agent.
@@ -1306,11 +1423,13 @@ class ImagiAgentService:
         history, runs the agent, and returns the response plus run metadata:
         the files it changed, the tools it called, and its working plan.
 
-        max_turns overrides the default agent-loop cap for this run;
-        cost_budget_usd, when set, stops the run once its token cost reaches
-        that many dollars (used by the initial build to bound spend). A run
-        stopped by either cap returns success with "capped": True — the files
-        it produced are already on disk.
+        Three optional bounds stop a long run, all treated the same way:
+        max_turns overrides the agent-loop cap; cost_budget_usd stops the run
+        once its token cost reaches that many dollars; deadline_at (an absolute
+        time.monotonic() value) stops it at a wall-clock deadline, which the
+        initial build uses so the founder's wait is bounded. A run stopped by
+        any of them returns success with "capped": True — the files it produced
+        are already on disk.
         """
         if not project_id:
             return {"success": False, "error": "Project ID is required"}
@@ -1334,9 +1453,11 @@ class ImagiAgentService:
             )
 
             run_kwargs: Dict[str, Any] = {}
-            budget_hook = make_cost_budget_hook(model or self.model, cost_budget_usd)
-            if budget_hook is not None:
-                run_kwargs["hooks"] = budget_hook
+            bounds_hook = make_run_bounds_hook(
+                model or self.model, cost_budget_usd, deadline_at
+            )
+            if bounds_hook is not None:
+                run_kwargs["hooks"] = bounds_hook
 
             result = Runner.run_sync(
                 self.agent,
@@ -1379,20 +1500,26 @@ class ImagiAgentService:
                 result_payload["dispatched_tasks"] = list(context.dispatched_tasks)
             return result_payload
 
-        except (MaxTurnsExceeded, RunBudgetExceeded) as cap:
-            # The run hit its turn or cost cap. Everything the agent wrote
-            # before the cap is already on disk, so surface a partial (capped)
-            # result rather than a hard failure. We don't have the SDK result
-            # object here, so metadata is minimal.
+        except (MaxTurnsExceeded, RunBudgetExceeded, RunDeadlineExceeded) as cap:
+            # The run hit one of its caps (turns, cost, or wall clock).
+            # Everything the agent wrote before the cap is already on disk, so
+            # surface a partial (capped) result rather than a hard failure. The
+            # SDK result object is lost here, so the files it produced are read
+            # back off the working tree instead.
             logger.info("Agent run capped for conversation %s: %s",
                         conversation.id if conversation else None, cap)
-            capped_note = (
-                "I reached this build's limit and stopped here. The files I "
-                "completed are saved — tell me what you'd like to refine or add next."
-            )
+            files_changed = self._capped_run_files(conversation)
+            capped_note = _capped_run_note(files_changed)
             if conversation is not None:
                 try:
-                    self.add_assistant_message(conversation, capped_note)
+                    self.add_assistant_message(
+                        conversation,
+                        capped_note,
+                        build_message_metadata(
+                            files_changed=files_changed,
+                            plan=list(getattr(context, "plan", []) or []),
+                        ),
+                    )
                 except Exception:  # pragma: no cover - best effort persistence
                     logger.warning("Could not persist capped-run note", exc_info=True)
                 # A capped run is a finished run: its files are on disk, so it
@@ -1405,7 +1532,7 @@ class ImagiAgentService:
                 "capped": True,
                 "response": capped_note,
                 "conversation_id": conversation.id if conversation else None,
-                "files_changed": [],
+                "files_changed": files_changed,
                 "tool_calls": [],
                 "plan": list(getattr(context, "plan", []) or []),
             }

--- a/backend/django/apps/Imagi/Build/services/coding_agent.py
+++ b/backend/django/apps/Imagi/Build/services/coding_agent.py
@@ -55,6 +55,14 @@ DEFAULT_MODEL = _BUILDER_SETTINGS.get('DEFAULT_MODEL', 'gpt-5.6-terra')
 # keep the requested effort for the actual coding. Tunable via IMAGI_BUILDER.
 LEAD_REASONING_EFFORT = _BUILDER_SETTINGS.get('LEAD_REASONING_EFFORT', 'low')
 
+# The initial build is bounded by wall-clock time (the founder is waiting on
+# it), and it writes new UI from a description rather than reasoning about
+# existing code. Low effort trades depth it doesn't need for turns it does:
+# more pages finished inside the budget. Tunable via IMAGI_BUILDER.
+INITIAL_BUILD_REASONING_EFFORT = _BUILDER_SETTINGS.get(
+    'INITIAL_BUILD_REASONING_EFFORT', 'low'
+)
+
 # Project memory files, in priority order (Codex reads AGENTS.md,
 # Claude Code reads CLAUDE.md). Only the first one found is loaded.
 PROJECT_MEMORY_FILES = ('AGENTS.md', 'CLAUDE.md')
@@ -113,25 +121,62 @@ DESIGN_DIRECTION = """Design direction (make what you build look genuinely good,
 - Keep it clean and accessible: sufficient color contrast, semantic markup, and real copy written for this business (never lorem ipsum or leftover scaffold text).
 - Follow any style preferences the founder gave; when they gave none, choose a look that fits the business's tone and industry."""
 
+# Working style for the initial build, replacing BUILDER_WORKING_STYLE. The
+# builder style is written for changing code that already exists — search, read,
+# then edit narrowly — which is exactly wrong here: the target is a scaffold
+# this prompt already describes, and every exploratory turn is spent against a
+# wall-clock budget. So: plan once, then write whole files.
+INITIAL_BUILD_WORKING_STYLE = """Working style:
+- Open with ONE update_plan call listing the pages you intend to build, then keep it updated as each one lands. The founder watches this plan in their workspace — it is how they see progress — so it is worth the single turn.
+- Write complete files: create_file for new ones, update_file to replace a scaffold file wholesale. Reach for edit_file only to make a small change to a file you have already written this run (adding a route to router/index.ts, adding a nav link).
+- Do not verify by re-reading what you just wrote. Write it correctly the first time.
+- If a tool returns an error or "success": false, say so in your summary — never claim success when an operation failed. If edit_file fails, read that one file and retry with its exact current text.
+- Afterward, briefly summarize what you built and where."""
+
 # Intro for the initial build — the one-shot, headless first build of a new
 # project. It runs like the chat builder (full editing tools, direct edits to
 # the real project) but with a first-build framing and design direction.
 INITIAL_BUILD_INTRO = """You are Imagi, performing the very first build of a brand-new web application for the founder who just described their business. Right now the project holds only Imagi's default scaffold: a home app and a prebuilt auth app. Turn it into a tailored, good-looking first version of THIS business's app. The founder sees your result the moment they open their workspace, so it should feel custom-built for them — not a generic starter."""
 
 # What the initial build should (and shouldn't) do. Deliberately does NOT limit
-# the agent to a fixed set of files — it decides what the business needs.
-INITIAL_BUILD_GUIDANCE = """Building the first version:
-- You decide what to build. From the founder's description (and any style preferences), build the pages and UI this specific business needs — you are NOT limited to a fixed list of files or pages. Always rework the home app's landing page around the business, and add whatever further pages make sense (About, Pricing, Features, Contact, a product/services page, ...), wiring up each new page's route.
-- Make it coherent and real: shared navigation, working links, and copy written for this business. Keep the header's sign-in and create-account links to the prebuilt auth pages ('/auth/signin', '/auth/register') present and working.
+# the agent to a fixed set of files — it decides what the business needs — but
+# it IS strictly bounded in time, so the guidance is written around spending
+# that time writing pages rather than exploring a scaffold it already knows.
+INITIAL_BUILD_GUIDANCE = """Building the first version — you are racing a clock:
+- You have ABOUT ONE MINUTE of wall-clock time, and the founder is watching and waiting. When it runs out you are stopped wherever you are. So spend every turn writing files, and treat anything else as a turn you don't get back.
+- Do NOT explore the project first. You already know the layout (below), and the scaffold is exactly as described — no get_project_tree, no glob_files, no grep_files, and no read_file on a scaffold file you are about to replace wholesale. Go straight to writing.
+- Write whole files with create_file (new pages) and update_file (replacing a scaffold file). Do not read-then-edit_file your way through a file you are rewriting anyway; one full write is one turn instead of three.
+
+You are building PAGES inside an existing, working project — you are not restructuring it. Write and rewrite page components freely; leave the project's plumbing exactly as it is.
+
+Work in this order, and stop cleanly whenever time runs short — every step is a good place to stop:
+1. FIRST, rewrite the landing page 'frontend/vuejs/src/apps/home/views/HomeView.vue' as a real, polished landing page for THIS business. This is the one thing that must happen: it is what the founder sees first. Keep its header links to '/auth/signin' and '/auth/register' working.
+2. THEN, only if you have time, add one or two further pages that this business genuinely needs (About, Pricing, Features, Contact, a product/services page, ...). For each page: write 'frontend/vuejs/src/apps/home/views/<Name>View.vue', ADD one route entry to the existing array in 'frontend/vuejs/src/apps/home/router/index.ts' with edit_file, export it from 'frontend/vuejs/src/apps/home/views/index.ts', and link it from the landing page's nav — all four, for that page, before you start another one.
+3. Stop and summarize. A tight two-page app that loads beats a five-page one that doesn't.
+
+How routing works here — get this wrong and NOTHING loads:
+- 'frontend/vuejs/src/router' is the project's ONE router. It already calls createRouter and automatically globs up every app's routes. Never touch it.
+- An app's 'router/index.ts' only exports a plain array: `const routes: RouteRecordRaw[] = [...]` plus `export { routes }`. Adding a page means adding ONE entry to that array with edit_file — never rewrite the file, and NEVER call createRouter or createWebHistory in it. An app router that exports a Router instead of a routes array still compiles, and then the app serves no routes at all: every page, including home, 404s.
+
+Hard rules:
+- DO NOT change the project's structure or its plumbing. You are adding and rewriting pages, nothing else. Leave every one of these exactly as you found it: 'frontend/vuejs/src/router' (the root router), 'frontend/vuejs/src/main.ts', 'frontend/vuejs/src/App.vue', 'frontend/vuejs/src/shared/', the whole 'frontend/vuejs/src/apps/auth/' app, 'vite.config.ts', 'package.json', 'tsconfig*.json', 'tailwind.config.js', 'postcss.config.js', 'index.html', and everything under 'backend/django/'. Do not add dependencies, change the build setup, or reorganize directories. A first build that rewires the project is discarded even if it looks good.
+- NEVER leave a reference dangling. Every file you import and every component you register must already exist. One import of a file you didn't write makes the whole app fail to load with a "Failed to resolve import" error, and a build in that state is DISCARDED — the founder gets the plain scaffold instead of your work. This is the single worst outcome, worse than building less.
+- NEVER reference an image or media file. There are NO image assets in this project and no 'public/' directory, so every '<img src="/images/...">', background-image url(), or imported .jpg/.png/.svg file is a dangling reference: it renders as a broken image and breaks the production build. You cannot create binary images either. Build visuals out of what you can actually write: CSS gradients, colored and rounded div blocks, inline <svg> you author yourself, borders, shadows, and type. A confident gradient-and-type hero looks far better than a broken image icon.
 - Authentication is already done for you: the auth app (sign-in and register pages plus its backend) is prebuilt and secure. Do NOT rebuild, restyle, or modify the auth app beyond leaving its links in place.
 - Do NOT build payment, checkout, cart, or subscription-billing functionality even if the business sells something — the founder installs secure, prebuilt payment pages later from their Sell workspace. Design the marketing/product pages with a clear call-to-action instead of wiring real payments.
-- Work efficiently on a tight build budget: build a cohesive set of pages that looks great and covers the core of the business, then stop. Don't pad it out with dozens of pages or half-finished features — a strong, complete first impression beats a sprawling unfinished one.
-- Finish each page completely before starting the next one, and never leave a reference dangling: every file you import and every component you register must already exist by the time you move on. A single import of a file you didn't write makes the whole app fail to load with a "Failed to resolve import" error, and a build in that state is discarded rather than shown to the founder. If you are running low on budget, stop cleanly — a smaller app that loads beats a bigger one that doesn't.
-- When you finish, briefly summarize what you built. The founder reads it as the first message in their workspace."""
+- Keep it to the frontend pages above. Don't add backend endpoints, stores, or API wiring on a first build unless a page genuinely cannot render without them.
+- When you finish, briefly summarize what you built. The founder reads it as the first message in their workspace.
+
+The scaffold you are starting from (already on disk — trust this instead of looking):
+- 'frontend/vuejs/src/apps/home/views/HomeView.vue' — generic placeholder landing page, routed at '/'. Replace it.
+- 'frontend/vuejs/src/apps/home/router/index.ts' — routes for the home app; its one entry maps '/' to HomeView.
+- 'frontend/vuejs/src/apps/home/views/index.ts' — barrel exporting HomeView.
+- 'frontend/vuejs/src/apps/auth/' — the prebuilt auth app serving '/auth/signin' and '/auth/register'. Leave it alone.
+- Tailwind, Vue Router, and Pinia are already installed and wired up."""
 
 # Full prompt for the initial build role.
 INITIAL_BUILD_INSTRUCTIONS = "\n\n".join(
-    (INITIAL_BUILD_INTRO, BUILDER_WORKING_STYLE, SHARED_PROJECT_GUIDANCE,
+    (INITIAL_BUILD_INTRO, INITIAL_BUILD_WORKING_STYLE, SHARED_PROJECT_GUIDANCE,
      DESIGN_DIRECTION, INITIAL_BUILD_GUIDANCE)
 )
 
@@ -266,6 +311,8 @@ def create_coding_agent(
     # triage-and-dispatch stays fast regardless of what the user picked.
     if kind == 'lead':
         reasoning_effort = LEAD_REASONING_EFFORT
+    elif kind == 'initial_build':
+        reasoning_effort = INITIAL_BUILD_REASONING_EFFORT
     effort = resolve_reasoning_effort(model, reasoning_effort)
     identity = get_model_identity_instructions(model)
 
@@ -292,8 +339,13 @@ def create_coding_agent(
         if StopAtTools is not None:
             kwargs['tool_use_behavior'] = StopAtTools(stop_at_tool_names=['ask_user'])
 
+    # The initial build is the one role that never searches: it is racing a
+    # wall-clock budget, and everything it needs is in the founder's brief. A
+    # single hosted search can eat a meaningful share of that budget, and it
+    # also costs every later turn the tool's schema in the prompt.
     web_search_enabled = (
         WebSearchTool is not None
+        and kind != 'initial_build'
         and _BUILDER_SETTINGS.get('ENABLE_WEB_SEARCH', True)
     )
     if web_search_enabled:

--- a/backend/django/apps/Imagi/Build/services/frontend_integrity.py
+++ b/backend/django/apps/Imagi/Build/services/frontend_integrity.py
@@ -1,19 +1,30 @@
 """
-Static integrity check for a generated project's Vue frontend.
+Static integrity checks for a generated project's Vue frontend.
 
-Vite resolves imports when a module is first requested, so a single import
-pointing at a file that was never written takes the whole preview down with
-an "Failed to resolve import ..." internal server error — the page the user
-was about to see is simply blank. An agent run that is cut short (turn or
-cost cap) leaves exactly that state: a view or route referencing a component
-it did not get around to creating.
+Two failure modes are caught here, both of which take an app down while
+compiling perfectly well, so neither a type-check nor ``vite build`` finds
+them:
 
-This module finds those dangling references without booting anything, so a
-run's output can be checked before it reaches the tree the preview serves.
-The scan is deliberately conservative — it only follows import specifiers
-that name a file inside the project (``@/...`` alias or a relative path) and
-resolves them the way Vite's resolver does, so a clean project always scans
-clean.
+1. Dangling references. Vite resolves imports when a module is first
+   requested, so a single import pointing at a file that was never written
+   takes the whole preview down with a "Failed to resolve import ..."
+   internal server error — the page the user was about to see is simply
+   blank. An agent run that is cut short leaves exactly that state: a view or
+   route referencing a component it did not get around to creating. The same
+   applies to a template ``src`` naming an image that does not exist.
+
+2. A broken app-router contract. Each app owns a ``router/index.ts`` that
+   exports a ``routes`` array, and the project's root router globs those up
+   into one route table. An agent that rewrites an app's router module as a
+   standalone ``createRouter(...)`` breaks that contract silently and
+   catastrophically: vue-router accepts the resulting value without
+   complaint and resolves to NO routes at all, so every URL — including the
+   home page — falls through to the 404 page.
+
+Both scans run without booting anything, so a run's output can be checked
+before it reaches the tree the preview serves. They are deliberately
+conservative: a clean project always scans clean, because a false positive
+discards a build that was actually fine.
 """
 
 import logging
@@ -47,9 +58,29 @@ _IMPORT_RE = re.compile(
     re.MULTILINE,
 )
 
+# Static asset references in a template: src="..." and poster="...". Vite
+# compiles these into imports, so one naming a file that does not exist is the
+# same dangling reference as a bad import statement — it renders as a broken
+# image and fails the production build. Only the static attribute form is
+# matched: a ':src'/'v-bind:src' binding is an expression, not a path.
+_TEMPLATE_ASSET_RE = re.compile(
+    r"""(?<![:\w.-])(?:src|poster)\s*=\s*["'](?P<asset>[^"']+)["']"""
+)
+
 # Specifiers that name a file in this project (everything else is an npm
 # package, which the shared dependency store owns).
 _LOCAL_PREFIXES = ('@/', './', '../')
+
+# A root-absolute reference ('/images/hero.jpg') is resolved by Vite against
+# the frontend's public/ directory, then its root. Generated projects ship no
+# public/ directory at all, so these are the most common way an agent invents
+# an asset that was never created.
+_PUBLIC_DIR = os.path.join('frontend', 'vuejs', 'public')
+_FRONTEND_ROOT = os.path.join('frontend', 'vuejs')
+
+# References that are not a path into this project: real URLs, protocol-
+# relative URLs, inline data, and template placeholders.
+_NON_PATH_PREFIXES = ('http://', 'https://', '//', 'data:', 'blob:', 'mailto:', '#')
 
 # A specifier built at runtime is not statically resolvable, and neither is a
 # glob — never report those.
@@ -69,23 +100,48 @@ def _iter_source_files(src_root):
                 yield os.path.join(dirpath, filename)
 
 
-def _resolves(spec, source_file, src_root):
-    """Whether an import specifier names a file that exists, as Vite resolves it."""
+def _candidate_targets(spec, source_file, src_root, root):
+    """Absolute paths Vite would try for a specifier, in resolution order."""
     if spec.startswith('@/'):
-        target = os.path.join(src_root, spec[2:])
-    else:
-        target = os.path.normpath(os.path.join(os.path.dirname(source_file), spec))
+        return [os.path.join(src_root, spec[2:])]
+    if spec.startswith('/'):
+        # Root-absolute: public/ first (Vite serves it at the root), then the
+        # frontend root itself.
+        relative = spec.lstrip('/')
+        return [
+            os.path.join(root, _PUBLIC_DIR, relative),
+            os.path.join(root, _FRONTEND_ROOT, relative),
+        ]
+    return [os.path.normpath(os.path.join(os.path.dirname(source_file), spec))]
 
-    if os.path.isfile(target):
-        return True
-    for ext in RESOLVED_EXTENSIONS:
-        if os.path.isfile(target + ext):
+
+def _resolves(spec, source_file, src_root, root):
+    """Whether a specifier names a file that exists, as Vite resolves it."""
+    for target in _candidate_targets(spec, source_file, src_root, root):
+        if os.path.isfile(target):
             return True
-    # A directory import resolves to its index file.
-    for ext in RESOLVED_EXTENSIONS:
-        if os.path.isfile(os.path.join(target, 'index' + ext)):
-            return True
+        for ext in RESOLVED_EXTENSIONS:
+            if os.path.isfile(target + ext):
+                return True
+        # A directory import resolves to its index file.
+        for ext in RESOLVED_EXTENSIONS:
+            if os.path.isfile(os.path.join(target, 'index' + ext)):
+                return True
     return False
+
+
+def _is_project_path(spec):
+    """Whether a specifier points at a file this project is meant to contain.
+
+    Excludes npm packages (bare specifiers), real URLs, inline data, and
+    anything assembled at runtime — none of which a static check can or should
+    judge.
+    """
+    if not spec or spec.startswith(_NON_PATH_PREFIXES):
+        return False
+    if any(marker in spec for marker in _DYNAMIC_MARKERS):
+        return False
+    return spec.startswith(_LOCAL_PREFIXES) or spec.startswith('/')
 
 
 def find_unresolved_imports(root):
@@ -114,16 +170,20 @@ def find_unresolved_imports(root):
             continue
 
         seen = set()
-        for match in _IMPORT_RE.finditer(source):
-            spec = match.group('static') or match.group('dynamic')
+        specs = [
+            match.group('static') or match.group('dynamic')
+            for match in _IMPORT_RE.finditer(source)
+        ]
+        specs += [
+            match.group('asset') for match in _TEMPLATE_ASSET_RE.finditer(source)
+        ]
+        for spec in specs:
             if not spec or spec in seen:
                 continue
             seen.add(spec)
-            if not spec.startswith(_LOCAL_PREFIXES):
+            if not _is_project_path(spec):
                 continue
-            if any(marker in spec for marker in _DYNAMIC_MARKERS):
-                continue
-            if _resolves(spec, source_file, src_root):
+            if _resolves(spec, source_file, src_root, root):
                 continue
             problems.append({
                 'file': os.path.relpath(source_file, root).replace(os.sep, '/'),
@@ -136,6 +196,87 @@ def describe_unresolved_imports(problems):
     """Render unresolved imports as a bulleted list for an agent prompt."""
     shown = problems[:MAX_REPORTED_PROBLEMS]
     lines = [f"- {p['file']} imports '{p['import']}', which does not exist" for p in shown]
+    if len(problems) > len(shown):
+        lines.append(f"- ... and {len(problems) - len(shown)} more")
+    return "\n".join(lines)
+
+
+# An app's router module must hand its routes to the root router as an array.
+# `export { routes }` is the scaffolded form; `export default [...]` also works,
+# since the root router accepts an array from either export.
+_ROUTES_EXPORT_RE = re.compile(
+    r"export\s+(?:const|let|var)\s+routes\b"      # export const routes = [...]
+    r"|export\s*\{[^}]*\broutes\b[^}]*\}"          # export { routes }
+    r"|export\s+default\s*\[",                     # export default [ ... ]
+    re.MULTILINE,
+)
+
+# The specific rewrite that breaks the contract: an app router that builds its
+# own Router instead of exporting route records.
+_CREATE_ROUTER_RE = re.compile(r"\bcreateRouter\s*\(")
+
+
+def find_router_contract_problems(root):
+    """Find app router modules that no longer hand routes to the root router.
+
+    Args:
+        root: The project tree to scan (a project_path or a task worktree).
+
+    Returns:
+        list[dict]: ``{'file': <project-relative path>, 'detail': <what broke>}``
+        in a stable order, empty when every app router still exports routes.
+        A project with no apps directory yields [] — this check reports a broken
+        contract, it does not require one to exist.
+    """
+    apps_root = os.path.join(root or '', FRONTEND_SRC, 'apps')
+    if not os.path.isdir(apps_root):
+        return []
+
+    problems = []
+    for app_name in sorted(os.listdir(apps_root)):
+        router_dir = os.path.join(apps_root, app_name, 'router')
+        if not os.path.isdir(router_dir):
+            continue
+        for filename in sorted(os.listdir(router_dir)):
+            if not filename.startswith('index.') or not filename.endswith(
+                ('.ts', '.js')
+            ):
+                continue
+            path = os.path.join(router_dir, filename)
+            try:
+                with open(path, 'r', encoding='utf-8') as f:
+                    source = f.read()
+            except (OSError, UnicodeDecodeError) as e:
+                logger.warning(f"Could not read {path} for router check: {e}")
+                continue
+
+            relative = os.path.relpath(path, root).replace(os.sep, '/')
+            if _CREATE_ROUTER_RE.search(source):
+                problems.append({
+                    'file': relative,
+                    'detail': (
+                        "calls createRouter(), but an app router must only "
+                        "export a 'routes' array — the project's root router "
+                        "(frontend/vuejs/src/router) is the one that creates "
+                        "the router. As written, the app contributes no routes "
+                        "at all and every page 404s"
+                    ),
+                })
+            elif not _ROUTES_EXPORT_RE.search(source):
+                problems.append({
+                    'file': relative,
+                    'detail': (
+                        "does not export a 'routes' array, so the root router "
+                        "picks up no routes from this app and its pages 404"
+                    ),
+                })
+    return problems
+
+
+def describe_router_contract_problems(problems):
+    """Render broken router contracts as a bulleted list for an agent prompt."""
+    shown = problems[:MAX_REPORTED_PROBLEMS]
+    lines = [f"- {p['file']} {p['detail']}" for p in shown]
     if len(problems) > len(shown):
         lines.append(f"- ... and {len(problems) - len(shown)} more")
     return "\n".join(lines)

--- a/backend/django/apps/Imagi/Build/services/version_control_service.py
+++ b/backend/django/apps/Imagi/Build/services/version_control_service.py
@@ -452,6 +452,40 @@ class VersionControlService:
         except Exception as e:
             return {'success': False, 'commit_hash': None, 'message': f"Error creating checkpoint: {str(e)}"}
 
+    def list_worktree_changes(self, worktree_path):
+        """Project-relative paths a worktree has added, modified, or deleted.
+
+        Used to report what a run actually produced when it was cut short by
+        one of its caps: the SDK result object is lost in that path, so the
+        working tree itself is the only record of the work. Best-effort — a
+        report that cannot be built comes back empty rather than raising into
+        the run's own error handling.
+        """
+        if not worktree_path or not os.path.isdir(worktree_path):
+            return []
+        try:
+            result = subprocess.run(
+                ['git', 'status', '--porcelain', '--untracked-files=all'],
+                cwd=worktree_path, capture_output=True, text=True
+            )
+            if result.returncode != 0:
+                return []
+        except Exception as e:  # pragma: no cover - best effort
+            logger.warning(f"Could not list worktree changes in {worktree_path}: {e}")
+            return []
+
+        paths = []
+        for line in result.stdout.splitlines():
+            # Porcelain v1: two status columns, a space, then the path. A
+            # rename/copy reads 'old -> new'; the new path is what was written.
+            entry = line[3:].strip()
+            if ' -> ' in entry:
+                entry = entry.split(' -> ', 1)[1]
+            entry = entry.strip('"')
+            if entry:
+                paths.append(entry)
+        return paths
+
     # ------------------------------------------------------------------
     # Per-task worktrees (one isolated checkout per task conversation)
     # ------------------------------------------------------------------

--- a/backend/django/apps/Imagi/Build/tests/test_agents.py
+++ b/backend/django/apps/Imagi/Build/tests/test_agents.py
@@ -10,6 +10,7 @@ no OpenAI calls are made.
 import os
 import shutil
 import tempfile
+import time
 from datetime import timedelta
 from types import SimpleNamespace
 from unittest.mock import PropertyMock, patch
@@ -25,14 +26,21 @@ from rest_framework.authtoken.models import Token
 from apps.Imagi.Build.api.views import _project_has_running_conversation
 from apps.Imagi.Build.models import AgentConversation, AgentMessage
 from apps.Imagi.Build.services.base_agent import (
+    CAPPED_NOTE_MAX_FILES,
     AgentContext,
     ImagiAgentService,
+    RunBudgetExceeded,
+    RunDeadlineExceeded,
+    _capped_run_note,
     compact_history,
     extract_run_metadata,
+    make_run_bounds_hook,
 )
 from apps.Imagi.Build.services.models_service import compute_cost_usd
 from apps.Imagi.Build.services.coding_agent import (
+    INITIAL_BUILD_REASONING_EFFORT,
     PROJECT_MEMORY_MAX_CHARS,
+    create_coding_agent,
     load_project_memory,
 )
 from apps.Imagi.Build.services.tools import (
@@ -879,6 +887,109 @@ class ComputeCostTests(SimpleTestCase):
 
     def test_unknown_model_returns_none(self):
         self.assertIsNone(compute_cost_usd('gpt-oops', 1000, 1000))
+
+
+class RunBoundsHookTests(SimpleTestCase):
+    """The cost and wall-clock bounds that stop a long run."""
+
+    def _fire(self, hook, input_tokens=0, output_tokens=0):
+        context = SimpleNamespace(
+            usage=SimpleNamespace(
+                input_tokens=input_tokens, output_tokens=output_tokens
+            )
+        )
+        async_to_sync(hook.on_llm_end)(context, None, None)
+
+    def test_no_bounds_means_no_hook(self):
+        self.assertIsNone(make_run_bounds_hook('gpt-5.6-sol'))
+
+    def test_run_within_both_bounds_is_left_alone(self):
+        hook = make_run_bounds_hook(
+            'gpt-5.6-sol', budget_usd=10.0, deadline_at=time.monotonic() + 300
+        )
+        self._fire(hook, input_tokens=1000, output_tokens=100)
+
+    def test_passed_deadline_stops_the_run(self):
+        hook = make_run_bounds_hook(
+            'gpt-5.6-sol', deadline_at=time.monotonic() - 1
+        )
+        with self.assertRaises(RunDeadlineExceeded):
+            self._fire(hook)
+
+    def test_deadline_is_checked_before_cost(self):
+        # A run that is both over time and over budget reports the deadline:
+        # for the initial build, time is the bound that matters.
+        hook = make_run_bounds_hook(
+            'gpt-5.6-sol', budget_usd=0.01, deadline_at=time.monotonic() - 1
+        )
+        with self.assertRaises(RunDeadlineExceeded):
+            self._fire(hook, input_tokens=1_000_000, output_tokens=1_000_000)
+
+    def test_spent_budget_stops_the_run(self):
+        hook = make_run_bounds_hook('gpt-5.6-sol', budget_usd=1.0)
+        with self.assertRaises(RunBudgetExceeded):
+            self._fire(hook, input_tokens=1_000_000, output_tokens=0)
+
+
+class InitialBuildAgentTests(SimpleTestCase):
+    """The first-build role's own configuration, which trades depth for speed."""
+
+    def test_initial_build_has_no_web_search_tool(self):
+        # A hosted search can eat a large share of a one-minute budget, and its
+        # schema costs every later turn prompt tokens.
+        agent = create_coding_agent(kind='initial_build')
+        self.assertNotIn(
+            'WebSearchTool', [type(tool).__name__ for tool in agent.tools]
+        )
+
+    def test_chat_keeps_web_search(self):
+        agent = create_coding_agent(kind='chat')
+        self.assertIn(
+            'WebSearchTool', [type(tool).__name__ for tool in agent.tools]
+        )
+
+    def test_initial_build_can_still_write_files(self):
+        agent = create_coding_agent(kind='initial_build')
+        names = {getattr(tool, 'name', '') for tool in agent.tools}
+        self.assertTrue({'create_file', 'update_file'} <= names, names)
+
+    def test_initial_build_runs_at_its_configured_effort(self):
+        # Set explicitly for the role, so a per-request effort meant for the
+        # interactive builders cannot slow the first build down.
+        agent = create_coding_agent(
+            kind='initial_build', reasoning_effort='xhigh'
+        )
+        self.assertEqual(
+            agent.model_settings.reasoning.effort, INITIAL_BUILD_REASONING_EFFORT
+        )
+
+
+class CappedRunNoteTests(SimpleTestCase):
+    """What a capped run tells the user it built.
+
+    A time-bounded first build ends at its cap as a matter of course, so this
+    note is the normal completion message in the subagent's thread.
+    """
+
+    def test_note_lists_what_was_built(self):
+        note = _capped_run_note([
+            'frontend/vuejs/src/apps/home/views/HomeView.vue',
+            'frontend/vuejs/src/apps/home/views/AboutView.vue',
+        ])
+        self.assertIn('HomeView.vue', note)
+        self.assertIn('AboutView.vue', note)
+
+    def test_long_file_lists_are_summarized(self):
+        files = [f'frontend/vuejs/src/apps/home/views/View{i}.vue' for i in range(20)]
+        note = _capped_run_note(files)
+        self.assertIn('View0.vue', note)
+        self.assertIn(f'and {20 - CAPPED_NOTE_MAX_FILES} more files', note)
+
+    def test_a_run_that_built_nothing_says_so(self):
+        # Must not claim work it did not do — this is the message the user reads.
+        note = _capped_run_note([])
+        self.assertIn('ran out of build time', note)
+        self.assertNotIn("here's what", note.lower())
 
 
 class ProjectMemoryTests(SimpleTestCase):

--- a/backend/django/apps/Imagi/Build/tests/test_frontend_integrity.py
+++ b/backend/django/apps/Imagi/Build/tests/test_frontend_integrity.py
@@ -14,7 +14,9 @@ import tempfile
 from django.test import TestCase
 
 from apps.Imagi.Build.services.frontend_integrity import (
+    describe_router_contract_problems,
     describe_unresolved_imports,
+    find_router_contract_problems,
     find_unresolved_imports,
 )
 
@@ -133,6 +135,147 @@ class FrontendIntegrityTests(TestCase):
             "import B from './Missing.vue'\n",
         )
         self.assertEqual(len(self._imports()), 1)
+
+    def _write_public(self, rel_path, content=''):
+        path = os.path.join(self.root, 'frontend', 'vuejs', 'public', rel_path)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, 'w') as f:
+            f.write(content)
+        return path
+
+    def test_missing_template_image_is_reported(self):
+        # Observed in a real first build: the agent wrote a hero <img> pointing
+        # at an image file it could not create. Vite compiles a template src
+        # into an import, so this renders broken and fails the production
+        # build — exactly the class of dangling reference this gate exists for.
+        self._write(
+            'apps/home/views/HomeView.vue',
+            '<template>\n'
+            '  <img src="/images/coffee-hero.jpg" alt="Pouring coffee" />\n'
+            '</template>\n',
+        )
+        self.assertEqual(self._imports(), [{
+            'file': 'frontend/vuejs/src/apps/home/views/HomeView.vue',
+            'import': '/images/coffee-hero.jpg',
+        }])
+
+    def test_template_image_present_in_public_resolves(self):
+        self._write_public('images/hero.jpg', 'jpegbytes')
+        self._write(
+            'apps/home/views/HomeView.vue',
+            '<template><img src="/images/hero.jpg" /></template>\n',
+        )
+        self.assertEqual(self._imports(), [])
+
+    def test_relative_template_image_is_checked(self):
+        self._write(
+            'apps/home/views/HomeView.vue',
+            '<template><img src="./logo.svg" /></template>\n',
+        )
+        self.assertEqual([p['import'] for p in self._imports()], ['./logo.svg'])
+
+    def test_bound_src_expressions_are_skipped(self):
+        # ':src' / 'v-bind:src' hold an expression, not a path — the value is
+        # decided at runtime, so a static check must not judge it.
+        self._write(
+            'apps/home/views/HomeView.vue',
+            '<template>\n'
+            '  <img :src="product.imageUrl" />\n'
+            '  <img v-bind:src="heroSrc" />\n'
+            '</template>\n',
+        )
+        self.assertEqual(self._imports(), [])
+
+    def test_remote_and_inline_sources_are_skipped(self):
+        self._write(
+            'apps/home/views/HomeView.vue',
+            '<template>\n'
+            '  <img src="https://cdn.example.com/a.jpg" />\n'
+            '  <img src="//cdn.example.com/b.jpg" />\n'
+            '  <img src="data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=" />\n'
+            '</template>\n',
+        )
+        self.assertEqual(self._imports(), [])
+
+    def test_root_absolute_import_is_checked(self):
+        self._write('apps/home/views/HomeView.vue', "import logo from '/logo.png'\n")
+        self.assertEqual([p['import'] for p in self._imports()], ['/logo.png'])
+
+    def test_scaffolded_app_router_is_accepted(self):
+        self._write(
+            'apps/home/router/index.ts',
+            "import type { RouteRecordRaw } from 'vue-router'\n"
+            "import HomeView from '../views/HomeView.vue'\n"
+            "\n"
+            "const routes: RouteRecordRaw[] = [\n"
+            "  { path: '/', name: 'home-view', component: HomeView }\n"
+            "]\n"
+            "\n"
+            "export { routes }\n",
+        )
+        self.assertEqual(find_router_contract_problems(self.root), [])
+
+    def test_default_exported_route_array_is_accepted(self):
+        # The root router takes an array from either export.
+        self._write(
+            'apps/home/router/index.ts',
+            "import HomeView from '../views/HomeView.vue'\n"
+            "export default [\n"
+            "  { path: '/', component: HomeView }\n"
+            "]\n",
+        )
+        self.assertEqual(find_router_contract_problems(self.root), [])
+
+    def test_app_router_rewritten_as_a_real_router_is_reported(self):
+        # Observed in a real first build. This compiles, type-checks, and passes
+        # `vite build` — then vue-router silently resolves to zero routes, so
+        # every page including home 404s. Nothing else catches it.
+        self._write(
+            'apps/home/router/index.ts',
+            "import { createRouter, createWebHistory } from 'vue-router'\n"
+            "import HomeView from '../views/HomeView.vue'\n"
+            "\n"
+            "const routes = [{ path: '/', component: HomeView }]\n"
+            "const router = createRouter({ history: createWebHistory(), routes })\n"
+            "export default router\n",
+        )
+        problems = find_router_contract_problems(self.root)
+        self.assertEqual(
+            [p['file'] for p in problems],
+            ['frontend/vuejs/src/apps/home/router/index.ts'],
+        )
+        self.assertIn('createRouter', problems[0]['detail'])
+
+    def test_app_router_without_a_routes_export_is_reported(self):
+        self._write(
+            'apps/home/router/index.ts',
+            "import HomeView from '../views/HomeView.vue'\n"
+            "const routes = [{ path: '/', component: HomeView }]\n",
+        )
+        problems = find_router_contract_problems(self.root)
+        self.assertIn('does not export', problems[0]['detail'])
+
+    def test_every_app_router_is_checked(self):
+        self._write('apps/home/router/index.ts', "export { routes }\n")
+        self._write(
+            'apps/shop/router/index.ts',
+            "import { createRouter } from 'vue-router'\n"
+            "export default createRouter({ routes: [] })\n",
+        )
+        self.assertEqual(
+            [p['file'] for p in find_router_contract_problems(self.root)],
+            ['frontend/vuejs/src/apps/shop/router/index.ts'],
+        )
+
+    def test_project_without_apps_has_no_router_problems(self):
+        self.assertEqual(find_router_contract_problems(self.root), [])
+
+    def test_router_problem_description_names_the_file(self):
+        described = describe_router_contract_problems(
+            [{'file': 'apps/home/router/index.ts', 'detail': 'calls createRouter()'}]
+        )
+        self.assertIn('apps/home/router/index.ts', described)
+        self.assertIn('createRouter', described)
 
     def test_description_lists_every_problem(self):
         problems = [

--- a/backend/django/apps/Imagi/Build/tests/test_task_worktrees.py
+++ b/backend/django/apps/Imagi/Build/tests/test_task_worktrees.py
@@ -776,6 +776,55 @@ class TaskCheckInTests(GitRepoTestMixin, TestCase):
             self.repo, 'frontend', 'vuejs', 'src', 'shared', 'components', 'SiteHeader.vue'
         )))
 
+    def _worktree_with_app_router(self, task, router_source):
+        """Give a task a worktree whose home app holds one router module."""
+        worktree = VersionControlService().create_task_worktree(
+            self.repo, task.id
+        )['worktree_path']
+        router_dir = os.path.join(
+            worktree, 'frontend', 'vuejs', 'src', 'apps', 'home', 'router'
+        )
+        os.makedirs(router_dir, exist_ok=True)
+        with open(os.path.join(router_dir, 'index.ts'), 'w') as f:
+            f.write(router_source)
+        task.worktree_path = worktree
+        task.save(update_fields=['worktree_path'])
+        return worktree
+
+    def test_auto_apply_defers_to_review_when_an_app_router_is_rewritten(self):
+        # An app router rewritten as a standalone createRouter compiles and
+        # builds cleanly, then leaves vue-router with no routes at all, so every
+        # page 404s. It must not reach the tree the preview serves.
+        task = self._task()
+        self._worktree_with_app_router(
+            task,
+            "import { createRouter, createWebHistory } from 'vue-router'\n"
+            "const routes = []\n"
+            "export default createRouter({ history: createWebHistory(), routes })\n",
+        )
+
+        self.service._finalize_task_run(task, self._context(), 'Built the pages.')
+
+        task.refresh_from_db()
+        self.assertEqual(task.review_status, 'ready')
+        self.assertFalse(
+            os.path.exists(os.path.join(self.repo, 'frontend', 'vuejs', 'src'))
+        )
+
+    def test_auto_apply_proceeds_when_the_app_router_keeps_its_contract(self):
+        task = self._task()
+        self._worktree_with_app_router(
+            task,
+            "import type { RouteRecordRaw } from 'vue-router'\n"
+            "const routes: RouteRecordRaw[] = [{ path: '/', name: 'home' }]\n"
+            "export { routes }\n",
+        )
+
+        self.service._finalize_task_run(task, self._context(), 'Added a route.')
+
+        task.refresh_from_db()
+        self.assertEqual(task.review_status, 'accepted')
+
     def test_capped_run_still_routes_the_task_back(self):
         # A run stopped by its turn or cost cap has already written files; if
         # it did not finalize, the task would sit at 'active' forever — never

--- a/backend/django/apps/Imagi/ProjectManager/services/codegen/templates.py
+++ b/backend/django/apps/Imagi/ProjectManager/services/codegen/templates.py
@@ -494,10 +494,18 @@ def vue_router_index() -> str:
 // Supports both TS and JS router modules if present
 const modules = import.meta.glob('@/apps/**/router/index.{ts,js}', { eager: true })
 
-// Extract routes from each module (default export or named `routes`)
-const routeModules = Object.values(modules)
-  .map((mod) => (mod && 'default' in mod ? mod.default : (mod && mod.routes) || []))
-  .flat()
+// Extract routes from each module: the named `routes` export is the contract,
+// with a default export accepted only when it is actually an array of routes.
+// Anything else (most importantly a whole Router instance, which vue-router
+// accepts silently and then resolves to NO routes at all) is ignored rather
+// than allowed to take the entire route table down with it.
+const asRoutes = (value) => (Array.isArray(value) ? value : [])
+const pickRoutes = (mod) => {
+  if (!mod) return []
+  const named = asRoutes(mod.routes)
+  return named.length ? named : asRoutes(mod.default)
+}
+const routeModules = Object.values(modules).map(pickRoutes).flat()
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),

--- a/backend/django/apps/Imagi/ProjectManager/services/initial_build_service.py
+++ b/backend/django/apps/Imagi/ProjectManager/services/initial_build_service.py
@@ -14,11 +14,18 @@ the first build the machinery every task already has — it builds in its own
 git worktree, so the project the preview serves is never half-written, and
 its result is merged in one step when it is finished and sound.
 
-"Sound" is enforced, not hoped for: a build cut short by its turn or cost cap
-routinely leaves a page importing a component it never wrote, and Vite serves
-that as a "Failed to resolve import" error instead of the app. Before the
-worktree is merged, the frontend's import graph is checked; a build with
-dangling references gets follow-up repair runs, and one that still doesn't
+The build is bounded by wall-clock time, not by how much it manages to build:
+the founder is waiting on it, so the whole thing — first run plus any repair
+runs — shares one deadline (IMAGI_BUILDER['INITIAL_BUILD_TIME_BUDGET_S']) and
+ships whatever is finished and sound when that runs out. This degrades safely
+because the project already holds a working home + auth scaffold the moment it
+is created: a build that runs short means less tailoring, never a broken app.
+
+"Sound" is enforced, not hoped for: a build cut short by a cap routinely leaves
+a page importing a component it never wrote, and Vite serves that as a "Failed
+to resolve import" error instead of the app. Before the worktree is merged, the
+frontend's import graph is checked; a build with dangling references gets
+follow-up repair runs from whatever time is left, and one that still doesn't
 resolve is never merged — the project keeps its clean, working scaffold.
 
 Build progress is tracked on the existing Project.generation_status field
@@ -27,6 +34,7 @@ Build progress is tracked on the existing Project.generation_status field
 
 import logging
 import threading
+import time
 
 from django.conf import settings
 from django.db import close_old_connections
@@ -75,21 +83,54 @@ Business description (written by the founder):
     return prompt
 
 
-def build_repair_prompt(problems) -> str:
-    """Ask the subagent to fix imports that point at files it never created."""
-    from apps.Imagi.Build.services.frontend_integrity import describe_unresolved_imports
+def build_repair_prompt(problems, router_problems=()) -> str:
+    """Ask the subagent to fix what is keeping its build from being applied.
 
-    return (
-        "Your build is not finished: the frontend imports files that do not "
-        "exist, so the app fails to load with a \"Failed to resolve import\" "
-        "error. Fix every one of these:\n\n"
-        f"{describe_unresolved_imports(problems)}\n\n"
-        "For each: either create the missing file properly, or remove the "
-        "import and whatever depends on it (including its route entry). Do not "
-        "start any new pages or features — this run is only to make what you "
-        "already built load cleanly. Verify with grep_files/read_file that every "
-        "path you reference exists, then summarize what you fixed."
+    Covers both blocking defects: references to files that were never created,
+    and an app router that stopped handing its routes to the root router.
+    """
+    from apps.Imagi.Build.services.frontend_integrity import (
+        describe_router_contract_problems,
+        describe_unresolved_imports,
     )
+
+    sections = ["Your build is not finished and cannot be shown to the founder yet."]
+
+    if problems:
+        sections.append(
+            "The frontend references files that do not exist, so the app fails "
+            "to load with a \"Failed to resolve import\" error. Fix every one "
+            f"of these:\n\n{describe_unresolved_imports(problems)}\n\n"
+            "For each: either create the missing file properly, or remove the "
+            "reference and whatever depends on it (including its route entry). "
+            "If it is an image or media file, remove it — this project has no "
+            "image assets and you cannot create them; use a CSS gradient, a "
+            "colored block, or an inline <svg> instead."
+        )
+
+    if router_problems:
+        sections.append(
+            "An app's router module no longer hands its routes to the project's "
+            "root router, which means every page 404s — including the home page:"
+            f"\n\n{describe_router_contract_problems(router_problems)}\n\n"
+            "Restore the contract: the app's 'router/index.ts' must import its "
+            "view components and export a plain routes array, like\n"
+            "    import type { RouteRecordRaw } from 'vue-router'\n"
+            "    import HomeView from '../views/HomeView.vue'\n"
+            "    const routes: RouteRecordRaw[] = [\n"
+            "      { path: '/', name: 'home-view', component: HomeView }\n"
+            "    ]\n"
+            "    export { routes }\n"
+            "Do NOT call createRouter or createWebHistory in an app router — "
+            "'frontend/vuejs/src/router' already does that and globs up every "
+            "app's routes."
+        )
+
+    sections.append(
+        "Do not start any new pages or features — this run is only to make what "
+        "you already built load cleanly. Then summarize what you fixed."
+    )
+    return "\n\n".join(sections)
 
 
 def start_initial_build(project, user) -> bool:
@@ -258,10 +299,24 @@ def _build_and_apply(service, task, user, project_id, prompt, builder):
     back off the conversation, and anything left unmerged with unresolved
     imports gets a targeted repair run. Returns whether the work landed in
     the project.
+
+    The founder's wait is the binding constraint, so every run in this loop
+    shares ONE deadline rather than getting a fresh budget: a build plus its
+    repairs is held to INITIAL_BUILD_TIME_BUDGET_S in total. When too little
+    time is left for a repair to plausibly finish, it is skipped — starting one
+    that gets killed mid-edit tends to leave more dangling references than it
+    fixes.
     """
-    from apps.Imagi.Build.services.frontend_integrity import find_unresolved_imports
+    from apps.Imagi.Build.services.frontend_integrity import (
+        find_router_contract_problems,
+        find_unresolved_imports,
+    )
 
     attempts = builder.get('INITIAL_BUILD_REPAIR_ATTEMPTS', 2)
+    time_budget = builder.get('INITIAL_BUILD_TIME_BUDGET_S', 60)
+    min_repair_seconds = builder.get('INITIAL_BUILD_MIN_REPAIR_SECONDS', 12)
+    deadline_at = time.monotonic() + time_budget if time_budget else None
+
     user_input = prompt
     max_turns = builder.get('INITIAL_BUILD_MAX_TURNS')
     cost_budget = builder.get('INITIAL_BUILD_COST_BUDGET_USD')
@@ -274,6 +329,7 @@ def _build_and_apply(service, task, user, project_id, prompt, builder):
             conversation_id=task.id,
             max_turns=max_turns,
             cost_budget_usd=cost_budget,
+            deadline_at=deadline_at,
         )
         if not result.get('success'):
             logger.error(
@@ -287,10 +343,13 @@ def _build_and_apply(service, task, user, project_id, prompt, builder):
         if task.review_status == 'accepted':
             return True
 
-        # Not applied. Unresolved imports are the one cause worth another run;
-        # anything else (a merge conflict, a git failure) needs the user.
+        # Not applied. A dangling reference or a broken app-router contract are
+        # the causes worth another run; anything else (a merge conflict, a git
+        # failure) needs the user.
         problems = find_unresolved_imports(task.worktree_path)
-        if not problems:
+        router_problems = find_router_contract_problems(task.worktree_path)
+        blocking = len(problems) + len(router_problems)
+        if not blocking:
             logger.error(
                 "Initial AI build for project %s finished but could not be applied "
                 "(review status %r)",
@@ -301,22 +360,37 @@ def _build_and_apply(service, task, user, project_id, prompt, builder):
         if attempt >= attempts:
             logger.error(
                 "Initial AI build for project %s still has %d unresolved import(s) "
-                "after %d repair attempt(s)",
+                "and %d router problem(s) after %d repair attempt(s)",
                 project_id,
                 len(problems),
+                len(router_problems),
                 attempts,
             )
             return False
 
+        remaining = deadline_at - time.monotonic() if deadline_at else None
+        if remaining is not None and remaining < min_repair_seconds:
+            logger.warning(
+                "Initial AI build for project %s left %d blocking problem(s) with "
+                "only %.1fs of its time budget left; skipping repair so the project "
+                "keeps its working scaffold",
+                project_id,
+                blocking,
+                remaining,
+            )
+            return False
+
         logger.warning(
-            "Initial AI build for project %s left %d unresolved import(s); "
-            "starting repair run %d/%d",
+            "Initial AI build for project %s left %d unresolved import(s) and %d "
+            "router problem(s); starting repair run %d/%d with %s of time budget left",
             project_id,
             len(problems),
+            len(router_problems),
             attempt + 1,
             attempts,
+            f"{remaining:.1f}s" if remaining is not None else "no limit",
         )
-        user_input = build_repair_prompt(problems)
+        user_input = build_repair_prompt(problems, router_problems)
         max_turns = builder.get('INITIAL_BUILD_REPAIR_MAX_TURNS')
         cost_budget = builder.get('INITIAL_BUILD_REPAIR_COST_BUDGET_USD')
 

--- a/backend/django/apps/Imagi/ProjectManager/tests.py
+++ b/backend/django/apps/Imagi/ProjectManager/tests.py
@@ -592,6 +592,102 @@ class InitialBuildServiceTests(TestCase):
         self.project.refresh_from_db()
         self.assertEqual(self.project.generation_status, 'failed')
 
+    def test_a_rewritten_app_router_triggers_a_repair_run(self):
+        # The worst failure mode seen live: the build replaced the home app's
+        # route module with its own createRouter, which compiles and builds
+        # cleanly but leaves every page — including home — 404ing. It must be
+        # repaired before the build can be applied.
+        from apps.Imagi.ProjectManager.services import initial_build_service
+
+        router_problem = [{
+            'file': 'frontend/vuejs/src/apps/home/router/index.ts',
+            'detail': "calls createRouter(), but an app router must only export a 'routes' array",
+        }]
+        with patch(
+            'apps.Imagi.Build.services.frontend_integrity.find_router_contract_problems',
+            return_value=router_problem,
+        ):
+            calls = self._run_build(['leave', 'accept'], unresolved=[])
+
+        self.assertEqual(len(calls), 2, 'a broken app router was not repaired')
+        repair_prompt = calls[1]['user_input']
+        self.assertIn('router/index.ts', repair_prompt)
+        self.assertIn('createRouter', repair_prompt)
+        self.assertIn('export { routes }', repair_prompt)
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.generation_status, 'completed')
+
+    def test_repair_prompt_covers_imports_and_routers_together(self):
+        from apps.Imagi.ProjectManager.services.initial_build_service import (
+            build_repair_prompt,
+        )
+
+        prompt = build_repair_prompt(
+            [{'file': 'HomeView.vue', 'import': '/images/hero.jpg'}],
+            [{'file': 'router/index.ts', 'detail': 'calls createRouter()'}],
+        )
+        self.assertIn('/images/hero.jpg', prompt)
+        self.assertIn('router/index.ts', prompt)
+        # An invented image must be removed, not "created properly" — the
+        # project has no image assets and the agent cannot make binaries.
+        self.assertIn('inline <svg>', prompt)
+
+    def test_every_run_shares_one_wall_clock_deadline(self):
+        # The founder's wait is what is being bounded, so a repair must eat
+        # into the same budget as the build — not restart it. A per-run budget
+        # would let one slow build plus two repairs run three times as long as
+        # the configured limit.
+        calls = self._run_build(
+            ['leave', 'accept'],
+            unresolved=[{
+                'file': 'frontend/vuejs/src/apps/home/views/HomeView.vue',
+                'import': '@/shared/components/SiteHeader.vue',
+            }],
+        )
+
+        self.assertEqual(len(calls), 2)
+        deadlines = {call['deadline_at'] for call in calls}
+        self.assertEqual(len(deadlines), 1, 'each run got its own deadline')
+        self.assertIsNotNone(calls[0]['deadline_at'])
+
+    def test_deadline_is_the_configured_time_budget_away(self):
+        from apps.Imagi.ProjectManager.services import initial_build_service
+
+        with patch.object(initial_build_service.time, 'monotonic', return_value=1000.0):
+            calls = self._run_build(['accept'])
+
+        self.assertEqual(
+            calls[0]['deadline_at'],
+            1000.0 + settings.IMAGI_BUILDER['INITIAL_BUILD_TIME_BUDGET_S'],
+        )
+
+    def test_repair_is_skipped_when_too_little_time_remains(self):
+        # Starting a repair that will be killed mid-edit tends to leave more
+        # dangling references than it fixes, so a build with no time left keeps
+        # its scaffold instead.
+        from apps.Imagi.ProjectManager.services import initial_build_service
+
+        budget = settings.IMAGI_BUILDER['INITIAL_BUILD_TIME_BUDGET_S']
+        min_repair = settings.IMAGI_BUILDER['INITIAL_BUILD_MIN_REPAIR_SECONDS']
+        # First reading sets the deadline; the second is checked before repair,
+        # by which point less than the repair minimum is left.
+        clock = iter([0.0, budget - (min_repair / 2)])
+
+        with patch.object(
+            initial_build_service.time, 'monotonic', side_effect=lambda: next(clock)
+        ):
+            calls = self._run_build(
+                ['leave', 'accept'],
+                unresolved=[{
+                    'file': 'frontend/vuejs/src/apps/home/views/HomeView.vue',
+                    'import': '@/shared/components/SiteHeader.vue',
+                }],
+            )
+
+        self.assertEqual(len(calls), 1, 'a repair ran with no time budget left')
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.generation_status, 'failed')
+
 
 @override_settings(PROJECTS_ROOT=_TMP_PROJECTS_ROOT)
 class ScaffoldWiringTests(TestCase):

--- a/backend/django/imagi/settings.py
+++ b/backend/django/imagi/settings.py
@@ -265,21 +265,45 @@ IMAGI_BUILDER = {
     'MAX_AGENT_TURNS': 30,
     # Initial build (the first build of a new project, dispatched from the
     # project's main thread to a background subagent) runs headless and
-    # unattended, so it gets its own model and tighter caps. The cost budget is
-    # the primary bound: the run stops once its token cost reaches this many
-    # dollars. The turn cap is a backstop against a run that spins without
-    # spending much. Together they keep a first build from running away.
+    # unattended, so it gets its own model and tighter caps.
+    #
+    # TIME is the primary bound, because the founder is sitting there waiting:
+    # the whole build — first run plus any repair runs — is held to this many
+    # seconds, and whatever is finished and sound by then is what ships. The
+    # project already holds a working home + auth scaffold from the moment it is
+    # created, so a build that stops early degrades to "less tailoring", never
+    # to a broken or empty app.
+    # Held a little under a minute on purpose: this bounds the agent's own run,
+    # and the founder additionally waits on the work either side of it (worktree
+    # setup, then the merge and database mirror on the way out) — measured at
+    # ~2s combined. 55 keeps the end-to-end wait under a minute.
     'INITIAL_BUILD_MODEL': 'gpt-5.6-terra',
-    'INITIAL_BUILD_COST_BUDGET_USD': 0.50,
+    'INITIAL_BUILD_TIME_BUDGET_S': 55,
+    # First builds create UI from a description rather than reasoning about
+    # existing code, so they run at low effort: it roughly halves per-turn
+    # latency, which buys more pages inside the time budget than deeper
+    # reasoning does.
+    'INITIAL_BUILD_REASONING_EFFORT': 'low',
+    # Cost and turns are runaway backstops now, not the operative limit — the
+    # time budget stops a normal build long before either binds. NOTE: the cost
+    # figure is priced with the *suite retail* rates in models_service (what a
+    # run is displayed as costing), which are a multiple of the underlying API
+    # price — so this is deliberately well above real expected spend. Sized so
+    # it never cuts a build short on its own; time does that.
+    'INITIAL_BUILD_COST_BUDGET_USD': 3.00,
     'INITIAL_BUILD_MAX_TURNS': 24,
-    # A build that stops at one of those caps can leave a page importing a
-    # component it never wrote, which takes the whole preview down. Such a
-    # build is not merged into the project; instead the subagent gets up to
-    # this many follow-up runs to repair the dangling references, each on a
-    # smaller budget (repair is a short, targeted job).
+    # A build that stops at a cap can leave a page importing a component it
+    # never wrote, which takes the whole preview down. Such a build is not
+    # merged; instead the subagent gets up to this many short follow-up runs to
+    # repair the dangling references — but only from whatever time is left in
+    # the budget above, so repair can never extend the founder's wait.
     'INITIAL_BUILD_REPAIR_ATTEMPTS': 2,
-    'INITIAL_BUILD_REPAIR_COST_BUDGET_USD': 0.20,
+    'INITIAL_BUILD_REPAIR_COST_BUDGET_USD': 1.00,
     'INITIAL_BUILD_REPAIR_MAX_TURNS': 12,
+    # Skip a repair run that cannot plausibly finish in the time left, rather
+    # than starting one that will be killed mid-edit (which tends to leave more
+    # dangling references than it fixes).
+    'INITIAL_BUILD_MIN_REPAIR_SECONDS': 12,
     # Attach OpenAI's hosted web-search tool to the agent.
     'ENABLE_WEB_SEARCH': True,
     # Apps scaffolded into every new project. Payment pages are deliberately


### PR DESCRIPTION
A new project's first build took far longer than a founder should wait — recorded runs spent 73s, 111s, and 156s on their *first* run alone, and two of three ended at a cap having built almost nothing. With up to two repair runs each starting a fresh budget, the worst case ran 3-6 minutes and often finished 'failed', leaving the plain scaffold.

The scaffold was never the problem: filesystem work, in-process startproject, the database mirror, and the git worktree together measure 0.6s. All of the latency was the agent loop, and the cap that kept cutting it short was mispriced. compute_cost_usd values a run at suite *retail* rates, so a $0.50 budget stopped the build at roughly $0.05 of real API spend, mid-page.

Time is now the operative bound, since time is what the founder actually experiences:

- A run-bounds hook stops a run at a wall-clock deadline, checked after each model turn, and the build shares ONE deadline with all of its repair runs (INITIAL_BUILD_TIME_BUDGET_S = 55) instead of each getting a fresh budget. A repair with too little time left is skipped rather than started and killed mid-edit. Cost and turns remain as runaway backstops, with the retail-vs-real pricing gap recorded so the next person doesn't re-tune it blind.
- The first build runs at low reasoning effort and without the hosted web search tool, whose schema taxed every turn's prompt.
- It gets its own working style. The builder style it inherited mandates "search, then read, then edit narrowly" — right for changing existing code, wasteful when the target is a scaffold we generated ourselves. It now receives the exact paths and a priority ladder: landing page first, further pages only if time allows, each wired completely before the next.
- A capped run reports what it built. Stopping at the deadline is now the normal ending, so the run's files are read back off its worktree instead of leaving only "I reached this build's limit" with empty metadata.

Two failure modes found by building and running the output, both of which compile, type-check, and pass `vite build` while leaving the app broken:

- An invented image asset. A build wrote <img src="/images/coffee-hero.jpg">; generated projects ship no public/ directory, so every image reference is dangling — a broken image in dev and a failed production build. The prompt now forbids referencing media outright and directs it to gradients, colored blocks, and inline SVG it can actually author. The integrity check never saw this class at all: it now also checks static template src/poster attributes and root-absolute paths, while skipping :src bindings, remote URLs and data: URIs.
- An app router rewritten as a standalone createRouter(...). The root router globs app modules expecting a `routes` array; handed a Router instance, vue-router accepts it silently and resolves to NO routes, so every URL including '/' falls through to the 404 page. This one merged as 'accepted'.

So the build may now change pages, and only pages. The prompt carries an explicit do-not-touch list (root router, main.ts, App.vue, shared/, the auth app, build config, backend) and adding a page means adding one route entry with edit_file. The merge gate enforces the router contract mechanically for every task, since it is a true architectural invariant, and a first build that breaks it gets a repair run naming the exact fix. The generated root router template now accepts only arrays, so a bad app module is ignored instead of taking the whole route table down.

Measured across three live end-to-end builds: 53s, 56s, and 61s, all merged cleanly, all passing `vite build`, with the router and every structural file untouched.