### PR TITLE
Give the subagent list a spine

### DIFF
--- a/frontend/vuejs/src/apps/imagi/build/components/molecules/sidebar/AgentInstanceCard.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/molecules/sidebar/AgentInstanceCard.vue
@@ -1,128 +1,131 @@
+<!--
+  AgentInstanceCard.vue — one subagent, as a line in the crew ledger.
+
+  Each card is spined by a status rail on its left edge: the rail is the only
+  thing that differs at a glance, so a column of these reads as a single
+  instrument — live work travels down the rail, work waiting on you sits as
+  solid ink, settled work fades to a hairline. The agent's name is set in the
+  brand serif, which makes the list read as a cast of characters rather than
+  another stack of chat rows.
+-->
 <template>
-  <div
+  <article
     :class="[
-      'group relative rounded-lg border px-2.5 py-2 cursor-pointer transition-all duration-200',
-      isActive
-        ? 'instance-card--active border-blue-300/80 dark:border-blue-400/40'
-        : 'border-blue-950/[0.08] dark:border-white/[0.1] bg-blue-50/40 hover:bg-blue-50 hover:border-blue-950/[0.16] dark:bg-white/[0.02] dark:hover:bg-white/[0.05] dark:hover:border-white/[0.18]',
-      isArchived ? 'opacity-70 hover:opacity-100' : ''
+      'agent-card group',
+      `agent-card--${status.state}`,
+      isActive ? 'agent-card--active' : '',
+      isArchived ? 'agent-card--archived' : ''
     ]"
+    :style="{ '--stagger': `${Math.min(index, 8) * 45}ms` }"
+    role="button"
+    tabindex="0"
+    :aria-current="isActive ? 'true' : undefined"
     @click="emit('select')"
+    @keydown.enter.prevent="emit('select')"
+    @keydown.space.prevent="emit('select')"
   >
-    <!-- Title row -->
-    <div class="flex items-start gap-2">
-      <div class="flex-1 min-w-0">
-        <div
-          :class="[
-            'text-xs truncate transition-colors duration-200',
-            isActive
-              ? 'font-semibold text-blue-950 dark:text-white'
-              : 'font-medium text-blue-950/80 dark:text-blue-100/75 group-hover:text-blue-950 dark:group-hover:text-white'
-          ]"
-        >
-          {{ instance.title || 'Untitled agent' }}
-        </div>
-        <!-- What this agent is doing right now. Active agents share one list,
-             so the status is what tells them apart. -->
-        <div class="flex items-center gap-1 mt-1 text-[10px]" :class="status.tone">
-          <i :class="[status.icon, 'text-[9px]']"></i>
-          <span class="truncate">{{ status.label }}</span>
-        </div>
-        <div class="flex items-center gap-1.5 mt-0.5 text-[10px] text-blue-950/40 dark:text-blue-100/45">
-          <span>{{ relativeTime(instance.updatedAt) }}</span>
-          <!-- Conversation-wide token total; null means never captured, so
-               nothing renders (unknown, not "0 tokens") -->
-          <span
-            v-if="typeof instance.totalTokens === 'number' && instance.totalTokens > 0"
-            :title="`${instance.totalTokens.toLocaleString()} tokens used`"
-          >
-            · {{ formatTokens(instance.totalTokens) }} tokens
-          </span>
-        </div>
+    <!-- The spine: state as a vertical rail, animated while a run is live -->
+    <span class="agent-card__rail" aria-hidden="true"></span>
+
+    <div class="agent-card__body">
+      <!-- Name + the two markers that can sit beside it -->
+      <div class="flex items-start gap-1.5">
+        <h3 class="agent-card__title">{{ instance.title || 'Untitled agent' }}</h3>
+
+        <!-- One of several parallel takes on the same brief -->
+        <span
+          v-if="variantCount && variantCount > 1"
+          class="agent-card__take"
+          :title="`Take ${variantIndex} of ${variantCount} on the same brief`"
+        >{{ variantIndex }}/{{ variantCount }}</span>
+
+        <!-- A run finished while this instance was off-screen -->
+        <span
+          v-if="instance.hasUnread"
+          class="agent-card__unread"
+          title="Agent finished while you were away"
+        ></span>
       </div>
 
-      <!-- Unread dot: a run finished while this instance was off-screen.
-           No per-card actions: an agent's work ends by being added to the app
-           or discarded from the main thread's queue, after which the card
-           settles into History as the record of what happened. -->
-      <span
-        v-if="instance.hasUnread"
-        class="shrink-0 w-1.5 h-1.5 mt-1.5 rounded-full bg-blue-950 dark:bg-[#f3ede2]"
-        title="Agent finished while you were away"
-      ></span>
+      <!-- Where this agent stands. While a run is live this carries the
+           agent's own words for what it is doing right now. -->
+      <div class="agent-card__status">
+        <i :class="[status.icon, 'agent-card__status-icon']"></i>
+        <span class="truncate">{{ status.label }}</span>
+      </div>
+
+      <!-- Ledger line: when it last moved, and what it has spent -->
+      <div class="agent-card__meta">
+        <span>{{ relativeTime(instance.updatedAt) }}</span>
+        <!-- Conversation-wide token total; null means never captured, so
+             nothing renders (unknown, not "0 tokens") -->
+        <template v-if="typeof instance.totalTokens === 'number' && instance.totalTokens > 0">
+          <span class="agent-card__dot" aria-hidden="true"></span>
+          <span :title="`${instance.totalTokens.toLocaleString()} tokens used`">
+            {{ formatTokens(instance.totalTokens) }} tokens
+          </span>
+        </template>
+      </div>
     </div>
-  </div>
+
+    <!-- Open affordance: no per-card actions, because an agent's work ends by
+         being added to the app or discarded from the main thread's queue —
+         this only says the thread is readable. -->
+    <i class="fas fa-chevron-right agent-card__chevron" aria-hidden="true"></i>
+  </article>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { AgentInstance } from '../../../types/services'
 
-const props = defineProps<{
-  instance: AgentInstance
-  isActive: boolean
-  isArchived?: boolean
-}>()
+const props = withDefaults(
+  defineProps<{
+    instance: AgentInstance
+    isActive: boolean
+    isArchived?: boolean
+    /** Position in its list — drives the staggered entrance only */
+    index?: number
+    /** This take's place among parallel takes on one brief */
+    variantIndex?: number
+    variantCount?: number
+  }>(),
+  { index: 0 }
+)
 
 /**
- * One line describing where this agent stands. Running beats everything (a
- * re-prompted agent is working again whatever its last outcome was), then the
- * states that want the user, then the settled ones.
+ * One line describing where this agent stands, plus the state token the rail
+ * and tones key off. Running beats everything (a re-prompted agent is working
+ * again whatever its last outcome was), then the states that want the user,
+ * then the settled ones.
  */
 const status = computed(() => {
   const instance = props.instance
   if (instance.isProcessing) {
     return {
-      label: 'Working…',
+      state: 'working' as const,
+      // The agent's own account of the current step, when it has one.
+      label: instance.statusText || 'Working…',
       icon: 'fas fa-circle-notch fa-spin',
-      tone: 'text-blue-600 dark:text-blue-300',
     }
   }
   if (instance.archivedAt) {
-    return {
-      label: 'Archived',
-      icon: 'fas fa-box-archive',
-      tone: 'text-blue-950/40 dark:text-blue-100/40',
-    }
+    return { state: 'settled' as const, label: 'Archived', icon: 'fas fa-box-archive' }
   }
   switch (instance.reviewStatus) {
     case 'input':
-      return {
-        label: 'Asked you a question',
-        icon: 'fas fa-circle-question',
-        tone: 'text-blue-950/60 dark:text-blue-100/60',
-      }
+      return { state: 'waiting' as const, label: 'Asked you a question', icon: 'fas fa-circle-question' }
     case 'ready':
-      return {
-        label: 'Finished — waiting on you',
-        icon: 'fas fa-check',
-        tone: 'text-blue-950/60 dark:text-blue-100/60',
-      }
+      return { state: 'waiting' as const, label: 'Finished — waiting on you', icon: 'fas fa-check' }
     case 'accepted':
-      return {
-        label: 'Added to your app',
-        icon: 'fas fa-check-double',
-        tone: 'text-blue-950/40 dark:text-blue-100/40',
-      }
+      return { state: 'settled' as const, label: 'Added to your app', icon: 'fas fa-check-double' }
     case 'dismissed':
-      return {
-        label: 'Discarded',
-        icon: 'fas fa-xmark',
-        tone: 'text-blue-950/40 dark:text-blue-100/40',
-      }
+      return { state: 'settled' as const, label: 'Discarded', icon: 'fas fa-xmark' }
     case 'active':
       // A dispatched agent between creation and its run starting.
-      return {
-        label: 'Starting…',
-        icon: 'fas fa-hourglass-start',
-        tone: 'text-blue-950/45 dark:text-blue-100/45',
-      }
+      return { state: 'starting' as const, label: 'Starting…', icon: 'fas fa-hourglass-start' }
     default:
-      return {
-        label: 'Idle',
-        icon: 'fas fa-comments',
-        tone: 'text-blue-950/40 dark:text-blue-100/40',
-      }
+      return { state: 'settled' as const, label: 'Idle', icon: 'fas fa-comments' }
   }
 })
 
@@ -157,8 +160,61 @@ function relativeTime(iso: string): string {
 </script>
 
 <style scoped>
-/* Selected card - soft baby-blue wash matching the site's primary accent */
-.instance-card--active {
+/* ── The card ───────────────────────────────────────────────────────────── */
+
+.agent-card {
+  --rail: rgba(23, 37, 84, 0.14);
+  --status: rgba(23, 37, 84, 0.55);
+
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.375rem;
+  padding: 0.4375rem 0.5rem 0.4375rem 0.75rem;
+  border-radius: 0.625rem;
+  border: 1px solid rgba(23, 37, 84, 0.07);
+  background: rgba(239, 246, 255, 0.4);
+  cursor: pointer;
+  overflow: hidden;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    transform 0.2s cubic-bezier(0.22, 1, 0.36, 1);
+  animation: agent-card-in 0.45s cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: var(--stagger, 0ms);
+}
+
+.dark .agent-card {
+  --rail: rgba(255, 255, 255, 0.16);
+  --status: rgba(219, 234, 254, 0.6);
+  border-color: rgba(255, 255, 255, 0.09);
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.agent-card:hover {
+  background: rgba(239, 246, 255, 0.95);
+  border-color: rgba(23, 37, 84, 0.14);
+  transform: translateX(1px);
+}
+
+.dark .agent-card:hover {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: rgba(255, 255, 255, 0.17);
+}
+
+.agent-card:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.45);
+}
+
+.dark .agent-card:focus-visible {
+  box-shadow: 0 0 0 2px rgba(147, 197, 253, 0.5);
+}
+
+/* Selected — the soft baby-blue wash the workspace uses for "you are here" */
+.agent-card--active {
+  border-color: rgba(147, 197, 253, 0.85);
   background: linear-gradient(155deg, rgba(219, 238, 255, 0.9) 0%, rgba(183, 221, 247, 0.45) 100%);
   box-shadow:
     0 1px 2px rgba(30, 58, 138, 0.08),
@@ -166,10 +222,279 @@ function relativeTime(iso: string): string {
     inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
-.dark .instance-card--active {
+.agent-card--active:hover {
+  background: linear-gradient(155deg, rgba(219, 238, 255, 1) 0%, rgba(183, 221, 247, 0.55) 100%);
+  border-color: rgba(147, 197, 253, 1);
+}
+
+.dark .agent-card--active,
+.dark .agent-card--active:hover {
+  border-color: rgba(96, 165, 250, 0.42);
   background: linear-gradient(155deg, rgba(96, 165, 250, 0.14) 0%, rgba(96, 165, 250, 0.05) 100%);
   box-shadow:
     0 1px 2px rgba(0, 0, 0, 0.3),
     inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.agent-card--archived {
+  opacity: 0.72;
+}
+
+.agent-card--archived:hover {
+  opacity: 1;
+}
+
+/* ── The spine ──────────────────────────────────────────────────────────── */
+
+.agent-card__rail {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 0.1875rem;
+  background: var(--rail);
+}
+
+/* Live run: ink travels down the rail, and the card breathes with the faintest
+   left-edge glow. This is the one moving thing in the list. */
+.agent-card--working {
+  --rail: rgba(37, 99, 235, 0.32);
+  --status: theme('colors.blue.600');
+}
+
+.dark .agent-card--working {
+  --rail: rgba(147, 197, 253, 0.3);
+  --status: theme('colors.blue.300');
+}
+
+.agent-card--working .agent-card__rail::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    theme('colors.blue.500') 40%,
+    theme('colors.blue.400') 60%,
+    transparent 100%
+  );
+  animation: rail-travel 2.1s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+}
+
+.dark .agent-card--working .agent-card__rail::after {
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    theme('colors.blue.300') 40%,
+    theme('colors.blue.200') 60%,
+    transparent 100%
+  );
+}
+
+/* Waiting on you: solid navy ink — a full-height mark you can spot from the
+   top of the list without reading a word. */
+.agent-card--waiting {
+  --rail: theme('colors.blue.950');
+  --status: rgba(23, 37, 84, 0.78);
+}
+
+.dark .agent-card--waiting {
+  --rail: #f3ede2;
+  --status: rgba(243, 237, 226, 0.85);
+}
+
+/* Dispatched but not yet running — the rail is drawn but not yet filled */
+.agent-card--starting {
+  --rail: repeating-linear-gradient(
+    180deg,
+    rgba(23, 37, 84, 0.3) 0 3px,
+    transparent 3px 7px
+  );
+  --status: rgba(23, 37, 84, 0.5);
+}
+
+.dark .agent-card--starting {
+  --rail: repeating-linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.3) 0 3px,
+    transparent 3px 7px
+  );
+  --status: rgba(219, 234, 254, 0.5);
+}
+
+/* Settled work recedes to a hairline */
+.agent-card--settled {
+  --rail: rgba(23, 37, 84, 0.1);
+  --status: rgba(23, 37, 84, 0.42);
+}
+
+.dark .agent-card--settled {
+  --rail: rgba(255, 255, 255, 0.1);
+  --status: rgba(219, 234, 254, 0.4);
+}
+
+/* ── Contents ───────────────────────────────────────────────────────────── */
+
+.agent-card__body {
+  flex: 1;
+  min-width: 0;
+}
+
+/* The name carries the brand serif (Fraunces), the same face as the pane
+   masthead — a subagent gets a byline, not a filename. */
+.agent-card__title {
+  flex: 1;
+  min-width: 0;
+  font-family: theme('fontFamily.display');
+  font-variation-settings: 'opsz' 11, 'SOFT' 30, 'WONK' 1;
+  font-size: 0.8125rem;
+  font-weight: 550;
+  line-height: 1.25;
+  letter-spacing: -0.006em;
+  color: rgba(23, 37, 84, 0.86);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition: color 0.2s ease;
+}
+
+.dark .agent-card__title {
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.agent-card:hover .agent-card__title,
+.agent-card--active .agent-card__title {
+  color: theme('colors.blue.950');
+}
+
+.dark .agent-card:hover .agent-card__title,
+.dark .agent-card--active .agent-card__title {
+  color: #ffffff;
+}
+
+.agent-card--active .agent-card__title {
+  font-weight: 650;
+}
+
+/* Take marker for parallel attempts at one brief */
+.agent-card__take {
+  flex-shrink: 0;
+  margin-top: 0.0625rem;
+  padding: 0 0.25rem;
+  border-radius: 0.25rem;
+  background: rgba(23, 37, 84, 0.07);
+  color: rgba(23, 37, 84, 0.55);
+  font-size: 0.5625rem;
+  font-weight: 600;
+  line-height: 1.05rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.dark .agent-card__take {
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(219, 234, 254, 0.6);
+}
+
+.agent-card__unread {
+  flex-shrink: 0;
+  width: 0.375rem;
+  height: 0.375rem;
+  margin-top: 0.3125rem;
+  border-radius: 9999px;
+  background: theme('colors.blue.950');
+  box-shadow: 0 0 0 2px rgba(219, 238, 255, 0.9);
+}
+
+.dark .agent-card__unread {
+  background: #f3ede2;
+  box-shadow: 0 0 0 2px rgba(10, 10, 10, 0.9);
+}
+
+.agent-card__status {
+  display: flex;
+  align-items: center;
+  gap: 0.3125rem;
+  margin-top: 0.1875rem;
+  font-size: 0.625rem;
+  line-height: 1.35;
+  color: var(--status);
+  transition: color 0.2s ease;
+}
+
+.agent-card__status-icon {
+  flex-shrink: 0;
+  font-size: 0.5625rem;
+}
+
+.agent-card__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.3125rem;
+  margin-top: 0.125rem;
+  font-size: 0.625rem;
+  letter-spacing: 0.004em;
+  font-variant-numeric: tabular-nums;
+  color: rgba(23, 37, 84, 0.38);
+}
+
+.dark .agent-card__meta {
+  color: rgba(219, 234, 254, 0.35);
+}
+
+.agent-card__dot {
+  width: 0.125rem;
+  height: 0.125rem;
+  border-radius: 9999px;
+  background: currentColor;
+  opacity: 0.7;
+}
+
+/* Quiet until hover — the row is clickable, but it does not advertise it */
+.agent-card__chevron {
+  flex-shrink: 0;
+  align-self: center;
+  font-size: 0.5rem;
+  color: rgba(23, 37, 84, 0.3);
+  opacity: 0;
+  transform: translateX(-3px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.dark .agent-card__chevron {
+  color: rgba(255, 255, 255, 0.35);
+}
+
+.agent-card:hover .agent-card__chevron,
+.agent-card:focus-visible .agent-card__chevron,
+.agent-card--active .agent-card__chevron {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+/* ── Motion ─────────────────────────────────────────────────────────────── */
+
+@keyframes rail-travel {
+  0% { transform: translateY(-100%); }
+  100% { transform: translateY(100%); }
+}
+
+@keyframes agent-card-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .agent-card {
+    animation: none;
+  }
+
+  .agent-card--working .agent-card__rail::after {
+    animation: none;
+    background: theme('colors.blue.500');
+  }
+
+  .agent-card:hover {
+    transform: none;
+  }
 }
 </style>

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/AgentManagerPanel.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/AgentManagerPanel.vue
@@ -1,3 +1,12 @@
+<!--
+  AgentManagerPanel.vue — the crew ledger.
+
+  Everything the project's subagents are doing, in one column. The pane wears
+  the same masthead as the chat pane, then states the fleet twice: once as a
+  meter (how the work splits between running and waiting on you) and once as
+  the cards themselves. Read-only by design — decisions happen in the main
+  agent's check-in queue, so this pane's whole job is legibility.
+-->
 <template>
   <div class="flex flex-col h-full bg-white dark:bg-[#0a0a0a] transition-colors duration-300">
     <!-- Header: the same plate the chat pane wears, switching back the other
@@ -8,7 +17,7 @@
       tone="muted"
       title="Subagents"
       :status="fleetStatus"
-      :live="activeAgents.some(a => a.isProcessing)"
+      :live="workingCount > 0"
       switch-icon="fas fa-comments"
       switch-label="Main agent"
       :switch-count="store.checkIns.length"
@@ -16,56 +25,90 @@
       @switch="emit('collapse')"
     />
 
+    <!-- Fleet meter: the same numbers as the status line, drawn. Segments are
+         proportional, so a glance says whether the crew is busy or the pile of
+         work waiting on you is the bigger half. -->
+    <div v-if="activeAgents.length > 0" class="fleet-meter" :title="fleetStatus">
+      <span
+        v-for="seg in fleetSegments"
+        :key="seg.key"
+        :class="['fleet-meter__seg', `fleet-meter__seg--${seg.key}`]"
+        :style="{ flexGrow: seg.count }"
+      ></span>
+    </div>
+
     <!-- Team view -->
-    <div class="flex-1 min-h-0 overflow-y-auto px-2 py-2 space-y-1">
-      <!-- Loading state -->
-      <div
-        v-if="store.instancesLoading && store.instances.length === 0"
-        class="flex items-center justify-center gap-2 px-2 py-8 text-xs text-blue-950/40 dark:text-blue-100/45"
-      >
-        <i class="fas fa-circle-notch fa-spin text-[11px]"></i>
-        <span>Loading agents…</span>
+    <div class="flex-1 min-h-0 overflow-y-auto px-2 py-2">
+      <!-- Loading: the shape of the list, before the list -->
+      <div v-if="store.instancesLoading && store.instances.length === 0" class="space-y-1.5 pt-1">
+        <div v-for="n in 3" :key="n" class="skeleton-card" :style="{ '--stagger': `${n * 90}ms` }">
+          <span class="skeleton-rail"></span>
+          <div class="flex-1 space-y-1.5">
+            <div class="skeleton-line" :style="{ width: n === 2 ? '58%' : '72%' }"></div>
+            <div class="skeleton-line skeleton-line--faint" :style="{ width: n === 3 ? '34%' : '46%' }"></div>
+          </div>
+        </div>
+        <p class="pt-1 text-center text-[10px] text-blue-950/35 dark:text-white/30">Loading agents…</p>
       </div>
 
       <template v-else>
         <!-- Active: every subagent still on the hook — running, waiting on an
              answer, or finished but not yet accepted. One list, because to the
-             user they are one thing; the status line says which is which.
+             user they are one thing; the rail and status say which is which.
              Read-only: decisions happen in the main agent's queue. -->
-        <div class="section-label px-2 pt-1 pb-1.5">Active</div>
-        <template v-if="activeAgents.length > 0">
+        <div class="section-head">
+          <span class="section-head__label">Active</span>
+          <span v-if="activeAgents.length" class="section-head__count">{{ activeAgents.length }}</span>
+          <span class="section-head__rule"></span>
+        </div>
+
+        <div v-if="activeAgents.length > 0" class="space-y-1">
           <InstanceCard
-            v-for="instance in activeAgents"
+            v-for="(instance, i) in activeAgents"
             :key="instance.id"
             :instance="instance"
+            :index="i"
             :is-active="instance.id === store.activeInstanceId"
+            :variant-index="variantPlace(instance).index"
+            :variant-count="variantPlace(instance).count"
             @select="handleSelect(instance.id)"
           />
-        </template>
-        <div v-else class="px-2 pb-1 text-[11px] text-blue-950/35 dark:text-white/30">
-          No agents working right now. Ask for what you want in your chat — your
-          agent hands off anything worth building in parallel.
+        </div>
+
+        <!-- Nothing running: say what would put something here -->
+        <div v-else class="empty-plate">
+          <span class="empty-plate__mark"><i class="fas fa-layer-group text-[10px]"></i></span>
+          <p class="empty-plate__title">No agents working right now</p>
+          <p class="empty-plate__body">
+            Ask for what you want in your chat — your agent hands off anything
+            worth building in parallel.
+          </p>
         </div>
 
         <!-- History: archived threads, legacy chats, resolved tasks -->
         <template v-if="history.length > 0">
           <button
-            class="w-full flex items-center justify-between rounded-md px-2 py-2 mt-3 text-[10px] font-semibold uppercase tracking-wider text-blue-950/40 dark:text-white/40 hover:text-blue-950/70 dark:hover:text-white/70 hover:bg-blue-50/60 dark:hover:bg-white/[0.04] transition-colors"
+            type="button"
+            class="section-head section-head--button"
+            :aria-expanded="showHistory"
             @click="showHistory = !showHistory"
           >
-            <span>History ({{ history.length }})</span>
-            <i :class="['fas text-[9px]', showHistory ? 'fa-chevron-down' : 'fa-chevron-right']"></i>
+            <i :class="['fas fa-chevron-right section-head__chevron', showHistory ? 'is-open' : '']"></i>
+            <span class="section-head__label">History</span>
+            <span class="section-head__count">{{ history.length }}</span>
+            <span class="section-head__rule"></span>
           </button>
-          <template v-if="showHistory">
+          <div v-if="showHistory" class="space-y-1">
             <InstanceCard
-              v-for="instance in history"
+              v-for="(instance, i) in history"
               :key="instance.id"
               :instance="instance"
+              :index="i"
               :is-active="instance.id === store.activeInstanceId"
               :is-archived="!!instance.archivedAt"
               @select="handleSelect(instance.id)"
             />
-          </template>
+          </div>
         </template>
       </template>
     </div>
@@ -77,6 +120,7 @@ import { computed, ref } from 'vue'
 import { useAgentStore } from '../../../stores/agentStore'
 import InstanceCard from '../../molecules/sidebar/AgentInstanceCard.vue'
 import WorkspacePaneHeader from '../../molecules/sidebar/WorkspacePaneHeader.vue'
+import type { AgentInstance } from '../../../types/services'
 
 const emit = defineEmits<{
   (e: 'collapse'): void
@@ -92,15 +136,56 @@ const showHistory = ref(false)
 const activeAgents = computed(() => store.activeAgentInstances)
 const history = computed(() => store.historyInstances)
 
+const workingCount = computed(() => activeAgents.value.filter(a => a.isProcessing).length)
+
 /** The fleet at a glance, leading with whoever is actually working. */
 const fleetStatus = computed(() => {
   const total = activeAgents.value.length
   if (total === 0) return 'No agents working'
-  const working = activeAgents.value.filter(a => a.isProcessing).length
+  const working = workingCount.value
   if (working === total) return `${total} ${total === 1 ? 'agent' : 'agents'} working`
   if (working > 0) return `${working} working · ${total - working} waiting on you`
   return `${total} ${total === 1 ? 'agent' : 'agents'} waiting on you`
 })
+
+/**
+ * The meter's segments, in the order the eye should read them: live work
+ * first, then what wants the user, then what has not started. Empty segments
+ * are dropped so the bar never carries a zero-width sliver.
+ */
+const fleetSegments = computed(() => {
+  const agents = activeAgents.value
+  const working = agents.filter(a => a.isProcessing).length
+  const starting = agents.filter(a => !a.isProcessing && a.reviewStatus === 'active').length
+  const waiting = agents.length - working - starting
+  return [
+    { key: 'working', count: working },
+    { key: 'waiting', count: waiting },
+    { key: 'starting', count: starting },
+  ].filter(s => s.count > 0)
+})
+
+/**
+ * Parallel takes on one brief share a variant group. A card that is one of
+ * several says so — otherwise accepting the first one looks like the only
+ * option. Ungrouped tasks report a count of 1 and render no marker.
+ */
+const variantPlaces = computed(() => {
+  const groups = new Map<string, string[]>()
+  for (const instance of activeAgents.value) {
+    if (!instance.variantGroup) continue
+    const ids = groups.get(instance.variantGroup) ?? []
+    ids.push(instance.id)
+    groups.set(instance.variantGroup, ids)
+  }
+  return groups
+})
+
+function variantPlace(instance: AgentInstance): { index: number; count: number } {
+  const siblings = instance.variantGroup ? variantPlaces.value.get(instance.variantGroup) : undefined
+  if (!siblings || siblings.length < 2) return { index: 1, count: 1 }
+  return { index: siblings.indexOf(instance.id) + 1, count: siblings.length }
+}
 
 async function handleSelect(id: string) {
   emit('select', id)
@@ -109,16 +194,302 @@ async function handleSelect(id: string) {
 </script>
 
 <style scoped>
-/* Section labels share the workspace's uppercase micro-label convention */
-.section-label {
-  font-size: 10px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: rgba(23, 37, 84, 0.4);
+/* ── Fleet meter ────────────────────────────────────────────────────────── */
+
+.fleet-meter {
+  display: flex;
+  gap: 0.125rem;
+  height: 0.125rem;
+  margin: 0 0.875rem;
+  padding-top: 0.5rem;
+  box-sizing: content-box;
 }
 
-.dark .section-label {
+.fleet-meter__seg {
+  flex-basis: 0;
+  border-radius: 9999px;
+  transition: flex-grow 0.35s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* Same three tones the card rails use, so the bar reads as a key to the list */
+.fleet-meter__seg--working {
+  background: linear-gradient(
+    90deg,
+    theme('colors.blue.400') 0%,
+    theme('colors.blue.600') 50%,
+    theme('colors.blue.400') 100%
+  );
+  background-size: 200% 100%;
+  animation: fleet-drift 2.8s linear infinite;
+}
+
+.fleet-meter__seg--waiting {
+  background: theme('colors.blue.950');
+}
+
+.fleet-meter__seg--starting {
+  background: rgba(23, 37, 84, 0.2);
+}
+
+.dark .fleet-meter__seg--working {
+  background: linear-gradient(
+    90deg,
+    theme('colors.blue.300') 0%,
+    theme('colors.blue.200') 50%,
+    theme('colors.blue.300') 100%
+  );
+  background-size: 200% 100%;
+}
+
+.dark .fleet-meter__seg--waiting {
+  background: #f3ede2;
+}
+
+.dark .fleet-meter__seg--starting {
+  background: rgba(255, 255, 255, 0.22);
+}
+
+@keyframes fleet-drift {
+  from { background-position: 200% 0; }
+  to { background-position: 0 0; }
+}
+
+/* ── Section heads ──────────────────────────────────────────────────────── */
+
+/* Uppercase micro-label, its count, then a hairline running to the edge —
+   the workspace's label convention, given a rule so sections separate without
+   another box. */
+.section-head {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  width: 100%;
+  padding: 0.375rem 0.5rem 0.5rem;
+  text-align: left;
+}
+
+.section-head--button {
+  margin-top: 0.75rem;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  transition: background-color 0.18s ease;
+}
+
+.section-head--button:hover {
+  background: rgba(239, 246, 255, 0.7);
+}
+
+.dark .section-head--button:hover {
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.section-head--button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.45);
+}
+
+.section-head__label {
+  font-size: 0.625rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: rgba(23, 37, 84, 0.45);
+  transition: color 0.18s ease;
+}
+
+.dark .section-head__label {
+  color: rgba(255, 255, 255, 0.42);
+}
+
+.section-head--button:hover .section-head__label {
+  color: rgba(23, 37, 84, 0.72);
+}
+
+.dark .section-head--button:hover .section-head__label {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.section-head__count {
+  font-size: 0.5625rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  padding: 0 0.25rem;
+  border-radius: 0.25rem;
+  background: rgba(23, 37, 84, 0.06);
+  color: rgba(23, 37, 84, 0.5);
+  line-height: 0.9375rem;
+}
+
+.dark .section-head__count {
+  background: rgba(255, 255, 255, 0.07);
+  color: rgba(219, 234, 254, 0.55);
+}
+
+.section-head__rule {
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(90deg, rgba(23, 37, 84, 0.12) 0%, rgba(23, 37, 84, 0) 100%);
+}
+
+.dark .section-head__rule {
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.14) 0%, rgba(255, 255, 255, 0) 100%);
+}
+
+.section-head__chevron {
+  font-size: 0.5rem;
+  color: rgba(23, 37, 84, 0.35);
+  transition: transform 0.2s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.dark .section-head__chevron {
+  color: rgba(255, 255, 255, 0.35);
+}
+
+.section-head__chevron.is-open {
+  transform: rotate(90deg);
+}
+
+/* ── Empty state ────────────────────────────────────────────────────────── */
+
+/* A drawn-but-unfilled plate: the same dashed language the "not started yet"
+   card rail uses, so an empty crew reads as capacity rather than an error. */
+.empty-plate {
+  margin: 0.125rem 0.125rem 0;
+  padding: 1.125rem 0.875rem 1.25rem;
+  border: 1px dashed rgba(23, 37, 84, 0.14);
+  border-radius: 0.75rem;
+  background: linear-gradient(180deg, rgba(239, 246, 255, 0.55) 0%, rgba(239, 246, 255, 0) 100%);
+  text-align: center;
+}
+
+.dark .empty-plate {
+  border-color: rgba(255, 255, 255, 0.11);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.03) 0%, rgba(255, 255, 255, 0) 100%);
+}
+
+.empty-plate__mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.625rem;
+  height: 1.625rem;
+  margin-bottom: 0.5rem;
+  border-radius: 0.5rem;
+  background: rgba(23, 37, 84, 0.06);
+  color: rgba(23, 37, 84, 0.4);
+  box-shadow: inset 0 0 0 1px rgba(23, 37, 84, 0.05);
+}
+
+.dark .empty-plate__mark {
+  background: rgba(255, 255, 255, 0.06);
   color: rgba(255, 255, 255, 0.4);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.empty-plate__title {
+  font-family: theme('fontFamily.display');
+  font-variation-settings: 'opsz' 12, 'SOFT' 30, 'WONK' 1;
+  font-size: 0.8125rem;
+  font-weight: 550;
+  color: rgba(23, 37, 84, 0.7);
+}
+
+.dark .empty-plate__title {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.empty-plate__body {
+  margin-top: 0.25rem;
+  font-size: 0.6875rem;
+  line-height: 1.45;
+  color: rgba(23, 37, 84, 0.42);
+}
+
+.dark .empty-plate__body {
+  color: rgba(219, 234, 254, 0.38);
+}
+
+/* ── Loading ────────────────────────────────────────────────────────────── */
+
+/* The list's own silhouette — rail on the left, two lines of text — so the
+   pane does not jump when the real cards land. */
+.skeleton-card {
+  position: relative;
+  display: flex;
+  gap: 0.625rem;
+  padding: 0.5rem 0.5rem 0.5rem 0.75rem;
+  border: 1px solid rgba(23, 37, 84, 0.06);
+  border-radius: 0.625rem;
+  overflow: hidden;
+  opacity: 0;
+  animation: skeleton-in 0.4s ease both;
+  animation-delay: var(--stagger, 0ms);
+}
+
+.dark .skeleton-card {
+  border-color: rgba(255, 255, 255, 0.07);
+}
+
+.skeleton-rail {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 0.1875rem;
+  background: rgba(23, 37, 84, 0.13);
+}
+
+.dark .skeleton-rail {
+  background: rgba(255, 255, 255, 0.13);
+}
+
+.skeleton-line {
+  height: 0.5rem;
+  border-radius: 9999px;
+  background: linear-gradient(
+    90deg,
+    rgba(23, 37, 84, 0.07) 0%,
+    rgba(23, 37, 84, 0.13) 50%,
+    rgba(23, 37, 84, 0.07) 100%
+  );
+  background-size: 200% 100%;
+  animation: skeleton-sweep 1.6s ease-in-out infinite;
+}
+
+.skeleton-line--faint {
+  height: 0.375rem;
+  opacity: 0.65;
+}
+
+.dark .skeleton-line {
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.05) 0%,
+    rgba(255, 255, 255, 0.11) 50%,
+    rgba(255, 255, 255, 0.05) 100%
+  );
+  background-size: 200% 100%;
+}
+
+@keyframes skeleton-sweep {
+  from { background-position: 200% 0; }
+  to { background-position: -200% 0; }
+}
+
+@keyframes skeleton-in {
+  from { opacity: 0; transform: translateY(3px); }
+  to { opacity: 1; transform: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fleet-meter__seg--working,
+  .skeleton-line,
+  .skeleton-card {
+    animation: none;
+  }
+
+  .skeleton-card {
+    opacity: 1;
+  }
 }
 </style>


### PR DESCRIPTION
## What changed

The Subagents pane was a stack of near-identical rows — the only thing separating a live run from work waiting on the user was a line of small grey text, so scanning the pane meant reading it. Both the pane and the per-agent card are redesigned around a single idea: **a status rail on each card's left edge**, so state is legible from the rail alone.

**`AgentInstanceCard.vue`**
- **Status rail** encodes state without words: ink travels down a blue track while a run is live; solid navy (cream in dark) when the agent is waiting on you; a dashed track before a run starts; a hairline once settled.
- **Real status text** — a working agent now reports its own step ("Editing project files…") from `instance.statusText`, which was already on the instance and simply unused here, instead of a generic "Working…".
- **Take marker** — parallel takes on one brief show `1/2`, `2/2`. Without it, accepting the first take looks like the only option.
- Titles carry the brand serif (Fraunces, the same face as the pane masthead), tabular-nums meta line, hover chevron, and a staggered entrance.
- Cards are keyboard-operable (`role="button"`, Enter/Space, focus ring) — they were click-only before.

**`AgentManagerPanel.vue`**
- **Fleet meter** under the masthead: a 2px segmented bar keyed to the same three rail tones, proportional to working / waiting-on-you / not-started. It says at a glance whether the crew is busy or the pile waiting on *you* is the bigger half.
- Section heads get a count chip and a hairline rule fading right; History is the same head as a disclosure with a rotating chevron.
- Empty state is a drawn-but-unfilled dashed plate — capacity, not an error.
- Loading is three skeleton cards in the list's own silhouette (rail + two lines) instead of a spinner, so the pane doesn't jump when the real cards land.

No behavior or data changes: the pane stays read-only, and decisions still happen in the main agent's check-in queue.

## Testing

- `npm run type-check` passes.
- `npm run lint` reports 0 errors; neither file contributes a warning.
- Rendered in the browser at sidebar width in **both light and dark**, across the populated, empty, loading, and expanded-history states, via a temporary preview route that was removed before committing.

## Notes for reviewers

- All motion (rail travel, fleet drift, skeleton sweep, entrance stagger) is dropped under `prefers-reduced-motion`.
- The variant `n/m` marker is computed in the panel from `variantGroup` over the active list, so an ungrouped task renders no marker at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)