### PR TITLE
Hold the first build to half a minute, and to one page

### DIFF
--- a/backend/django/apps/Imagi/Build/services/base_agent.py
+++ b/backend/django/apps/Imagi/Build/services/base_agent.py
@@ -169,6 +169,20 @@ class RunDeadlineExceeded(Exception):
         )
 
 
+def response_has_tool_calls(response) -> bool:
+    """Whether a model response asked for tool calls that have yet to run.
+
+    The SDK names every tool item's type with a '_call' suffix ('function_call',
+    'file_search_call', ...), and reasoning/message items never end that way, so
+    the suffix is a stable test across tool kinds.
+    """
+    for item in getattr(response, 'output', None) or ():
+        item_type = getattr(item, 'type', '') or ''
+        if item_type.endswith('_call'):
+            return True
+    return False
+
+
 def make_run_bounds_hook(
     model_id: str,
     budget_usd: Optional[float] = None,
@@ -178,6 +192,13 @@ def make_run_bounds_hook(
 
     Both are checked after each model turn — the only point the SDK hands us
     control — so a run overshoots by at most the turn in flight.
+
+    A turn that ends over its bound while holding tool calls is allowed to run
+    them before the run stops. Raising immediately would throw that turn's work
+    away, and for the initial build the turn in flight is usually THE turn: the
+    agent spends most of its half-minute generating one large file, and a page
+    generated but never written to disk is a build that produced nothing. Tool
+    execution is a file write, so waiting for it costs milliseconds.
 
     deadline_at is an absolute time.monotonic() value, so a multi-run build can
     share one deadline across its runs instead of giving each a fresh budget.
@@ -194,11 +215,16 @@ def make_run_bounds_hook(
     started_at = time.monotonic()
 
     class _RunBoundsHook(RunHooks):
-        async def on_llm_end(self, context, agent, response):  # noqa: ANN001
+        # Set once a bound is passed on a turn whose tool calls still need to
+        # run; raised before the next model turn starts instead.
+        deferred_stop = None
+
+        def _exceeded_bound(self, context):
+            """The exception for whichever bound this turn passed, if any."""
             if has_deadline:
                 now = time.monotonic()
                 if now >= deadline_at:
-                    raise RunDeadlineExceeded(
+                    return RunDeadlineExceeded(
                         now - started_at, deadline_at - started_at
                     )
             if has_budget:
@@ -207,7 +233,27 @@ def make_run_bounds_hook(
                 output_tokens = getattr(usage, 'output_tokens', 0) or 0
                 cost = compute_cost_usd(model_id, input_tokens, output_tokens)
                 if cost is not None and cost >= budget_usd:
-                    raise RunBudgetExceeded(cost, budget_usd)
+                    return RunBudgetExceeded(cost, budget_usd)
+            return None
+
+        async def on_llm_start(self, context, agent, system_prompt, input_items):  # noqa: ANN001
+            # The previous turn's tools have run by now, so this is the first
+            # moment a deferred stop costs nothing.
+            if self.deferred_stop is not None:
+                raise self.deferred_stop
+
+        async def on_llm_end(self, context, agent, response):  # noqa: ANN001
+            # Reached only on an SDK without on_llm_start: the deferred turn's
+            # tools have long since run, so stop here rather than never.
+            if self.deferred_stop is not None:
+                raise self.deferred_stop
+            exceeded = self._exceeded_bound(context)
+            if exceeded is None:
+                return
+            if response_has_tool_calls(response):
+                self.deferred_stop = exceeded
+                return
+            raise exceeded
 
     return _RunBoundsHook()
 
@@ -1021,8 +1067,9 @@ class ImagiAgentService:
         Returns True when the changes were applied (the task is now
         'accepted'); False when we deliberately leave it for a manual review —
         a broken frontend import graph, an app router that stopped exporting its
-        routes, a live canonical run we must not merge across, a merge conflict,
-        a stale base, or any git-level failure.
+        routes, a first build that dropped its links to the prebuilt auth pages,
+        a live canonical run we must not merge across, a merge conflict, a stale
+        base, or any git-level failure.
         Best-effort by contract: it never raises, so any trouble simply parks
         the task at 'ready' for the user.
         """
@@ -1035,6 +1082,8 @@ class ImagiAgentService:
         if self._worktree_import_problems(conversation):
             return False
         if self._worktree_router_problems(conversation):
+            return False
+        if self._worktree_auth_link_problems(conversation):
             return False
         try:
             from ..api.views import _apply_task_worktree, _conversation_project
@@ -1122,6 +1171,40 @@ class ImagiAgentService:
                 len(problems),
                 problems[0]['file'],
                 problems[0]['detail'],
+            )
+        return problems
+
+    def _worktree_auth_link_problems(self, conversation) -> List[Dict[str, str]]:
+        """Prebuilt auth pages the first build's home page stopped linking to.
+
+        Only the initial build is checked, and only it can be: the page it
+        rewrites is the scaffold's, which ships those links, so their absence
+        means the run dropped them. Later tasks restructure headers for the
+        user all the time, and the same check there would fight them.
+
+        Blocking the merge here is how the repair run gets to happen at all —
+        it needs the worktree, which the merge removes. It is not the last
+        word: initial_build_service ships a page that still fails this rather
+        than handing the founder the untouched scaffold. Best-effort, like the
+        checks above: an error reports no problems.
+        """
+        if self.agent_kind != 'initial_build':
+            return []
+        worktree_path = getattr(conversation, 'worktree_path', '') or ''
+        if not worktree_path:
+            return []
+        try:
+            from .frontend_integrity import find_auth_link_problems
+            problems = find_auth_link_problems(worktree_path)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning(f"Could not check auth links before applying: {e}")
+            return []
+        if problems:
+            logger.warning(
+                "Not auto-applying conversation %s yet: its home page links to "
+                "neither %s",
+                getattr(conversation, 'id', None),
+                " nor ".join(p['path'] for p in problems),
             )
         return problems
 

--- a/backend/django/apps/Imagi/Build/services/coding_agent.py
+++ b/backend/django/apps/Imagi/Build/services/coding_agent.py
@@ -63,6 +63,11 @@ INITIAL_BUILD_REASONING_EFFORT = _BUILDER_SETTINGS.get(
     'INITIAL_BUILD_REASONING_EFFORT', 'low'
 )
 
+# The wall-clock budget that first build races (IMAGI_BUILDER in settings).
+# Quoted into its prompt so the agent's sense of the clock cannot drift from
+# the cap that actually stops it.
+INITIAL_BUILD_TIME_BUDGET_S = _BUILDER_SETTINGS.get('INITIAL_BUILD_TIME_BUDGET_S', 28)
+
 # Project memory files, in priority order (Codex reads AGENTS.md,
 # Claude Code reads CLAUDE.md). Only the first one found is loaded.
 PROJECT_MEMORY_FILES = ('AGENTS.md', 'CLAUDE.md')
@@ -124,55 +129,57 @@ DESIGN_DIRECTION = """Design direction (make what you build look genuinely good,
 # Working style for the initial build, replacing BUILDER_WORKING_STYLE. The
 # builder style is written for changing code that already exists — search, read,
 # then edit narrowly — which is exactly wrong here: the target is a scaffold
-# this prompt already describes, and every exploratory turn is spent against a
-# wall-clock budget. So: plan once, then write whole files.
+# this prompt already describes, and the whole budget is about half a minute.
+# At that length the run is one write, so every other turn — planning,
+# exploring, verifying — is taken directly out of the page.
 INITIAL_BUILD_WORKING_STYLE = """Working style:
-- Open with ONE update_plan call listing the pages you intend to build, then keep it updated as each one lands. The founder watches this plan in their workspace — it is how they see progress — so it is worth the single turn.
-- Write complete files: create_file for new ones, update_file to replace a scaffold file wholesale. Reach for edit_file only to make a small change to a file you have already written this run (adding a route to router/index.ts, adding a nav link).
-- Do not verify by re-reading what you just wrote. Write it correctly the first time.
-- If a tool returns an error or "success": false, say so in your summary — never claim success when an operation failed. If edit_file fails, read that one file and retry with its exact current text.
-- Afterward, briefly summarize what you built and where."""
+- Write the page in ONE update_file call, as your first action. No planning turn, no exploration turn, no verification turn — there is only time for the write.
+- Do not re-read what you just wrote. Write it correctly the first time.
+- If a tool returns an error or "success": false, say so in your summary — never claim success when an operation failed. A failed write is the one thing worth a second turn: read that file and retry with its exact current text.
+- Then summarize in two or three sentences what you built, so the founder can see it reflects their business."""
 
 # Intro for the initial build — the one-shot, headless first build of a new
 # project. It runs like the chat builder (full editing tools, direct edits to
 # the real project) but with a first-build framing and design direction.
-INITIAL_BUILD_INTRO = """You are Imagi, performing the very first build of a brand-new web application for the founder who just described their business. Right now the project holds only Imagi's default scaffold: a home app and a prebuilt auth app. Turn it into a tailored, good-looking first version of THIS business's app. The founder sees your result the moment they open their workspace, so it should feel custom-built for them — not a generic starter."""
+INITIAL_BUILD_INTRO = """You are Imagi, performing the very first build of a brand-new web application for the founder who just described their business. Right now the project holds only Imagi's default scaffold: a home app and a prebuilt auth app. Your job is one page: turn the placeholder landing page into a real home page for THIS business, with the prebuilt sign-in and register pages wired into it. The founder sees your result the moment they open their workspace, so it should feel custom-built for them — not a generic starter."""
 
-# What the initial build should (and shouldn't) do. Deliberately does NOT limit
-# the agent to a fixed set of files — it decides what the business needs — but
-# it IS strictly bounded in time, so the guidance is written around spending
-# that time writing pages rather than exploring a scaffold it already knows.
-INITIAL_BUILD_GUIDANCE = """Building the first version — you are racing a clock:
-- You have ABOUT ONE MINUTE of wall-clock time, and the founder is watching and waiting. When it runs out you are stopped wherever you are. So spend every turn writing files, and treat anything else as a turn you don't get back.
-- Do NOT explore the project first. You already know the layout (below), and the scaffold is exactly as described — no get_project_tree, no glob_files, no grep_files, and no read_file on a scaffold file you are about to replace wholesale. Go straight to writing.
-- Write whole files with create_file (new pages) and update_file (replacing a scaffold file). Do not read-then-edit_file your way through a file you are rewriting anyway; one full write is one turn instead of three.
+# What the initial build should (and shouldn't) do. The scope is one file, and
+# that is a consequence of the clock: at half a minute there is time for a
+# single good write, and a run stopped mid-way through a multi-file page can
+# leave an import pointing at a component it never got to — which fails the
+# integrity check and throws the whole build away. One self-contained file
+# cannot fail that way, so the budget buys a page instead of a gamble.
+INITIAL_BUILD_GUIDANCE = (
+    f"""Building the first version — you have about {INITIAL_BUILD_TIME_BUDGET_S} seconds of wall-clock time:
+- The founder is watching and waiting, and when the time runs out you are stopped wherever you are.
+- Do NOT explore the project first. You already know the layout (below) and the scaffold is exactly as described — no get_project_tree, no glob_files, no grep_files, and no read_file on the file you are about to replace wholesale. Go straight to writing.
 
-You are building PAGES inside an existing, working project — you are not restructuring it. Write and rewrite page components freely; leave the project's plumbing exactly as it is.
+Your job is ONE file: rewrite 'frontend/vuejs/src/apps/home/views/HomeView.vue', with a single update_file call, as a real landing page for THIS business.
+"""
+    + """- Everything lives in that one file — template, script setup, Tailwind classes. Do NOT create component files, do NOT add other pages, do NOT add routes, do NOT touch any other file. This is not a stylistic preference; it is what makes your work survive the clock. A single complete file can never reference something you did not get around to writing, and a build with even one dangling reference is DISCARDED — the founder gets the plain scaffold instead of your work.
+- One file has room for a real landing page, so build a whole one: a header carrying the business's name, a hero that says plainly what this business does and for whom, three or four well-differentiated sections (what it offers, how it works, proof or testimonials, FAQ — whatever this business actually needs), a closing call to action, and a footer.
+- If you finish with time left, keep improving THAT page — sharper copy, another section, better responsive and dark-mode detail. Do not start anything new.
 
-Work in this order, and stop cleanly whenever time runs short — every step is a good place to stop:
-1. FIRST, rewrite the landing page 'frontend/vuejs/src/apps/home/views/HomeView.vue' as a real, polished landing page for THIS business. This is the one thing that must happen: it is what the founder sees first. Keep its header links to '/auth/signin' and '/auth/register' working.
-2. THEN, only if you have time, add one or two further pages that this business genuinely needs (About, Pricing, Features, Contact, a product/services page, ...). For each page: write 'frontend/vuejs/src/apps/home/views/<Name>View.vue', ADD one route entry to the existing array in 'frontend/vuejs/src/apps/home/router/index.ts' with edit_file, export it from 'frontend/vuejs/src/apps/home/views/index.ts', and link it from the landing page's nav — all four, for that page, before you start another one.
-3. Stop and summarize. A tight two-page app that loads beats a five-page one that doesn't.
-
-How routing works here — get this wrong and NOTHING loads:
-- 'frontend/vuejs/src/router' is the project's ONE router. It already calls createRouter and automatically globs up every app's routes. Never touch it.
-- An app's 'router/index.ts' only exports a plain array: `const routes: RouteRecordRaw[] = [...]` plus `export { routes }`. Adding a page means adding ONE entry to that array with edit_file — never rewrite the file, and NEVER call createRouter or createWebHistory in it. An app router that exports a Router instead of a routes array still compiles, and then the app serves no routes at all: every page, including home, 404s.
+Wire in the authentication pages, which are prebuilt and already working at '/auth/signin' and '/auth/register':
+- Keep the scaffold's script setup as it stands: `import { useAuthStore } from '../../auth/stores/index'` and `const authStore = useAuthStore()`. That is the only import your page needs.
+- In the header, show the signed-in user when `authStore.isAuthenticated` (their username and a sign-out button calling `authStore.logout($router)`), and when signed out show a 'Sign in' link to '/auth/signin' plus a prominent create-account link to '/auth/register'.
+- Make the hero's primary call to action a <router-link> to '/auth/register', worded for this business ("Start your free trial", "Book a table", "Get a quote") rather than a generic "Create account".
+- Style all of it to fit your design, but keep those two paths exact. Do NOT open, restyle, or modify anything under 'frontend/vuejs/src/apps/auth/' — those pages and their backend are prebuilt and secure.
 
 Hard rules:
-- DO NOT change the project's structure or its plumbing. You are adding and rewriting pages, nothing else. Leave every one of these exactly as you found it: 'frontend/vuejs/src/router' (the root router), 'frontend/vuejs/src/main.ts', 'frontend/vuejs/src/App.vue', 'frontend/vuejs/src/shared/', the whole 'frontend/vuejs/src/apps/auth/' app, 'vite.config.ts', 'package.json', 'tsconfig*.json', 'tailwind.config.js', 'postcss.config.js', 'index.html', and everything under 'backend/django/'. Do not add dependencies, change the build setup, or reorganize directories. A first build that rewires the project is discarded even if it looks good.
-- NEVER leave a reference dangling. Every file you import and every component you register must already exist. One import of a file you didn't write makes the whole app fail to load with a "Failed to resolve import" error, and a build in that state is DISCARDED — the founder gets the plain scaffold instead of your work. This is the single worst outcome, worse than building less.
+- DO NOT change the project's structure or its plumbing. Leave every one of these exactly as you found it: 'frontend/vuejs/src/router' (the root router), 'frontend/vuejs/src/main.ts', 'frontend/vuejs/src/App.vue', 'frontend/vuejs/src/shared/', the whole 'frontend/vuejs/src/apps/auth/' app, 'vite.config.ts', 'package.json', 'tsconfig*.json', 'tailwind.config.js', 'postcss.config.js', 'index.html', and everything under 'backend/django/'. Do not add dependencies, change the build setup, or reorganize directories. A first build that rewires the project is discarded even if it looks good.
 - NEVER reference an image or media file. There are NO image assets in this project and no 'public/' directory, so every '<img src="/images/...">', background-image url(), or imported .jpg/.png/.svg file is a dangling reference: it renders as a broken image and breaks the production build. You cannot create binary images either. Build visuals out of what you can actually write: CSS gradients, colored and rounded div blocks, inline <svg> you author yourself, borders, shadows, and type. A confident gradient-and-type hero looks far better than a broken image icon.
-- Authentication is already done for you: the auth app (sign-in and register pages plus its backend) is prebuilt and secure. Do NOT rebuild, restyle, or modify the auth app beyond leaving its links in place.
-- Do NOT build payment, checkout, cart, or subscription-billing functionality even if the business sells something — the founder installs secure, prebuilt payment pages later from their Sell workspace. Design the marketing/product pages with a clear call-to-action instead of wiring real payments.
-- Keep it to the frontend pages above. Don't add backend endpoints, stores, or API wiring on a first build unless a page genuinely cannot render without them.
+- Write real copy for this business throughout — never lorem ipsum, never leftover scaffold text like "Welcome to your new project".
+- Do NOT build payment, checkout, cart, or subscription-billing functionality even if the business sells something — the founder installs secure, prebuilt payment pages later from their Sell workspace. Give the page a clear call to action instead of wiring real payments.
+- Do NOT add backend endpoints, stores, or API wiring. The first build is this one page.
 - When you finish, briefly summarize what you built. The founder reads it as the first message in their workspace.
 
 The scaffold you are starting from (already on disk — trust this instead of looking):
-- 'frontend/vuejs/src/apps/home/views/HomeView.vue' — generic placeholder landing page, routed at '/'. Replace it.
-- 'frontend/vuejs/src/apps/home/router/index.ts' — routes for the home app; its one entry maps '/' to HomeView.
-- 'frontend/vuejs/src/apps/home/views/index.ts' — barrel exporting HomeView.
+- 'frontend/vuejs/src/apps/home/views/HomeView.vue' — a generic placeholder landing page, routed at '/', already carrying the auth header and calls to action described above. This is the file you rewrite, and the only one you touch.
 - 'frontend/vuejs/src/apps/auth/' — the prebuilt auth app serving '/auth/signin' and '/auth/register'. Leave it alone.
-- Tailwind, Vue Router, and Pinia are already installed and wired up."""
+- 'frontend/vuejs/src/apps/home/router/index.ts' already maps '/' to HomeView, so your page is live the moment you write it and you never touch a router.
+- Tailwind, Vue Router, and Pinia are installed and wired up."""
+)
 
 # Full prompt for the initial build role.
 INITIAL_BUILD_INSTRUCTIONS = "\n\n".join(

--- a/backend/django/apps/Imagi/Build/services/frontend_integrity.py
+++ b/backend/django/apps/Imagi/Build/services/frontend_integrity.py
@@ -21,7 +21,14 @@ them:
    complaint and resolves to NO routes at all, so every URL — including the
    home page — falls through to the 404 page.
 
-Both scans run without booting anything, so a run's output can be checked
+3. Auth pages nothing links to. Every project is created with working
+   sign-in and register pages and a home page linking to both; a first build
+   that rewrites that home page can drop the links, leaving pages that exist
+   but cannot be reached. This one is advisory rather than blocking — a good
+   page with no sign-in link still beats the untouched scaffold — so it feeds
+   a repair run, and the caller decides what an unrepaired one is worth.
+
+Every scan runs without booting anything, so a run's output can be checked
 before it reaches the tree the preview serves. They are deliberately
 conservative: a clean project always scans clean, because a false positive
 discards a build that was actually fine.
@@ -277,6 +284,72 @@ def describe_router_contract_problems(problems):
     """Render broken router contracts as a bulleted list for an agent prompt."""
     shown = problems[:MAX_REPORTED_PROBLEMS]
     lines = [f"- {p['file']} {p['detail']}" for p in shown]
+    if len(problems) > len(shown):
+        lines.append(f"- ... and {len(problems) - len(shown)} more")
+    return "\n".join(lines)
+
+
+# The routes the prebuilt auth app serves. The scaffolded home page ships
+# linking to both, so a home app that references neither has lost them.
+AUTH_LINK_PATHS = ('/auth/signin', '/auth/register')
+
+# The app whose pages are the way into the auth pages: '/' lives here.
+LANDING_APP = 'home'
+
+
+def find_auth_link_problems(root, app_name=LANDING_APP):
+    """Find prebuilt auth pages the landing app stopped linking to.
+
+    Every project is created with a working sign-in and register page and a
+    home page that links to both. A first build rewrites that home page
+    wholesale, and a rewrite that drops the links leaves the founder an app
+    whose auth pages exist but cannot be reached from anywhere. Nothing else
+    notices: it compiles, loads, and looks finished.
+
+    Unlike the two checks above, this one is advisory — see
+    initial_build_service, which prefers shipping a page that fails it to
+    handing the founder the untouched scaffold.
+
+    Args:
+        root: The project tree to scan (a project_path or a task worktree).
+        app_name: The frontend app that owns the landing page.
+
+    Returns:
+        list[dict]: ``{'path': '/auth/...'}`` for each auth route the app's
+        source no longer references anywhere, in a stable order. A project
+        without an auth app, or without that landing app, yields [] — this
+        reports a link that was lost, it does not require one to exist.
+    """
+    src_root = os.path.join(root or '', FRONTEND_SRC)
+    auth_app = os.path.join(src_root, 'apps', 'auth')
+    app_root = os.path.join(src_root, 'apps', app_name)
+    if not os.path.isdir(auth_app) or not os.path.isdir(app_root):
+        return []
+
+    # Read the app whole: a link counts wherever it lives, so a build that
+    # moved the header into a layout component is not reported.
+    sources = []
+    for source_file in _iter_source_files(app_root):
+        try:
+            with open(source_file, 'r', encoding='utf-8') as f:
+                sources.append(f.read())
+        except (OSError, UnicodeDecodeError) as e:
+            logger.warning(f"Could not read {source_file} for auth link check: {e}")
+    if not sources:
+        return []
+
+    app_source = "\n".join(sources)
+    return [
+        {'path': path} for path in AUTH_LINK_PATHS if path not in app_source
+    ]
+
+
+def describe_auth_link_problems(problems):
+    """Render lost auth links as a bulleted list for an agent prompt."""
+    shown = problems[:MAX_REPORTED_PROBLEMS]
+    lines = [
+        f"- nothing links to '{p['path']}' any more" for p in shown
+    ]
     if len(problems) > len(shown):
         lines.append(f"- ... and {len(problems) - len(shown)} more")
     return "\n".join(lines)

--- a/backend/django/apps/Imagi/Build/tests/test_agents.py
+++ b/backend/django/apps/Imagi/Build/tests/test_agents.py
@@ -38,7 +38,9 @@ from apps.Imagi.Build.services.base_agent import (
 )
 from apps.Imagi.Build.services.models_service import compute_cost_usd
 from apps.Imagi.Build.services.coding_agent import (
+    INITIAL_BUILD_INSTRUCTIONS,
     INITIAL_BUILD_REASONING_EFFORT,
+    INITIAL_BUILD_TIME_BUDGET_S,
     PROJECT_MEMORY_MAX_CHARS,
     create_coding_agent,
     load_project_memory,
@@ -892,13 +894,23 @@ class ComputeCostTests(SimpleTestCase):
 class RunBoundsHookTests(SimpleTestCase):
     """The cost and wall-clock bounds that stop a long run."""
 
-    def _fire(self, hook, input_tokens=0, output_tokens=0):
+    def _fire(self, hook, input_tokens=0, output_tokens=0, response=None):
         context = SimpleNamespace(
             usage=SimpleNamespace(
                 input_tokens=input_tokens, output_tokens=output_tokens
             )
         )
-        async_to_sync(hook.on_llm_end)(context, None, None)
+        async_to_sync(hook.on_llm_end)(context, None, response)
+
+    def _start_turn(self, hook):
+        async_to_sync(hook.on_llm_start)(None, None, None, [])
+
+    @staticmethod
+    def _response_with_tool_call():
+        return SimpleNamespace(output=[
+            SimpleNamespace(type='reasoning'),
+            SimpleNamespace(type='function_call'),
+        ])
 
     def test_no_bounds_means_no_hook(self):
         self.assertIsNone(make_run_bounds_hook('gpt-5.6-sol'))
@@ -930,13 +942,41 @@ class RunBoundsHookTests(SimpleTestCase):
         with self.assertRaises(RunBudgetExceeded):
             self._fire(hook, input_tokens=1_000_000, output_tokens=0)
 
+    def test_pending_tool_calls_run_before_the_stop(self):
+        # The turn that ends over the deadline is usually the turn that wrote
+        # the page. Stopping on the spot would discard it, so its tool calls
+        # are executed and the run stops before the next model turn instead.
+        hook = make_run_bounds_hook(
+            'gpt-5.6-sol', deadline_at=time.monotonic() - 1
+        )
+        self._fire(hook, response=self._response_with_tool_call())
+        with self.assertRaises(RunDeadlineExceeded):
+            self._start_turn(hook)
+
+    def test_stop_is_deferred_only_past_the_bound(self):
+        hook = make_run_bounds_hook(
+            'gpt-5.6-sol', deadline_at=time.monotonic() + 300
+        )
+        self._fire(hook, response=self._response_with_tool_call())
+        self._start_turn(hook)
+
+    def test_a_deferred_stop_still_fires_without_on_llm_start(self):
+        # Belt and braces for an SDK that never calls on_llm_start: the next
+        # turn's end raises rather than letting the run continue unbounded.
+        hook = make_run_bounds_hook(
+            'gpt-5.6-sol', deadline_at=time.monotonic() - 1
+        )
+        self._fire(hook, response=self._response_with_tool_call())
+        with self.assertRaises(RunDeadlineExceeded):
+            self._fire(hook, response=self._response_with_tool_call())
+
 
 class InitialBuildAgentTests(SimpleTestCase):
     """The first-build role's own configuration, which trades depth for speed."""
 
     def test_initial_build_has_no_web_search_tool(self):
-        # A hosted search can eat a large share of a one-minute budget, and its
-        # schema costs every later turn prompt tokens.
+        # A hosted search can eat a large share of a half-minute budget, and
+        # its schema costs every later turn prompt tokens.
         agent = create_coding_agent(kind='initial_build')
         self.assertNotIn(
             'WebSearchTool', [type(tool).__name__ for tool in agent.tools]
@@ -952,6 +992,40 @@ class InitialBuildAgentTests(SimpleTestCase):
         agent = create_coding_agent(kind='initial_build')
         names = {getattr(tool, 'name', '') for tool in agent.tools}
         self.assertTrue({'create_file', 'update_file'} <= names, names)
+
+    def test_prompt_quotes_the_real_time_budget(self):
+        # The agent paces itself by the number in its prompt, so that number is
+        # read from the same setting that stops the run.
+        self.assertIn(
+            f"about {INITIAL_BUILD_TIME_BUDGET_S} seconds",
+            INITIAL_BUILD_INSTRUCTIONS,
+        )
+
+    def test_prompt_scopes_the_build_to_the_home_page_alone(self):
+        # Half a minute buys one good write. Anything split across files can be
+        # cut off mid-way holding a dangling import, which discards the build.
+        self.assertIn(
+            'frontend/vuejs/src/apps/home/views/HomeView.vue',
+            INITIAL_BUILD_INSTRUCTIONS,
+        )
+        for rule in (
+            'Do NOT create component files',
+            'do NOT add other pages',
+            'do NOT add routes',
+        ):
+            self.assertIn(rule, INITIAL_BUILD_INSTRUCTIONS)
+
+    def test_prompt_wires_in_the_prebuilt_auth_pages(self):
+        # The auth app is prebuilt and left untouched; the first build's job is
+        # to bring its two pages into the home page it writes.
+        for path in ("'/auth/signin'", "'/auth/register'"):
+            self.assertIn(path, INITIAL_BUILD_INSTRUCTIONS)
+        self.assertIn('useAuthStore', INITIAL_BUILD_INSTRUCTIONS)
+        self.assertIn(
+            "Do NOT open, restyle, or modify anything under "
+            "'frontend/vuejs/src/apps/auth/'",
+            INITIAL_BUILD_INSTRUCTIONS,
+        )
 
     def test_initial_build_runs_at_its_configured_effort(self):
         # Set explicitly for the role, so a per-request effort meant for the

--- a/backend/django/apps/Imagi/Build/tests/test_frontend_integrity.py
+++ b/backend/django/apps/Imagi/Build/tests/test_frontend_integrity.py
@@ -14,8 +14,10 @@ import tempfile
 from django.test import TestCase
 
 from apps.Imagi.Build.services.frontend_integrity import (
+    describe_auth_link_problems,
     describe_router_contract_problems,
     describe_unresolved_imports,
+    find_auth_link_problems,
     find_router_contract_problems,
     find_unresolved_imports,
 )
@@ -291,3 +293,84 @@ class FrontendIntegrityTests(TestCase):
         problems = [{'file': f'{i}.vue', 'import': './x.vue'} for i in range(40)]
         described = describe_unresolved_imports(problems)
         self.assertIn('and 15 more', described)
+
+
+class AuthLinkTests(TestCase):
+    """Whether the built home page still reaches the prebuilt auth pages.
+
+    The scaffold ships a home page linking to both; a first build rewrites
+    that page wholesale, and one that drops the links leaves the founder with
+    sign-in and register pages nothing points at.
+    """
+
+    def setUp(self):
+        self.root = tempfile.mkdtemp(prefix='imagi-auth-links-')
+        self.src = os.path.join(self.root, 'frontend', 'vuejs', 'src')
+        os.makedirs(self.src)
+        self.addCleanup(shutil.rmtree, self.root, True)
+
+    def _write(self, rel_path, content):
+        path = os.path.join(self.src, rel_path)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, 'w') as f:
+            f.write(content)
+        return path
+
+    def _scaffold_auth_app(self):
+        self._write('apps/auth/views/SignInView.vue', "<template><form /></template>\n")
+
+    def test_a_page_keeping_both_links_is_clean(self):
+        self._scaffold_auth_app()
+        self._write(
+            'apps/home/views/HomeView.vue',
+            "<template>\n"
+            "  <router-link to=\"/auth/signin\">Sign in</router-link>\n"
+            "  <router-link to=\"/auth/register\">Start free</router-link>\n"
+            "</template>\n",
+        )
+        self.assertEqual(find_auth_link_problems(self.root), [])
+
+    def test_a_dropped_link_is_reported(self):
+        self._scaffold_auth_app()
+        self._write(
+            'apps/home/views/HomeView.vue',
+            "<template><router-link to=\"/auth/signin\">Sign in</router-link></template>\n",
+        )
+        self.assertEqual(
+            find_auth_link_problems(self.root), [{'path': '/auth/register'}]
+        )
+
+    def test_a_page_that_dropped_auth_entirely_reports_both(self):
+        self._scaffold_auth_app()
+        self._write('apps/home/views/HomeView.vue', "<template><h1>Beanline</h1></template>\n")
+        self.assertEqual(
+            [p['path'] for p in find_auth_link_problems(self.root)],
+            ['/auth/signin', '/auth/register'],
+        )
+
+    def test_links_count_from_anywhere_in_the_app(self):
+        # A build that put its header in a component of its own still gives the
+        # founder a way in, so it is not reported.
+        self._scaffold_auth_app()
+        self._write('apps/home/views/HomeView.vue', "<template><SiteHeader /></template>\n")
+        self._write(
+            'apps/home/components/SiteHeader.vue',
+            "<template>\n"
+            "  <router-link to=\"/auth/signin\">Sign in</router-link>\n"
+            "  <router-link to=\"/auth/register\">Join</router-link>\n"
+            "</template>\n",
+        )
+        self.assertEqual(find_auth_link_problems(self.root), [])
+
+    def test_a_project_without_an_auth_app_is_not_reported(self):
+        # Nothing to link to: this check reports a link that was lost, not one
+        # that never existed.
+        self._write('apps/home/views/HomeView.vue', "<template><h1>Beanline</h1></template>\n")
+        self.assertEqual(find_auth_link_problems(self.root), [])
+
+    def test_no_frontend_is_not_an_auth_problem(self):
+        self.assertEqual(find_auth_link_problems(tempfile.mkdtemp()), [])
+
+    def test_description_names_the_lost_route(self):
+        described = describe_auth_link_problems([{'path': '/auth/register'}])
+        self.assertIn('/auth/register', described)

--- a/backend/django/apps/Imagi/ProjectManager/services/initial_build_service.py
+++ b/backend/django/apps/Imagi/ProjectManager/services/initial_build_service.py
@@ -1,8 +1,8 @@
 """
 Initial AI build service.
 
-When a user creates a project (their business), the business name and
-description they provided become the first build prompt for the coding
+When a user creates a project (their business), the name, description and any
+style preferences they provided become the first build prompt for the coding
 agent. The build runs in a background thread so project creation stays
 fast; by the time the user enters build mode the workspace already has a
 tailored starting point instead of the generic scaffold.
@@ -16,17 +16,33 @@ its result is merged in one step when it is finished and sound.
 
 The build is bounded by wall-clock time, not by how much it manages to build:
 the founder is waiting on it, so the whole thing — first run plus any repair
-runs — shares one deadline (IMAGI_BUILDER['INITIAL_BUILD_TIME_BUDGET_S']) and
-ships whatever is finished and sound when that runs out. This degrades safely
-because the project already holds a working home + auth scaffold the moment it
-is created: a build that runs short means less tailoring, never a broken app.
+run — shares one deadline (IMAGI_BUILDER['INITIAL_BUILD_TIME_BUDGET_S'], sized
+so the founder waits about half a minute) and ships whatever is finished and
+sound when that runs out. This degrades safely because the project already
+holds a working home + auth scaffold the moment it is created: a build that
+runs short means less tailoring, never a broken app.
 
-"Sound" is enforced, not hoped for: a build cut short by a cap routinely leaves
-a page importing a component it never wrote, and Vite serves that as a "Failed
-to resolve import" error instead of the app. Before the worktree is merged, the
-frontend's import graph is checked; a build with dangling references gets
-follow-up repair runs from whatever time is left, and one that still doesn't
-resolve is never merged — the project keeps its clean, working scaffold.
+That deadline is what sets the scope. Half a minute buys one good write, so the
+subagent is pointed at exactly one thing (coding_agent.INITIAL_BUILD_GUIDANCE):
+rewrite the home page as a single self-contained component, with the prebuilt
+auth app's sign-in and register pages wired into its header and calls to
+action. Everything else a web app needs — the Vue and Django scaffolding, the
+auth app itself — is already on disk before this runs.
+
+"Sound" is enforced, not hoped for: a build cut short by a cap can leave a page
+importing a component it never wrote, and Vite serves that as a "Failed to
+resolve import" error instead of the app. Before the worktree is merged, the
+frontend's import graph is checked; a build with dangling references gets a
+follow-up repair run from whatever time is left, and one that still doesn't
+resolve is never merged — the project keeps its clean, working scaffold. The
+one-file scope is the first line of that defense: a page that imports nothing
+it wrote itself cannot dangle in the first place.
+
+A third check asks whether the page the build wrote still links to the sign-in
+and register pages, since a wholesale rewrite can quietly drop them and leave
+auth nothing points at. That one earns a repair run but never costs the build:
+a page that loads and is hard to sign into still beats the scaffold, so an
+unrepaired one is merged anyway.
 
 Build progress is tracked on the existing Project.generation_status field
 ('generating' -> 'completed'/'failed').
@@ -76,20 +92,24 @@ Business description (written by the founder):
         prompt += f"\n\nDesign & style preferences (from the founder):\n{design}"
 
     prompt += (
-        "\n\nBuild a tailored, polished first version that fits this business, "
-        "following your design direction. When you're done, briefly summarize "
-        "what you built."
+        "\n\nBuild a tailored, polished home page that fits this business, "
+        "following your design direction, and wire the prebuilt sign-in and "
+        "register pages into it. When you're done, briefly summarize what you "
+        "built."
     )
     return prompt
 
 
-def build_repair_prompt(problems, router_problems=()) -> str:
+def build_repair_prompt(problems, router_problems=(), auth_problems=()) -> str:
     """Ask the subagent to fix what is keeping its build from being applied.
 
-    Covers both blocking defects: references to files that were never created,
-    and an app router that stopped handing its routes to the root router.
+    Covers the two blocking defects — references to files that were never
+    created, and an app router that stopped handing its routes to the root
+    router — plus the one advisory defect: a home page that no longer links to
+    the prebuilt sign-in and register pages.
     """
     from apps.Imagi.Build.services.frontend_integrity import (
+        describe_auth_link_problems,
         describe_router_contract_problems,
         describe_unresolved_imports,
     )
@@ -124,6 +144,19 @@ def build_repair_prompt(problems, router_problems=()) -> str:
             "Do NOT call createRouter or createWebHistory in an app router — "
             "'frontend/vuejs/src/router' already does that and globs up every "
             "app's routes."
+        )
+
+    if auth_problems:
+        sections.append(
+            "Your home page dropped the links to the project's prebuilt "
+            "sign-in and register pages, so there is now no way into them:"
+            f"\n\n{describe_auth_link_problems(auth_problems)}\n\n"
+            "Add them back to the page you wrote, styled to match it: a "
+            "'Sign in' <router-link> to '/auth/signin' in the header, and a "
+            "create-account <router-link> to '/auth/register' as the header's "
+            "and the hero's call to action (word it for this business). Keep "
+            "both paths exact, and leave 'frontend/vuejs/src/apps/auth/' "
+            "itself untouched — those pages already work."
         )
 
     sections.append(
@@ -291,14 +324,73 @@ def _run_initial_build(project_id: int, user_id: int) -> None:
         close_old_connections()
 
 
+def _apply_despite_lost_auth_links(service, task, user, project_id, auth_problems) -> bool:
+    """Merge a build whose only remaining defect is a lost link to auth.
+
+    The auth-link gate blocks the automatic merge for one reason: to buy a
+    repair run while the worktree still exists. It is not a verdict on the
+    build. Once the repairs are spent, a home page tailored to the founder's
+    business but missing its 'Sign in' link is plainly worth more to them than
+    the untouched scaffold, and getting the link back is one sentence to their
+    main thread. The blocking checks have already passed by the time this
+    runs, so what merges here is a page that loads.
+
+    Returns whether the merge landed; a refusal leaves the project on its
+    scaffold exactly as before.
+    """
+    from apps.Imagi.Build.api.views import (
+        _apply_task_worktree,
+        _conversation_project,
+    )
+
+    # The merge rewrites the canonical tree, so it must not race a chat or lead
+    # run editing it — the same guard the automatic path applies.
+    if service._project_has_live_canonical_run(user, project_id):
+        logger.warning(
+            "Not applying the initial build for project %s: another run holds "
+            "the canonical tree",
+            project_id,
+        )
+        return False
+
+    project = _conversation_project(task)
+    if project is None:
+        return False
+
+    outcome = _apply_task_worktree(task, project)
+    if not outcome.get('ok'):
+        logger.error(
+            "Could not apply the initial build for project %s: %s",
+            project_id,
+            outcome.get('detail') or outcome.get('error'),
+        )
+        return False
+
+    logger.warning(
+        "Applied the initial build for project %s even though its home page no "
+        "longer links to %s — a tailored page beats the scaffold, and the links "
+        "are one request away",
+        project_id,
+        " or ".join(p['path'] for p in auth_problems),
+    )
+    return True
+
+
 def _build_and_apply(service, task, user, project_id, prompt, builder):
-    """Run the build, repairing dangling imports until the work can be applied.
+    """Run the build, repairing what stands between it and the project.
 
     Each run ends in the usual task finalization, which merges the worktree
-    only when its frontend actually resolves. So "was it applied?" is read
-    back off the conversation, and anything left unmerged with unresolved
-    imports gets a targeted repair run. Returns whether the work landed in
+    only when its frontend actually resolves, its app routers still export
+    their routes, and its home page still reaches the prebuilt auth pages. So
+    "was it applied?" is read back off the conversation, and anything left
+    unmerged gets a targeted repair run. Returns whether the work landed in
     the project.
+
+    The three defects are not weighted the same when the repairs run out. A
+    dangling import or a broken router means an app that does not load, so
+    that build is abandoned and the project keeps its scaffold. A missing auth
+    link only means a page that loads and is harder to sign into, so that one
+    ships anyway.
 
     The founder's wait is the binding constraint, so every run in this loop
     shares ONE deadline rather than getting a fresh budget: a build plus its
@@ -308,6 +400,7 @@ def _build_and_apply(service, task, user, project_id, prompt, builder):
     fixes.
     """
     from apps.Imagi.Build.services.frontend_integrity import (
+        find_auth_link_problems,
         find_router_contract_problems,
         find_unresolved_imports,
     )
@@ -343,13 +436,15 @@ def _build_and_apply(service, task, user, project_id, prompt, builder):
         if task.review_status == 'accepted':
             return True
 
-        # Not applied. A dangling reference or a broken app-router contract are
-        # the causes worth another run; anything else (a merge conflict, a git
-        # failure) needs the user.
+        # Not applied. A dangling reference, a broken app-router contract, or a
+        # home page that lost its way into the auth pages are the causes worth
+        # another run; anything else (a merge conflict, a git failure) needs
+        # the user.
         problems = find_unresolved_imports(task.worktree_path)
         router_problems = find_router_contract_problems(task.worktree_path)
-        blocking = len(problems) + len(router_problems)
-        if not blocking:
+        auth_problems = find_auth_link_problems(task.worktree_path)
+        found = len(problems) + len(router_problems) + len(auth_problems)
+        if not found:
             logger.error(
                 "Initial AI build for project %s finished but could not be applied "
                 "(review status %r)",
@@ -357,40 +452,49 @@ def _build_and_apply(service, task, user, project_id, prompt, builder):
                 task.review_status,
             )
             return False
-        if attempt >= attempts:
-            logger.error(
-                "Initial AI build for project %s still has %d unresolved import(s) "
-                "and %d router problem(s) after %d repair attempt(s)",
-                project_id,
-                len(problems),
-                len(router_problems),
-                attempts,
-            )
-            return False
 
         remaining = deadline_at - time.monotonic() if deadline_at else None
-        if remaining is not None and remaining < min_repair_seconds:
-            logger.warning(
-                "Initial AI build for project %s left %d blocking problem(s) with "
-                "only %.1fs of its time budget left; skipping repair so the project "
-                "keeps its working scaffold",
-                project_id,
-                blocking,
-                remaining,
-            )
+        out_of_attempts = attempt >= attempts
+        out_of_time = remaining is not None and remaining < min_repair_seconds
+        if out_of_attempts or out_of_time:
+            # Only the blocking defects are worth losing the build over.
+            if auth_problems and not problems and not router_problems:
+                return _apply_despite_lost_auth_links(
+                    service, task, user, project_id, auth_problems
+                )
+            if out_of_attempts:
+                logger.error(
+                    "Initial AI build for project %s still has %d unresolved "
+                    "import(s) and %d router problem(s) after %d repair attempt(s)",
+                    project_id,
+                    len(problems),
+                    len(router_problems),
+                    attempts,
+                )
+            else:
+                logger.warning(
+                    "Initial AI build for project %s left %d problem(s) with only "
+                    "%.1fs of its time budget left; skipping repair so the project "
+                    "keeps its working scaffold",
+                    project_id,
+                    found,
+                    remaining,
+                )
             return False
 
         logger.warning(
-            "Initial AI build for project %s left %d unresolved import(s) and %d "
-            "router problem(s); starting repair run %d/%d with %s of time budget left",
+            "Initial AI build for project %s left %d unresolved import(s), %d "
+            "router problem(s) and %d lost auth link(s); starting repair run "
+            "%d/%d with %s of time budget left",
             project_id,
             len(problems),
             len(router_problems),
+            len(auth_problems),
             attempt + 1,
             attempts,
             f"{remaining:.1f}s" if remaining is not None else "no limit",
         )
-        user_input = build_repair_prompt(problems, router_problems)
+        user_input = build_repair_prompt(problems, router_problems, auth_problems)
         max_turns = builder.get('INITIAL_BUILD_REPAIR_MAX_TURNS')
         cost_budget = builder.get('INITIAL_BUILD_REPAIR_COST_BUDGET_USD')
 

--- a/backend/django/apps/Imagi/ProjectManager/tests.py
+++ b/backend/django/apps/Imagi/ProjectManager/tests.py
@@ -617,6 +617,66 @@ class InitialBuildServiceTests(TestCase):
         self.project.refresh_from_db()
         self.assertEqual(self.project.generation_status, 'completed')
 
+    def test_a_home_page_that_dropped_its_auth_links_is_repaired(self):
+        # The build compiles and looks finished, but nothing on it reaches the
+        # sign-in or register pages the project already ships.
+        with patch(
+            'apps.Imagi.Build.services.frontend_integrity.find_auth_link_problems',
+            return_value=[{'path': '/auth/register'}],
+        ):
+            calls = self._run_build(['leave', 'accept'], unresolved=[])
+
+        self.assertEqual(len(calls), 2, 'a home page with no way into auth was shipped as-is')
+        repair_prompt = calls[1]['user_input']
+        self.assertIn('/auth/register', repair_prompt)
+        self.assertIn('/auth/signin', repair_prompt)
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.generation_status, 'completed')
+
+    def test_an_unrepaired_auth_link_still_ships_the_page(self):
+        # Unlike a dangling import, this build loads — it is just harder to
+        # sign into. A tailored page beats handing the founder the scaffold,
+        # so once the repairs are spent it is merged anyway.
+        from apps.Imagi.Build import api as build_api
+
+        attempts = settings.IMAGI_BUILDER['INITIAL_BUILD_REPAIR_ATTEMPTS']
+        with patch(
+            'apps.Imagi.Build.services.frontend_integrity.find_auth_link_problems',
+            return_value=[{'path': '/auth/register'}],
+        ), patch.object(
+            build_api.views, '_apply_task_worktree', return_value={'ok': True}
+        ) as apply_worktree:
+            calls = self._run_build(['leave'] * (attempts + 1), unresolved=[])
+
+        self.assertEqual(len(calls), attempts + 1)
+        apply_worktree.assert_called_once()
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.generation_status, 'completed')
+
+    def test_a_dangling_import_alongside_it_is_still_discarded(self):
+        # The soft treatment is only for the auth links. A build that does not
+        # load is abandoned however it got there.
+        from apps.Imagi.Build import api as build_api
+
+        attempts = settings.IMAGI_BUILDER['INITIAL_BUILD_REPAIR_ATTEMPTS']
+        with patch(
+            'apps.Imagi.Build.services.frontend_integrity.find_auth_link_problems',
+            return_value=[{'path': '/auth/register'}],
+        ), patch.object(
+            build_api.views, '_apply_task_worktree', return_value={'ok': True}
+        ) as apply_worktree:
+            self._run_build(
+                ['leave'] * (attempts + 1),
+                unresolved=[{
+                    'file': 'frontend/vuejs/src/apps/home/views/HomeView.vue',
+                    'import': '@/shared/components/SiteHeader.vue',
+                }],
+            )
+
+        apply_worktree.assert_not_called()
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.generation_status, 'failed')
+
     def test_repair_prompt_covers_imports_and_routers_together(self):
         from apps.Imagi.ProjectManager.services.initial_build_service import (
             build_repair_prompt,
@@ -760,6 +820,15 @@ class ScaffoldWiringTests(TestCase):
         )
         self.assertIn('/auth/signin', home_view)
         self.assertIn('/auth/register', home_view)
+
+    def test_a_freshly_scaffolded_project_passes_the_auth_link_check(self):
+        # The check gates the first build's merge, so a false positive on a
+        # clean project would block every build there is.
+        from apps.Imagi.Build.services.frontend_integrity import (
+            find_auth_link_problems,
+        )
+
+        self.assertEqual(find_auth_link_problems(self.project.project_path), [])
 
     def test_scaffolded_files_are_mirrored_to_database(self):
         # Disk is the source of truth; the DB mirror should hold the same

--- a/backend/django/imagi/settings.py
+++ b/backend/django/imagi/settings.py
@@ -273,12 +273,14 @@ IMAGI_BUILDER = {
     # project already holds a working home + auth scaffold from the moment it is
     # created, so a build that stops early degrades to "less tailoring", never
     # to a broken or empty app.
-    # Held a little under a minute on purpose: this bounds the agent's own run,
-    # and the founder additionally waits on the work either side of it (worktree
-    # setup, then the merge and database mirror on the way out) — measured at
-    # ~2s combined. 55 keeps the end-to-end wait under a minute.
+    # The target is a 30-second wait, so the agent's own run gets 28: the
+    # founder additionally waits on the work either side of it (worktree setup,
+    # then the merge and database mirror on the way out) — measured at ~2s
+    # combined. Half a minute is what the scope below is sized for: one
+    # self-contained home page, which is all a founder needs to see to know the
+    # build understood their business.
     'INITIAL_BUILD_MODEL': 'gpt-5.6-terra',
-    'INITIAL_BUILD_TIME_BUDGET_S': 55,
+    'INITIAL_BUILD_TIME_BUDGET_S': 28,
     # First builds create UI from a description rather than reasoning about
     # existing code, so they run at low effort: it roughly halves per-turn
     # latency, which buys more pages inside the time budget than deeper
@@ -290,20 +292,23 @@ IMAGI_BUILDER = {
     # run is displayed as costing), which are a multiple of the underlying API
     # price — so this is deliberately well above real expected spend. Sized so
     # it never cuts a build short on its own; time does that.
-    'INITIAL_BUILD_COST_BUDGET_USD': 3.00,
-    'INITIAL_BUILD_MAX_TURNS': 24,
+    'INITIAL_BUILD_COST_BUDGET_USD': 1.50,
+    'INITIAL_BUILD_MAX_TURNS': 12,
     # A build that stops at a cap can leave a page importing a component it
     # never wrote, which takes the whole preview down. Such a build is not
-    # merged; instead the subagent gets up to this many short follow-up runs to
-    # repair the dangling references — but only from whatever time is left in
-    # the budget above, so repair can never extend the founder's wait.
-    'INITIAL_BUILD_REPAIR_ATTEMPTS': 2,
-    'INITIAL_BUILD_REPAIR_COST_BUDGET_USD': 1.00,
-    'INITIAL_BUILD_REPAIR_MAX_TURNS': 12,
+    # merged; instead the subagent gets a short follow-up run to repair the
+    # dangling references — but only from whatever time is left in the budget
+    # above, so repair can never extend the founder's wait. At half a minute
+    # there is rarely room for even one, which is why the first-build prompt
+    # asks for a single self-contained file: a build that writes no cross-file
+    # references cannot leave a dangling one to repair.
+    'INITIAL_BUILD_REPAIR_ATTEMPTS': 1,
+    'INITIAL_BUILD_REPAIR_COST_BUDGET_USD': 0.50,
+    'INITIAL_BUILD_REPAIR_MAX_TURNS': 6,
     # Skip a repair run that cannot plausibly finish in the time left, rather
     # than starting one that will be killed mid-edit (which tends to leave more
     # dangling references than it fixes).
-    'INITIAL_BUILD_MIN_REPAIR_SECONDS': 12,
+    'INITIAL_BUILD_MIN_REPAIR_SECONDS': 8,
     # Attach OpenAI's hosted web-search tool to the agent.
     'ENABLE_WEB_SEARCH': True,
     # Apps scaffolded into every new project. Payment pages are deliberately


### PR DESCRIPTION
## What this changes

The project-creation subagent that builds a founder's first app while they wait is now bounded at **~30s end-to-end** (28s for the agent run, ~2s for worktree setup plus the merge and DB mirror), down from 55s. Everything else follows from that number.

**Scope: one page, one file.** The prompt asked for the landing page and then one or two more, each needing a view, a route entry, a barrel export and a nav link. At half a minute that's a losing bet — a run cut off partway leaves an import pointing at a component it never wrote, which fails the integrity check and discards the *entire* build, so the founder gets the plain scaffold and the time bought nothing. The build now writes exactly one self-contained `HomeView.vue` in a single `update_file` call: no component files, no new pages, no routes. Worst case degrades to "less page" instead of "no build". The opening `update_plan` turn is gone too; leftover time goes back into the same page.

**Auth wiring is now explicit**, not a passing clause: keep the scaffold's `useAuthStore` setup, the signed-in/signed-out header states, the exact `/auth/signin` and `/auth/register` paths, and a hero CTA to register worded for the business — with `apps/auth/` itself off-limits. The prompt quotes the budget straight from `IMAGI_BUILDER` so the number the agent paces itself by can't drift from the one that stops it.

**A bug the tighter budget would have made fatal.** The run-bounds hook raised in `on_llm_end` — after the model generates a turn, but *before* the SDK executes that turn's tool calls. Under a one-big-write design the turn in flight is the turn that writes the page, so hitting the deadline discarded the whole build. It now lets pending tool calls run and stops before the next model turn (tool execution is a file write — milliseconds of overshoot), with a fallback for an SDK that never calls `on_llm_start`.

**Verification that the page still links to auth.** Nothing checked this before; a wholesale rewrite can drop the links, leaving auth pages that work but that nothing points at — it compiles, loads, and looks finished. `find_auth_link_problems` scans the home app for both routes pre-merge, for the initial build only.

## Reviewer notes

- **Why the auth check doesn't block.** Blocking the merge is only how the repair run gets a worktree to work in. Once repairs are spent, `_apply_despite_lost_auth_links` merges anyway — a tailored page that loads and is harder to sign into beats the untouched scaffold, and restoring the link is one sentence to the main thread. Dangling imports and broken app routers keep their hard block, including when auth links are missing too.
- **Why the check is initial-build only.** Only the first build starts from a page known to carry those links. Later tasks restructure headers on the user's instructions, and the same check there would fight them.
- **The prompt is the implementation** for scope and auth wiring, so the diff is mostly prose. The mechanical guarantees are the integrity checks and the merge gate.
- Backstops resized with the budget: 12 turns, \$1.50 retail cost, one repair attempt. Time still binds long before any of them.
- **Not measured end to end** — 28s is a budget, not an observed build time. The previous latency commit cited live runs; this one doesn't.

## Testing

Full `apps.Imagi` suite passes (416 tests). New coverage:

- `find_auth_link_problems`: both links kept, one dropped, both dropped, links living in a sibling component, no auth app, no frontend.
- The real scaffold from `ProjectCreationService` scans clean — the guard that matters most, since a false positive would block every build's merge.
- Service level: a dropped link triggers a repair naming both paths; an unrepaired one still merges; the same case *with* a dangling import does not.
- Bounds hook: pending tool calls run before the stop; no deferral when under the bound; the deferred stop still fires without `on_llm_start`.
- Prompt contract: quotes the configured budget, scopes to `HomeView.vue`, forbids extra files/pages/routes, names both auth paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)