### PR TITLE
Stamp generated projects with the real Imagi domain

### DIFF
--- a/backend/django/apps/Imagi/Build/services/version_control_service.py
+++ b/backend/django/apps/Imagi/Build/services/version_control_service.py
@@ -203,7 +203,7 @@ class VersionControlService:
             )
             
             subprocess.run(
-                ['git', 'config', 'user.email', 'system@imagioasis.com'],
+                ['git', 'config', 'user.email', 'system@imagi.ai'],
                 cwd=project_path,
                 capture_output=True,
                 text=True,


### PR DESCRIPTION
## What changed

One line in [`version_control_service.py`](backend/django/apps/Imagi/Build/services/version_control_service.py): the git commit identity written into every generated project's repo changes from `system@imagioasis.com` to `system@imagi.ai`.

## Why

`imagioasis.com` is a leftover from the Oasis-era naming and is not a domain Imagi owns. Generated projects are the user's own repos, so this address was landing in their commit history.

`imagi.ai` matches `support@imagi.ai` already used elsewhere in the codebase.

## What was deliberately left alone

A repo-wide sweep for `oasis` found nine other hits, all Django migration history:

- `ProjectManager/migrations/0002_rename_oasis_to_imagi_projects.py` — the data migration that performed the original rename, including the `oasis_projects` path in its reverse function
- Four migrations (`Sell/0001`, `Operate/0001`, `Marketing/0001`, `ProjectManager/0003`) that depend on it **by filename**

Renaming that file would break the migration dependency graph and every deployed database's `django_migrations` table. The name is a historical record, not a stale path.

There is no `/products/oasis/*` route in the frontend — the live route is `/imagi/projects`. The `/products/` paths in `sellService.ts` are the Sell app's product-catalog API and are unrelated.

## Testing

This branch started as a test pass over the project creation service; the fix came out of that.

- `apps.Imagi.ProjectManager` + `apps.Imagi.Build`: **315 tests, all passing**
- `manage.py check`: 0 issues
- End-to-end in the preview browser: created a project through the UI (`201 Created` → `initialize` → build `completed`), verified the scaffold on disk (dual-stack layout, `home` + `auth` apps, `node_modules` symlinked to the shared store, no stray root dirs, 79 files mirrored to the DB), confirmed the generated backend passes its own `manage.py check`, and confirmed the generated app renders with a working `/auth/signin` route and no console errors.

## Reviewer note

The commit identity only affects **newly** created project repos. Existing generated repos keep the old address in their history and in their local `.git/config`; this change does not migrate them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)