### PR TITLE
Report a finished subagent in the thread, not in the queue

### DIFF
--- a/backend/django/apps/Imagi/Build/api/views.py
+++ b/backend/django/apps/Imagi/Build/api/views.py
@@ -9,6 +9,7 @@ and Agents sub-apps.
 
 import json
 import logging
+import re
 import traceback
 from datetime import timedelta
 from rest_framework import status
@@ -1244,11 +1245,38 @@ def _conversation_total_tokens(conversation):
     return total
 
 
+PREVIEW_LIMIT = 240
+
+
+def _message_preview(text: str) -> str:
+    """A message's gist on one line: markdown chrome off, lines run together.
+
+    Not just the first line — a subagent's sign-off routinely opens with a
+    heading ("Here's what I built:") and puts the substance underneath, and
+    this preview is what the main thread's dispatch card reports as the
+    result. Whatever it drops is one click away in the thread itself.
+    """
+    parts = []
+    length = 0
+    for raw in (text or '').splitlines():
+        line = raw.strip()
+        # Rules, fences and other pure-punctuation lines carry no content
+        if not line or not line.strip('-=*_#`~ '):
+            continue
+        line = line.lstrip('#>* ').replace('**', '').replace('`', '')
+        line = re.sub(r'^(?:[-*+]|\d+\.)\s+', '', line)
+        if not line:
+            continue
+        parts.append(line)
+        length += len(line) + 1
+        if length >= PREVIEW_LIMIT:
+            break
+    return ' '.join(parts)[:PREVIEW_LIMIT]
+
+
 def _serialize_conversation(conversation):
     last_message = conversation.messages.order_by('-created_at').first()
-    preview = ''
-    if last_message and last_message.content:
-        preview = last_message.content.strip().splitlines()[0][:140]
+    preview = _message_preview(last_message.content) if last_message else ''
     return {
         'id': conversation.id,
         'title': conversation.title or '',
@@ -1751,6 +1779,20 @@ def check_ins_list(request):
     status_param = request.query_params.get('status', 'pending')
     if status_param != 'all':
         qs = qs.filter(status=status_param)
+    if status_param == 'pending':
+        # A task that merged itself reports in the main thread's transcript,
+        # not here. Entries filed before that (a "done" card for work already
+        # in the app) would read as a decision the user still owes, so they
+        # are cleared on sight instead of shown.
+        applied = [
+            ci.id for ci in qs
+            if ci.kind == 'ready' and ci.conversation.review_status == 'accepted'
+        ]
+        if applied:
+            AgentCheckIn.objects.filter(id__in=applied).update(
+                status='resolved', resolved_at=timezone.now()
+            )
+            qs = qs.exclude(id__in=applied)
     data = [_serialize_check_in(ci) for ci in qs.order_by('created_at')]
     return Response(data, status=status.HTTP_200_OK)
 

--- a/backend/django/apps/Imagi/Build/services/base_agent.py
+++ b/backend/django/apps/Imagi/Build/services/base_agent.py
@@ -981,11 +981,12 @@ class ImagiAgentService:
 
         A run that ended on ask_user parks the task at 'input' and queues the
         question. A run that finished its work applies itself: a solo task
-        auto-merges into the project and files a "done — changes applied"
-        notification, so the user is only told, not asked. Variant takes (built
-        to compare) and any task whose auto-merge can't run cleanly fall back to
-        a 'ready' review card the user picks or merges by hand. Either way the
-        task never interrupts the user directly — it surfaces in the queue.
+        auto-merges into the project and queues nothing at all — its summary
+        and 'added to your app' outcome live on the dispatch card in the main
+        thread, which is a record to read rather than a card to clear. Variant
+        takes (built to compare) and any task whose auto-merge can't run
+        cleanly fall back to a 'ready' review card the user picks or merges by
+        hand. Either way the task never interrupts the user directly.
         """
         # getattr: test doubles stand in for the conversation here.
         if getattr(conversation, 'kind', 'chat') != 'task':
@@ -1007,12 +1008,17 @@ class ImagiAgentService:
             not getattr(conversation, 'variant_group', '')
             and self._auto_apply_task(conversation)
         )
-        if not applied:
-            try:
-                conversation.review_status = 'ready'
-                conversation.save(update_fields=["review_status"])
-            except Exception as e:  # pragma: no cover - best effort
-                logger.warning(f"Could not update task review status: {e}")
+        if applied:
+            # Nothing is being asked, so nothing goes in the queue: the work
+            # is already in the app and the thread's dispatch card reports it.
+            # Any entry an earlier run of this task left behind is stale now.
+            self._resolve_pending_check_ins(conversation)
+            return
+        try:
+            conversation.review_status = 'ready'
+            conversation.save(update_fields=["review_status"])
+        except Exception as e:  # pragma: no cover - best effort
+            logger.warning(f"Could not update task review status: {e}")
         self._file_check_in(conversation, 'ready', response_content)
 
     def _auto_apply_task(self, conversation) -> bool:

--- a/backend/django/apps/Imagi/Build/tests/test_agents.py
+++ b/backend/django/apps/Imagi/Build/tests/test_agents.py
@@ -1029,3 +1029,34 @@ class ProjectMemoryTests(SimpleTestCase):
         memory = load_project_memory(self.root)
         self.assertIn('[truncated]', memory)
         self.assertLess(len(memory), PROJECT_MEMORY_MAX_CHARS + 200)
+
+
+class MessagePreviewTests(SimpleTestCase):
+    """The one-line gist the main thread's dispatch card reports as a result."""
+
+    def _preview(self, text):
+        from apps.Imagi.Build.api.views import _message_preview
+        return _message_preview(text)
+
+    def test_reads_past_a_heading_line_to_the_substance(self):
+        # A subagent's sign-off routinely opens with a header and puts what it
+        # actually did underneath — stopping at line one would report nothing.
+        preview = self._preview(
+            "Here's what I built:\n\n"
+            "- A pricing page with three tiers\n"
+            "- A contact form that validates on submit\n"
+        )
+        self.assertIn('A pricing page with three tiers', preview)
+        self.assertIn('A contact form', preview)
+
+    def test_strips_markdown_chrome(self):
+        preview = self._preview("## Done\n\n**Added** the `/contact` route.\n---\n")
+        self.assertEqual(preview, 'Done Added the /contact route.')
+
+    def test_caps_the_length(self):
+        preview = self._preview('word ' * 400)
+        self.assertLessEqual(len(preview), 240)
+
+    def test_empty_message_previews_as_empty(self):
+        self.assertEqual(self._preview(''), '')
+        self.assertEqual(self._preview('\n\n---\n'), '')

--- a/backend/django/apps/Imagi/Build/tests/test_task_worktrees.py
+++ b/backend/django/apps/Imagi/Build/tests/test_task_worktrees.py
@@ -684,23 +684,37 @@ class TaskCheckInTests(GitRepoTestMixin, TestCase):
         self.assertEqual(check_in.lead_id, self.lead.id)
         self.assertEqual(check_in.body, 'Added the page.')
 
-    def test_finished_solo_task_auto_applies_and_notifies(self):
+    def test_finished_solo_task_auto_applies_without_queueing(self):
         task = self._task()
         self._worktree_with_change(task)
 
         self.service._finalize_task_run(task, self._context(), 'Added the feature.')
 
         task.refresh_from_db()
-        # Merged straight into the project — the user is notified, not asked.
+        # Merged straight into the project — the user is told, not asked.
         self.assertEqual(task.review_status, 'accepted')
         self.assertEqual(task.worktree_path, '')
         with open(os.path.join(self.repo, 'feature.txt')) as f:
             self.assertEqual(f.read(), 'task output')
-        # Still files a check-in: the queue shows a "done" notification whose
-        # accepted status tells the card to drop the accept/discard buttons.
-        check_in = AgentCheckIn.objects.get(conversation=task)
-        self.assertEqual(check_in.kind, 'ready')
-        self.assertEqual(check_in.body, 'Added the feature.')
+        # Nothing to decide, so nothing goes in the queue: the outcome is
+        # reported on the task's dispatch card in the main thread.
+        self.assertFalse(AgentCheckIn.objects.filter(conversation=task).exists())
+
+    def test_auto_apply_clears_a_check_in_an_earlier_run_left_behind(self):
+        task = self._task()
+        AgentCheckIn.objects.create(
+            user=self.user, project_id=self.project.id, conversation=task,
+            lead=self.lead, kind='question', body='Which layout?',
+        )
+        self._worktree_with_change(task)
+
+        self.service._finalize_task_run(task, self._context(), 'Added the feature.')
+
+        # The question is answered by the work being done; leaving it pending
+        # would keep asking for input on a task already merged.
+        self.assertFalse(
+            AgentCheckIn.objects.filter(conversation=task, status='pending').exists()
+        )
 
     def test_variant_task_waits_for_a_pick_one_review(self):
         task = self.service.create_conversation(
@@ -848,8 +862,10 @@ class TaskCheckInTests(GitRepoTestMixin, TestCase):
 
         self.assertTrue(result.get('capped'))
         task.refresh_from_db()
+        # Applied, so its report is the dispatch card in the main thread —
+        # what matters here is that it left 'active' at all.
         self.assertEqual(task.review_status, 'accepted')
-        self.assertTrue(
+        self.assertFalse(
             AgentCheckIn.objects.filter(conversation=task, status='pending').exists()
         )
 
@@ -1269,6 +1285,22 @@ class CheckInEndpointTests(TestCase):
         self.assertEqual([c['id'] for c in data], [first.id, second.id])
         self.assertEqual(data[0]['task']['id'], first.conversation_id)
         self.assertEqual(data[1]['kind'], 'question')
+
+    def test_list_clears_a_done_card_for_work_already_in_the_app(self):
+        # Filed before finished-and-merged tasks stopped queueing. Showing it
+        # would ask the user to accept or discard work the app already has.
+        stale = self._check_in(body='merged itself')
+        stale.conversation.review_status = 'accepted'
+        stale.conversation.save(update_fields=['review_status'])
+        live = self._check_in(kind='question', body='Stripe or PayPal?')
+
+        resp = self.client.get(
+            reverse('check_ins_list'), {'project_id': self.project.id}
+        )
+
+        self.assertEqual([c['id'] for c in resp.json()], [live.id])
+        stale.refresh_from_db()
+        self.assertEqual(stale.status, 'resolved')
 
     def test_list_never_leaks_another_users_queue(self):
         self._check_in(body='mine')

--- a/frontend/vuejs/src/apps/imagi/build/components/__tests__/ChatConversation.spec.ts
+++ b/frontend/vuejs/src/apps/imagi/build/components/__tests__/ChatConversation.spec.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
 import ChatConversation from '../organisms/chat/ChatConversation.vue'
-import type { AIMessage } from '@/apps/imagi/build/types/services'
+import { useAgentStore } from '@/apps/imagi/build/stores/agentStore'
+import type { AgentInstance, AIMessage } from '@/apps/imagi/build/types/services'
 
 const user = (content: string): AIMessage => ({
   role: 'user', content, timestamp: '2026-01-01T00:00:00Z', id: 'u1',
@@ -16,6 +18,10 @@ const indicatorText = (wrapper: ReturnType<typeof mount>) => {
 }
 
 describe('ChatConversation activity indicator', () => {
+  // Dispatch cards read subagent state straight from the store, so the
+  // component needs a pinia even when the transcript has no cards in it.
+  beforeEach(() => setActivePinia(createPinia()))
+
   const mountWith = (props: object) =>
     mount(ChatConversation, { props: { messages: [user('hi')], ...props } })
 
@@ -55,5 +61,66 @@ describe('ChatConversation activity indicator', () => {
       messages: [user('hi'), assistant('done')],
     })
     expect(indicatorText(wrapper)).toBeNull()
+  })
+})
+
+describe('ChatConversation dispatch card', () => {
+  beforeEach(() => setActivePinia(createPinia()))
+
+  const withSubagent = (instance: Partial<AgentInstance>) => {
+    const store = useAgentStore()
+    store.instances = [{
+      id: 'inst-1',
+      conversationId: 7,
+      title: 'Contact page',
+      kind: 'task',
+      parentId: null,
+      reviewStatus: '',
+      variantGroup: '',
+      hasWorktree: false,
+      totalTokens: null,
+      selectedModelId: null,
+      selectedEffort: 'medium',
+      selectedFile: null,
+      conversation: [],
+      isProcessing: false,
+      statusText: '',
+      archivedAt: null,
+      updatedAt: '2026-01-01T00:00:00Z',
+      lastMessagePreview: '',
+      messagesLoaded: true,
+      hasUnread: false,
+      queuedPrompt: null,
+      ...instance,
+    } as AgentInstance]
+    const reply: AIMessage = {
+      ...assistant('On it.'),
+      dispatchedTasks: [{ conversationId: 7, title: 'Contact page' }],
+    }
+    return mount(ChatConversation, { props: { messages: [user('hi'), reply] } })
+  }
+
+  it('reports what a finished subagent did, and that it landed', () => {
+    // A task that merged itself queues nothing, so this card is the whole
+    // report — it has to say both what happened and where the work went.
+    const wrapper = withSubagent({
+      reviewStatus: 'accepted',
+      lastMessagePreview: 'Added a /contact route with a validated form.',
+    })
+
+    const card = wrapper.find('.dispatch-card')
+    expect(card.text()).toContain('Added to your app')
+    expect(card.text()).toContain('Added a /contact route with a validated form.')
+  })
+
+  it('says nothing about results while the subagent is still working', () => {
+    const wrapper = withSubagent({
+      isProcessing: true,
+      lastMessagePreview: 'Reading the router…',
+    })
+
+    const card = wrapper.find('.dispatch-card')
+    expect(card.text()).toContain('Working in the background…')
+    expect(card.text()).not.toContain('Reading the router…')
   })
 })

--- a/frontend/vuejs/src/apps/imagi/build/components/molecules/sidebar/CheckInQueue.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/molecules/sidebar/CheckInQueue.vue
@@ -1,10 +1,13 @@
 <!--
   CheckInQueue.vue — the main thread's processing queue.
 
-  Background subagents never interrupt the user: when one finishes, needs an
-  answer, or fails, it files a check-in that surfaces here, above the lead
-  thread's composer. One card is shown at a time (FIFO) so the user stays
-  single-threaded; the rest wait behind a count.
+  Background subagents never interrupt the user: when one needs an answer,
+  fails, or finishes work the user has to pick between, it files a check-in
+  that surfaces here, above the lead thread's composer. Everything in this
+  queue is a decision — a subagent that simply finished and merged its own
+  work reports on its dispatch card in the thread and never lands here.
+  One card is shown at a time (FIFO) so the user stays single-threaded; the
+  rest wait behind a count.
 -->
 <template>
   <div v-if="queue.length > 0" class="mb-1.5">
@@ -96,27 +99,10 @@
         </div>
       </div>
 
-      <!-- An auto-applied task is already part of the app: this is a
-           notification, not a decision — just look or clear it away. -->
-      <div v-else-if="applied" class="flex items-center gap-1.5 mt-2">
-        <button
-          type="button"
-          class="btn-ghost flex-1 rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors"
-          @click="emit('view', current)"
-        >
-          View changes
-        </button>
-        <button
-          type="button"
-          class="btn-ghost flex-1 rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors"
-          @click="emit('skip', current)"
-        >
-          Dismiss
-        </button>
-      </div>
-
       <!-- A variant take (or a task whose auto-merge fell back) is merged or
-           discarded from right here -->
+           discarded from right here. A task that merged itself never gets
+           here — it has nothing to decide, so it is reported on its dispatch
+           card in the thread instead of queued. -->
       <div v-else-if="current.kind === 'ready'" class="flex items-center gap-1.5 mt-2">
         <button
           type="button"
@@ -209,13 +195,6 @@ const siblingIndex = computed(
   () => siblings.value.findIndex(c => c.id === current.value?.id) + 1
 )
 
-// A finished solo task merges itself into the app; its check-in is a
-// notification, not a review. Variant takes and merge-conflict fallbacks stay
-// at 'ready' (still awaiting the user), so they keep the Add/Discard card.
-const applied = computed(
-  () => current.value?.kind === 'ready' && current.value?.task.review_status === 'accepted'
-)
-
 const kindIcon = computed(() => {
   switch (current.value?.kind) {
     case 'question': return 'fas fa-circle-question'
@@ -228,7 +207,7 @@ const kindLabel = computed(() => {
   switch (current.value?.kind) {
     case 'question': return 'Needs your answer'
     case 'error': return 'Stopped early'
-    default: return applied.value ? 'Done — added to your app' : 'Finished — ready to review'
+    default: return 'Finished — ready to review'
   }
 })
 

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/chat/ChatConversation.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/chat/ChatConversation.vue
@@ -67,7 +67,7 @@
                   v-for="task in message.dispatchedTasks"
                   :key="task.conversationId"
                   type="button"
-                  class="dispatch-card group flex items-center gap-2.5 w-full rounded-xl border border-blue-950/[0.08] dark:border-white/[0.12] bg-blue-50/50 dark:bg-white/[0.04] px-3 py-2 text-left transition-colors hover:bg-blue-100/60 dark:hover:bg-white/[0.07]"
+                  class="dispatch-card group flex items-start gap-2.5 w-full rounded-xl border border-blue-950/[0.08] dark:border-white/[0.12] bg-blue-50/50 dark:bg-white/[0.04] px-3 py-2 text-left transition-colors hover:bg-blue-100/60 dark:hover:bg-white/[0.07]"
                   :title="`Open this subagent's thread`"
                   @click="emit('open-task', task.conversationId)"
                 >
@@ -81,8 +81,17 @@
                     <span class="block text-[10px] text-blue-950/45 dark:text-white/40">
                       {{ dispatchStatus(task.conversationId) }}
                     </span>
+                    <!-- What the subagent actually did. A finished task is
+                         reported here and nowhere else — there is no card to
+                         accept or clear, so this line is the record. -->
+                    <span
+                      v-if="dispatchSummary(task.conversationId)"
+                      class="mt-1 text-[11px] leading-snug text-blue-950/65 dark:text-white/55 line-clamp-3"
+                    >
+                      {{ dispatchSummary(task.conversationId) }}
+                    </span>
                   </span>
-                  <i class="fas fa-chevron-right text-[10px] text-blue-950/30 dark:text-white/30 group-hover:text-blue-950/60 dark:group-hover:text-white/60 transition-colors shrink-0"></i>
+                  <i class="fas fa-chevron-right text-[10px] mt-0.5 text-blue-950/30 dark:text-white/30 group-hover:text-blue-950/60 dark:group-hover:text-white/60 transition-colors shrink-0"></i>
                 </button>
               </div>
               <div v-if="message.filesChanged?.length" class="mt-2">
@@ -209,6 +218,15 @@ function dispatchStatus(conversationId: number): string {
     case 'dismissed': return 'Discarded'
     default: return 'Starting…'
   }
+}
+
+/** What a finished subagent says it accomplished — its closing line, which is
+ *  the whole report now that a self-merging task queues nothing. Nothing while
+ *  it is still working: a mid-run line would read as a result. */
+function dispatchSummary(conversationId: number): string {
+  const instance = agentStore.instances.find(i => i.conversationId === conversationId)
+  if (!instance || instance.isProcessing) return ''
+  return instance.lastMessagePreview || ''
 }
 
 // Refs and reactive state

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/AgentManagerPanel.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/AgentManagerPanel.vue
@@ -1,5 +1,55 @@
 <template>
   <div class="flex flex-col h-full bg-white dark:bg-[#0a0a0a] transition-colors duration-300">
+    <!-- Reading one subagent's thread. It happens here rather than in the chat
+         pane on purpose: a subagent is something you look in on, so opening one
+         must not displace the thread you are actually talking in. -->
+    <template v-if="opened">
+      <WorkspacePaneHeader
+        icon="fas fa-robot"
+        tone="muted"
+        :title="opened.title || 'Background agent'"
+        :status="openedStatus"
+        :live="!!opened.isProcessing"
+        switch-icon="fas fa-layer-group"
+        switch-label="Subagents"
+        switch-direction="back"
+        @switch="closeOpened"
+      />
+
+      <div class="flex-1 min-h-0 overflow-hidden flex flex-col">
+        <!-- Keyed by instance: scroll position belongs to one transcript. -->
+        <ChatConversation
+          :key="opened.id"
+          :messages="opened.conversation"
+          :is-processing="!!opened.isProcessing"
+          :status-text="opened.statusText || ''"
+          :can-restore="false"
+          @open-task="openByConversation"
+          class="flex-1"
+        />
+      </div>
+
+      <!-- No composer: this thread is driven from the main thread (dispatch,
+           and answers relayed from the check-in queue). -->
+      <div class="shrink-0 px-2 pt-1 pb-3">
+        <div class="rounded-2xl border border-blue-950/[0.08] dark:border-white/[0.14] bg-blue-50/40 dark:bg-white/[0.03] px-3 py-2.5">
+          <p class="text-[11px] leading-snug text-blue-950/60 dark:text-white/55">
+            {{ opened.isProcessing
+              ? 'This agent is working in the background. You direct it from your main thread — its results and questions arrive there.'
+              : 'A record of what this agent did. You direct subagents from your main thread.' }}
+          </p>
+          <button
+            type="button"
+            class="btn-back mt-2 w-full rounded-full px-3 py-1.5 text-[11px] font-semibold text-[#fdf9f2] dark:text-blue-950 transition-all duration-200"
+            @click="closeOpened"
+          >
+            Back to subagents
+          </button>
+        </div>
+      </div>
+    </template>
+
+    <template v-else>
     <!-- Header: the same plate the chat pane wears, switching back the other
          way. The status line reports the fleet, which is what the removed
          "view only" badge was gesturing at — except it carries real news. -->
@@ -38,8 +88,8 @@
             v-for="instance in activeAgents"
             :key="instance.id"
             :instance="instance"
-            :is-active="instance.id === store.activeInstanceId"
-            @select="handleSelect(instance.id)"
+            :is-active="instance.id === store.openedSubagentId"
+            @select="handleSelect(instance)"
           />
         </template>
         <div v-else class="px-2 pb-1 text-[11px] text-blue-950/35 dark:text-white/30">
@@ -61,14 +111,15 @@
               v-for="instance in history"
               :key="instance.id"
               :instance="instance"
-              :is-active="instance.id === store.activeInstanceId"
+              :is-active="instance.id === store.openedSubagentId || instance.id === store.activeInstanceId"
               :is-archived="!!instance.archivedAt"
-              @select="handleSelect(instance.id)"
+              @select="handleSelect(instance)"
             />
           </template>
         </template>
       </template>
     </div>
+    </template>
   </div>
 </template>
 
@@ -77,15 +128,20 @@ import { computed, ref } from 'vue'
 import { useAgentStore } from '../../../stores/agentStore'
 import InstanceCard from '../../molecules/sidebar/AgentInstanceCard.vue'
 import WorkspacePaneHeader from '../../molecules/sidebar/WorkspacePaneHeader.vue'
+import { ChatConversation } from '../../organisms/chat'
+import type { AgentInstance } from '../../../types/services'
 
 const emit = defineEmits<{
   (e: 'collapse'): void
-  /** An instance was clicked — the workspace flips the sidebar to chat. */
+  /** A thread the user can actually talk in was clicked (a legacy chat, a
+   *  stray lead) — the workspace flips the sidebar to chat for it. Subagents
+   *  never emit this: they open in place, right here. */
   (e: 'select', instanceId: string): void
 }>()
 
 const store = useAgentStore()
 const showHistory = ref(false)
+const opened = computed(() => store.openedSubagent)
 
 // Already newest-first. The main agent's own thread is the chat pane, so it
 // is deliberately absent here — this panel is only about the subagents.
@@ -102,9 +158,43 @@ const fleetStatus = computed(() => {
   return `${total} ${total === 1 ? 'agent' : 'agents'} waiting on you`
 })
 
-async function handleSelect(id: string) {
-  emit('select', id)
-  await store.switchInstance(id)
+/** The open subagent's own header line — the same wording its card uses. */
+const openedStatus = computed(() => {
+  const instance = opened.value
+  if (!instance) return ''
+  if (instance.isProcessing) return instance.statusText || 'Working…'
+  switch (instance.reviewStatus) {
+    case 'input': return 'Asked you a question'
+    case 'ready': return 'Finished — waiting on you'
+    case 'accepted': return 'Added to your app'
+    case 'dismissed': return 'Discarded'
+    default: return 'Read only'
+  }
+})
+
+/**
+ * A card was clicked. A subagent opens in place, so the user stays in this
+ * pane and the main thread keeps its place. History also holds threads the
+ * user can still talk in (legacy chats, a stray second lead) — those have a
+ * composer, so they still belong in the chat pane.
+ */
+async function handleSelect(instance: AgentInstance) {
+  if (instance.kind === 'task') {
+    await store.openSubagent(instance.id)
+    return
+  }
+  emit('select', instance.id)
+  await store.switchInstance(instance.id)
+}
+
+function closeOpened() {
+  void store.openSubagent(null)
+}
+
+/** A dispatch card inside a subagent's transcript: follow it in place. */
+async function openByConversation(conversationId: number) {
+  const instance = store.instances.find(i => i.conversationId === conversationId)
+  if (instance) await store.openSubagent(instance.id)
 }
 </script>
 
@@ -120,5 +210,29 @@ async function handleSelect(id: string) {
 
 .dark .section-label {
   color: rgba(255, 255, 255, 0.4);
+}
+
+/* Navy ink primary — the same recipe the chat pane's back button wears */
+.btn-back {
+  background: theme('colors.blue.950');
+  box-shadow:
+    0 1px 2px rgba(23, 37, 84, 0.2),
+    0 3px 8px -2px rgba(23, 37, 84, 0.25),
+    inset 0 1px 0 rgba(255, 255, 255, 0.12);
+}
+
+.btn-back:hover {
+  background: theme('colors.blue.900');
+}
+
+.dark .btn-back {
+  background: #f3ede2;
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.4),
+    0 3px 8px -2px rgba(0, 0, 0, 0.45);
+}
+
+.dark .btn-back:hover {
+  background: #ffffff;
 }
 </style>

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
@@ -345,6 +345,8 @@ const emit = defineEmits<{
   (e: 'check-in-accept', checkIn: CheckInDto): void
   /** Discard a finished background task's work */
   (e: 'check-in-dismiss', checkIn: CheckInDto): void
+  /** Look in on a subagent — it opens in the Subagents pane, never here */
+  (e: 'open-task', conversationId: number): void
 }>()
 
 const store = useAgentStore()
@@ -405,16 +407,14 @@ function onSkipCheckIn(checkIn: CheckInDto) {
 }
 
 /** Open the task's read-only thread to see what it actually did. */
-async function onViewCheckIn(checkIn: CheckInDto) {
-  const instance = store.instances.find(i => i.conversationId === checkIn.task.id)
-  if (instance) await store.switchInstance(instance.id)
+function onViewCheckIn(checkIn: CheckInDto) {
+  emit('open-task', checkIn.task.id)
 }
 
 /** A dispatch card in the transcript was clicked — open that subagent's
- *  thread so the user can watch it work (the main thread stays clean). */
-async function onOpenTask(conversationId: number) {
-  const instance = store.instances.find(i => i.conversationId === conversationId)
-  if (instance) await store.switchInstance(instance.id)
+ *  thread over in the Subagents pane, so this thread keeps its place. */
+function onOpenTask(conversationId: number) {
+  emit('open-task', conversationId)
 }
 
 // Restores git-reset the canonical working tree. Only canonical-tree
@@ -634,29 +634,20 @@ function ensureValidMessages(messages: any[]): AIMessage[] {
     return true
   })
   
+  // Spread, never a field whitelist: everything a message carries beyond the
+  // four fields defaulted here — activity feed, plan, files-changed chip, cost
+  // caption, dispatch cards, checkpoint — is the transcript's content, and a
+  // whitelist silently drops whatever it was not updated to know about.
   const validMessages = filteredMessages
     .filter(m => m && typeof m === 'object' && m.role)
-    .map(m => {
-      const content = m.content || ''
-      const messageId = m.id || `msg-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`
-      
-      return {
-        role: m.role,
-        content: content,
-        code: m.code || '',
-        timestamp: m.timestamp || new Date().toISOString(),
-        id: messageId,
-        // Run telemetry rides along or the transcript loses its activity
-        // feed, plan, files-changed chip and cost caption.
-        plan: m.plan,
-        activity: m.activity,
-        filesChanged: m.filesChanged,
-        usage: m.usage,
-        dbId: m.dbId,
-        checkpoint: m.checkpoint
-      }
-    }) as AIMessage[]
-  
+    .map(m => ({
+      ...m,
+      content: m.content || '',
+      code: m.code || '',
+      timestamp: m.timestamp || new Date().toISOString(),
+      id: m.id || `msg-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
+    })) as AIMessage[]
+
   return validMessages
 }
 

--- a/frontend/vuejs/src/apps/imagi/build/stores/__tests__/agentStore.spec.ts
+++ b/frontend/vuejs/src/apps/imagi/build/stores/__tests__/agentStore.spec.ts
@@ -97,6 +97,54 @@ describe('agent store manager taxonomy', () => {
   })
 })
 
+describe('agent store openSubagent', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    setActivePinia(createPinia())
+    Object.values(agentService).forEach((fn) => fn.mockReset())
+  })
+
+  it('reads a subagent without moving the thread the user talks in', async () => {
+    const store = useAgentStore()
+    const lead = makeInstance({ kind: 'lead' })
+    const task = makeInstance({ kind: 'task', hasUnread: true })
+    store.instances = [lead, task]
+    store.activeInstanceId = lead.id
+
+    await store.openSubagent(task.id)
+
+    expect(store.openedSubagent?.id).toBe(task.id)
+    // The composer (and its draft) stay with the lead thread.
+    expect(store.activeInstanceId).toBe(lead.id)
+    expect(task.hasUnread).toBe(false)
+  })
+
+  it('goes back to the list on null', async () => {
+    const store = useAgentStore()
+    const task = makeInstance({ kind: 'task' })
+    store.instances = [task]
+
+    await store.openSubagent(task.id)
+    await store.openSubagent(null)
+
+    expect(store.openedSubagent).toBeNull()
+  })
+
+  it('closes a subagent the user deleted', async () => {
+    const store = useAgentStore()
+    const lead = makeInstance({ kind: 'lead' })
+    const task = makeInstance({ kind: 'task' })
+    store.instances = [lead, task]
+    store.activeInstanceId = lead.id
+    agentService.deleteConversation.mockResolvedValue(undefined)
+
+    await store.openSubagent(task.id)
+    await store.deleteInstance(task.id)
+
+    expect(store.openedSubagentId).toBeNull()
+  })
+})
+
 describe('agent store deleteInstance', () => {
   beforeEach(() => {
     localStorage.clear()

--- a/frontend/vuejs/src/apps/imagi/build/stores/agentStore.ts
+++ b/frontend/vuejs/src/apps/imagi/build/stores/agentStore.ts
@@ -96,6 +96,7 @@ export const useAgentStore = defineStore('agent', {
     availableModels: [],
     instances: [],
     activeInstanceId: null,
+    openedSubagentId: null,
     files: [],
     unsavedChanges: false,
     error: null,
@@ -120,6 +121,13 @@ export const useAgentStore = defineStore('agent', {
     /** The project's one pinned lead thread (ensured by loadInstances). */
     leadInstance(state): AgentInstance | null {
       return state.instances.find(i => i.kind === 'lead' && !i.archivedAt) || null
+    },
+
+    /** The subagent the Subagents pane is reading, or null when it is showing
+     *  the list. */
+    openedSubagent(state): AgentInstance | null {
+      if (!state.openedSubagentId) return null
+      return state.instances.find(i => i.id === state.openedSubagentId) || null
     },
 
     /** Every subagent whose work is not finished yet, newest first: running,
@@ -215,6 +223,9 @@ export const useAgentStore = defineStore('agent', {
         const dtos = await AgentService.listConversations(projectId)
         const fallback = pickDefaultModelId(this.availableModels)
         this.instances = dtos.map(d => dtoToInstance(d, fallback))
+        // Local ids are regenerated above, so any drilled-into subagent id is
+        // now stale — the pane falls back to its list.
+        this.openedSubagentId = null
 
         // Every project pins exactly one lead thread; the backend dedupes
         // lead creation, so racing tabs converge on the same conversation.
@@ -225,7 +236,12 @@ export const useAgentStore = defineStore('agent', {
         // Pick active: remembered id from localStorage, else the lead
         const remembered = localStorage.getItem(`activeAgentInstance_${projectId}`)
         const activeConvId: number | null = remembered ? Number(remembered) : null
-        let picked = this.instances.find(i => i.conversationId === activeConvId && !i.archivedAt)
+        // Never a task: a subagent's thread is read in the Subagents pane, so
+        // restoring one as the active (composer-bearing) thread would strand
+        // the user in a thread they cannot type in.
+        let picked = this.instances.find(
+          i => i.conversationId === activeConvId && !i.archivedAt && i.kind !== 'task'
+        )
         if (!picked) {
           picked = this.leadInstance
             || this.instances.find(i => !i.archivedAt)
@@ -571,6 +587,21 @@ export const useAgentStore = defineStore('agent', {
       return instance
     },
 
+    /**
+     * Read a subagent's thread inside the Subagents pane. Deliberately not
+     * switchInstance: a subagent's thread is a record you look at, not one you
+     * talk in, so opening it must leave the main thread — and the composer's
+     * draft — exactly where they were. Pass null to go back to the list.
+     */
+    async openSubagent(instanceId: string | null) {
+      this.openedSubagentId = instanceId
+      if (!instanceId) return
+      const instance = this._findInstance(instanceId)
+      if (!instance) return
+      instance.hasUnread = false
+      await this.ensureMessagesLoaded(instance.id)
+    },
+
     async switchInstance(instanceId: string) {
       const instance = this._findInstance(instanceId)
       if (!instance) return
@@ -653,6 +684,7 @@ export const useAgentStore = defineStore('agent', {
         await AgentService.deleteConversation(instance.conversationId)
       }
       this.instances = this.instances.filter(i => i.id !== instance.id)
+      if (this.openedSubagentId === instance.id) this.openedSubagentId = null
       if (wasActive) {
         // Fall back to the lead thread; never auto-create plain chats.
         const next = this.leadInstance

--- a/frontend/vuejs/src/apps/imagi/build/types/stores.ts
+++ b/frontend/vuejs/src/apps/imagi/build/types/stores.ts
@@ -10,6 +10,10 @@ export interface AgentState {
   availableModels: AIModel[];
   instances: AgentInstance[];
   activeInstanceId: string | null;
+  /** The subagent whose transcript the Subagents pane is drilled into, if
+   *  any. Separate from activeInstanceId on purpose: reading a subagent's
+   *  thread must never move the thread the user is talking in. */
+  openedSubagentId: string | null;
   files: ProjectFile[];
   unsavedChanges: boolean;
   error: string | null;

--- a/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
+++ b/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
@@ -53,6 +53,7 @@
                 @restore-checkpoint="onRestoreCheckpoint"
                 @check-in-accept="handleCheckInAccept"
                 @check-in-dismiss="handleCheckInDismiss"
+                @open-task="openSubagent"
               />
             </KeepAlive>
           </Transition>
@@ -241,7 +242,9 @@ const activeSidebarPane = computed<SidebarView>(() =>
   isMobile.value ? (mobileView.value === 'manager' ? 'manager' : 'chat') : sidebarView.value
 )
 
-/** An instance was clicked in the manager — open its conversation.
+/** A thread the user can talk in was clicked in the manager — open its
+ *  conversation in the chat pane. Subagents don't come through here: they
+ *  open inside the Subagents pane itself.
  *  The 'select' emit is the ONLY path that flips the pane to chat: the
  *  active instance also changes programmatically (archive/delete falling
  *  back to the lead, loadInstances regenerating local ids), and those must
@@ -249,6 +252,17 @@ const activeSidebarPane = computed<SidebarView>(() =>
 function handleManagerSelect() {
   setSidebarView('chat')
   if (isMobile.value) mobileView.value = 'chat'
+}
+
+/** Look in on a subagent from the main thread (a dispatch card, a check-in's
+ *  open arrow). It reads in the Subagents pane, so the main thread stays
+ *  exactly where the user left it — draft and all. */
+async function openSubagent(conversationId: number) {
+  const instance = store.instances.find(i => i.conversationId === conversationId)
+  if (!instance) return
+  setSidebarView('manager')
+  if (isMobile.value) mobileView.value = 'manager'
+  await store.openSubagent(instance.id)
 }
 
 /** An accepted task's worktree just merged into the canonical tree —


### PR DESCRIPTION
## What changed

A subagent that finished and merged its own work was still filing a check-in — a card the user had to read and clear before the queue would advance, for something with nothing to decide. It now files nothing. Its outcome lives where the rest of the conversation does: the dispatch card in the main thread reports **what it did** and **that it landed**. No "View changes", no "Dismiss".

The queue keeps what actually needs the user: a question, a failure, and a finished task they still have to pick or merge by hand (variants, merge-conflict fallbacks). Check-ins filed before this change are cleared by the list endpoint rather than shown as an accept/discard for work the app already has.

Two bugs surfaced while wiring this up, both fixed here:

- **Dispatch cards never rendered.** `ensureValidMessages` rebuilt each message from a field whitelist with no `dispatchedTasks`, so every card was dropped on its way into the transcript. It spreads the message now.
- **The summary was the first line only.** A subagent's sign-off routinely opens with a heading ("Here's what I built:") and puts the substance underneath, so the card reported nothing useful. `_message_preview` runs the lines together with markdown stripped, up to 240 chars.

## Opening a subagent

Clicking a subagent — from its card in the manager, a dispatch card in the thread, or a check-in's open arrow — now drills in **inside the Subagents pane** and leaves the main thread exactly where it was, unsent draft included. Back returns to the subagent list, then to Main agent.

This is a new `openedSubagentId`, deliberately separate from `activeInstanceId`. History threads that still have a composer (legacy chats, a stray lead) keep opening in the chat pane, since there'd otherwise be no way to type in them.

## Verification

Exercised against the running dev workspace on a project with a merged subagent: the card reports "Initial build / Added to your app / <summary>" with no buttons and an empty queue; clicking it opens the read-only transcript in the Subagents pane with the main thread untouched; back returns to the list.

- 405 backend tests pass (new coverage for the no-queue path, the stale-row cleanup, and `_message_preview`)
- 99 frontend tests pass (new coverage for the dispatch card's report and `openSubagent`); `vue-tsc` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)