### PR TITLE
Build the first version's pages in parallel, one subagent each

### DIFF
--- a/backend/django/apps/Imagi/Build/services/codegen/prebuilt_apps/__init__.py
+++ b/backend/django/apps/Imagi/Build/services/codegen/prebuilt_apps/__init__.py
@@ -2,6 +2,12 @@
 Prebuilt app templates for Imagi Builder.
 Generates both frontend (Vue) and backend (Django) files for default apps: home, auth.
 
+'about' and 'contact' are prebuilt too, but as frontend-only PAGE apps: they
+are static marketing pages with nothing to serve, and they exist mainly so the
+initial build can hand each of its parallel subagents a single file to rewrite
+(see pages.py). They are kept out of PREBUILT_MAP/DEFAULT_APPS because that
+path also registers a Django app in INSTALLED_APPS, which these do not have.
+
 Payment pages are intentionally not scaffolded here: users install them
 from the Sell workspace's template gallery (apps.Imagi.Sell.services
 .payment_templates), which drops in secure, Stripe-hosted checkout pages
@@ -16,11 +22,18 @@ from typing import Dict, List
 
 from .home import home_app_files
 from .auth import auth_app_files
+from .pages import about_app_files, contact_app_files
 
 
 PREBUILT_MAP = {
     'home': home_app_files,
     'auth': auth_app_files,
+}
+
+# Frontend-only page apps, scaffolded alongside the default apps.
+PAGE_APP_MAP = {
+    'about': about_app_files,
+    'contact': contact_app_files,
 }
 
 
@@ -32,9 +45,21 @@ def generate_prebuilt_app_files(app_name: str, app_description: str | None = Non
     return func()
 
 
+def generate_page_app_files(app_name: str) -> List[Dict[str, str]]:
+    """Frontend-only files for a prebuilt page app ('about', 'contact')."""
+    func = PAGE_APP_MAP.get((app_name or '').lower())
+    if not func:
+        return []
+    return func()
+
+
 __all__ = [
     'home_app_files',
     'auth_app_files',
+    'about_app_files',
+    'contact_app_files',
     'PREBUILT_MAP',
+    'PAGE_APP_MAP',
     'generate_prebuilt_app_files',
+    'generate_page_app_files',
 ]

--- a/backend/django/apps/Imagi/Build/services/codegen/prebuilt_apps/pages.py
+++ b/backend/django/apps/Imagi/Build/services/codegen/prebuilt_apps/pages.py
@@ -1,0 +1,93 @@
+"""
+Prebuilt marketing page apps: about, contact.
+
+These exist so the initial build can run several subagents at once. Each
+subagent is given ONE file to rewrite, which is the property the whole
+time-budgeted first build rests on: a single self-contained file can never
+reference something the agent did not get around to writing, so a run cut off
+by the clock still merges. If a subagent had to create its page *and* the
+router entry pointing at it, a run stopped between the two would leave a
+dangling import and the build would be discarded.
+
+Scaffolding the app up front moves that risk out of the agent's way entirely —
+the route exists and resolves from the moment the project is created, and the
+agent's whole job is to replace the placeholder view with a real page.
+
+Unlike 'home' and 'auth' these are frontend-only: they are static marketing
+pages with nothing to serve, so they get no Django app, no INSTALLED_APPS
+entry, and no migrations. The route path, name and title all come from
+_frontend_scaffold's defaults ('/about', '/contact'), so only the placeholder
+view differs from a generic app.
+"""
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .shared import _frontend_scaffold
+
+
+def _placeholder_view(heading: str, blurb: str) -> str:
+    """A self-contained placeholder page, styled like the home scaffold.
+
+    Imports nothing: this is what the project serves if the first build never
+    runs (no API key configured) or if this page's subagent is discarded, so
+    it has to stand on its own.
+    """
+    return f"""<template>
+  <div class="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 flex flex-col">
+    <header class="w-full">
+      <nav class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-5 flex items-center justify-between">
+        <router-link to="/" class="text-xl font-bold text-gray-900">Home</router-link>
+        <div class="flex items-center gap-4">
+          <router-link to="/about" class="text-sm font-medium text-gray-700 hover:text-gray-900">
+            About
+          </router-link>
+          <router-link to="/contact" class="text-sm font-medium text-gray-700 hover:text-gray-900">
+            Contact
+          </router-link>
+        </div>
+      </nav>
+    </header>
+
+    <main class="flex-grow flex items-center">
+      <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16 text-center">
+        <h1 class="text-5xl font-bold text-gray-900 mb-6">{heading}</h1>
+        <p class="text-xl text-gray-600 max-w-3xl mx-auto">{blurb}</p>
+      </div>
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+</script>
+"""
+
+
+ABOUT_VIEW_VUE = _placeholder_view(
+    'About', 'The story behind this business.'
+)
+
+CONTACT_VIEW_VUE = _placeholder_view(
+    'Contact', 'Get in touch with this business.'
+)
+
+
+def _page_app_files(app_name: str, cap: str, welcome: str, view_content: str) -> List[Dict[str, str]]:
+    """Frontend-only scaffold for a static page app."""
+    files = _frontend_scaffold(app_name, cap, welcome)
+    for f in files:
+        if f['name'] == f'frontend/vuejs/src/apps/{app_name}/views/{cap}View.vue':
+            f['content'] = view_content
+    return files
+
+
+def about_app_files() -> List[Dict[str, str]]:
+    return _page_app_files(
+        'about', 'About', 'The story behind this business.', ABOUT_VIEW_VUE
+    )
+
+
+def contact_app_files() -> List[Dict[str, str]]:
+    return _page_app_files(
+        'contact', 'Contact', 'Get in touch with this business.', CONTACT_VIEW_VUE
+    )

--- a/backend/django/apps/Imagi/Build/services/coding_agent.py
+++ b/backend/django/apps/Imagi/Build/services/coding_agent.py
@@ -141,47 +141,56 @@ INITIAL_BUILD_WORKING_STYLE = """Working style:
 # Intro for the initial build — the one-shot, headless first build of a new
 # project. It runs like the chat builder (full editing tools, direct edits to
 # the real project) but with a first-build framing and design direction.
-INITIAL_BUILD_INTRO = """You are Imagi, performing the very first build of a brand-new web application for the founder who just described their business. Right now the project holds only Imagi's default scaffold: a home app and a prebuilt auth app. Your job is one page: turn the placeholder landing page into a real home page for THIS business, with the prebuilt sign-in and register pages wired into it. The founder sees your result the moment they open their workspace, so it should feel custom-built for them — not a generic starter."""
+INITIAL_BUILD_INTRO = """You are Imagi, performing the very first build of a brand-new web application for the founder who just described their business. Right now the project holds only Imagi's default scaffold: placeholder home, about and contact pages, plus a prebuilt auth app.
 
-# What the initial build should (and shouldn't) do. The scope is one file, and
-# that is a consequence of the clock: at half a minute there is time for a
-# single good write, and a run stopped mid-way through a multi-file page can
-# leave an import pointing at a component it never got to — which fails the
-# integrity check and throws the whole build away. One self-contained file
+You are one of several subagents building that first version at the same time, one page each. Your brief names the single page you own. Your siblings are writing the others right now — you cannot see their work and they cannot see yours, so the one rule that makes this work is that you touch ONLY your own page's file. The founder sees the result the moment they open their workspace, so it should feel custom-built for them — not a generic starter."""
+
+# What the initial build should (and shouldn't) do. The scope is one file per
+# subagent, and that is a consequence of the clock: at half a minute there is
+# time for a single good write, and a run stopped mid-way through a multi-file
+# page can leave an import pointing at a component it never got to — which
+# fails the integrity check and throws that page away. One self-contained file
 # cannot fail that way, so the budget buys a page instead of a gamble.
+#
+# It is also what makes the pages safe to build in parallel: each subagent
+# writes into a git worktree of its own and the three are merged back one after
+# another, so two agents writing the same file would collide. Disjoint files
+# mean the merges never conflict.
 INITIAL_BUILD_GUIDANCE = (
     f"""Building the first version — you have about {INITIAL_BUILD_TIME_BUDGET_S} seconds of wall-clock time:
 - The founder is watching and waiting, and when the time runs out you are stopped wherever you are.
 - Do NOT explore the project first. You already know the layout (below) and the scaffold is exactly as described — no get_project_tree, no glob_files, no grep_files, and no read_file on the file you are about to replace wholesale. Go straight to writing.
 
-Your job is ONE file: rewrite 'frontend/vuejs/src/apps/home/views/HomeView.vue', with a single update_file call, as a real landing page for THIS business.
+Your job is ONE file: the view file named in your brief, rewritten with a single update_file call as a real page for THIS business.
 """
-    + """- Everything lives in that one file — template, script setup, Tailwind classes. Do NOT create component files, do NOT add other pages, do NOT add routes, do NOT touch any other file. This is not a stylistic preference; it is what makes your work survive the clock. A single complete file can never reference something you did not get around to writing, and a build with even one dangling reference is DISCARDED — the founder gets the plain scaffold instead of your work.
-- One file has room for a real landing page, so build a whole one: a header carrying the business's name, a hero that says plainly what this business does and for whom, three or four well-differentiated sections (what it offers, how it works, proof or testimonials, FAQ — whatever this business actually needs), a closing call to action, and a footer.
-- If you finish with time left, keep improving THAT page — sharper copy, another section, better responsive and dark-mode detail. Do not start anything new.
+    + """- Everything lives in that one file — template, script setup, Tailwind classes. Do NOT create component files, do NOT add other pages, do NOT add routes, do NOT touch any other file. This is not a stylistic preference; it is what makes your work survive the clock. A single complete file can never reference something you did not get around to writing, and a page with even one dangling reference is DISCARDED — the founder gets the plain scaffold for it instead of your work.
+- It is also what keeps you out of your siblings' way. Another subagent owns each of the other pages and is writing it right now. If you edit a file that is not yours, the two versions collide when the work is merged and somebody's page is lost. Your page's file is the only file you touch.
+- One file has room for a real page, so build a whole one — see your brief for what this particular page needs.
+- If you finish with time left, keep improving THAT page — sharper copy, another section, better responsive and dark-mode detail. Do not start anything new, and do not go and help with another page.
 
-Wire in the authentication pages, which are prebuilt and already working at '/auth/signin' and '/auth/register':
-- Keep the scaffold's script setup as it stands: `import { useAuthStore } from '../../auth/stores/index'` and `const authStore = useAuthStore()`. That is the only import your page needs.
-- In the header, show the signed-in user when `authStore.isAuthenticated` (their username and a sign-out button calling `authStore.logout($router)`), and when signed out show a 'Sign in' link to '/auth/signin' plus a prominent create-account link to '/auth/register'.
-- Make the hero's primary call to action a <router-link> to '/auth/register', worded for this business ("Start your free trial", "Book a table", "Get a quote") rather than a generic "Create account".
-- Style all of it to fit your design, but keep those two paths exact. Do NOT open, restyle, or modify anything under 'frontend/vuejs/src/apps/auth/' — those pages and their backend are prebuilt and secure.
+Every page shares one header and footer, which you write inline in your own file (there is no shared component to import, and creating one would collide with your siblings). Link the three pages to each other so the site navigates: '/' (home), '/about', and '/contact'. Keep those paths exact. Style the header and footer to fit your design — they do not have to match your siblings' exactly, and a small variation is far better than a dangling import.
 
 Hard rules:
-- DO NOT change the project's structure or its plumbing. Leave every one of these exactly as you found it: 'frontend/vuejs/src/router' (the root router), 'frontend/vuejs/src/main.ts', 'frontend/vuejs/src/App.vue', 'frontend/vuejs/src/shared/', the whole 'frontend/vuejs/src/apps/auth/' app, 'vite.config.ts', 'package.json', 'tsconfig*.json', 'tailwind.config.js', 'postcss.config.js', 'index.html', and everything under 'backend/django/'. Do not add dependencies, change the build setup, or reorganize directories. A first build that rewires the project is discarded even if it looks good.
+- DO NOT change the project's structure or its plumbing. Leave every one of these exactly as you found it: 'frontend/vuejs/src/router' (the root router), 'frontend/vuejs/src/main.ts', 'frontend/vuejs/src/App.vue', 'frontend/vuejs/src/shared/', the whole 'frontend/vuejs/src/apps/auth/' app, every router/index.ts, 'vite.config.ts', 'package.json', 'tsconfig*.json', 'tailwind.config.js', 'postcss.config.js', 'index.html', and everything under 'backend/django/'. Do not add dependencies, change the build setup, or reorganize directories. A first build that rewires the project is discarded even if it looks good.
 - NEVER reference an image or media file. There are NO image assets in this project and no 'public/' directory, so every '<img src="/images/...">', background-image url(), or imported .jpg/.png/.svg file is a dangling reference: it renders as a broken image and breaks the production build. You cannot create binary images either. Build visuals out of what you can actually write: CSS gradients, colored and rounded div blocks, inline <svg> you author yourself, borders, shadows, and type. A confident gradient-and-type hero looks far better than a broken image icon.
-- Write real copy for this business throughout — never lorem ipsum, never leftover scaffold text like "Welcome to your new project".
+- Write real copy for this business throughout — never lorem ipsum, never leftover scaffold text like "Welcome to your new project". Invent the specifics a real page needs (team names, addresses, hours, prices) only where the page would look unfinished without them, and keep them plausible for this business.
 - Do NOT build payment, checkout, cart, or subscription-billing functionality even if the business sells something — the founder installs secure, prebuilt payment pages later from their Sell workspace. Give the page a clear call to action instead of wiring real payments.
-- Do NOT add backend endpoints, stores, or API wiring. The first build is this one page.
-- When you finish, briefly summarize what you built. The founder reads it as the first message in their workspace.
+- Do NOT add backend endpoints, stores, or API wiring. Your whole build is this one page.
+- When you finish, briefly summarize what you built. The founder reads it in their workspace.
 
 The scaffold you are starting from (already on disk — trust this instead of looking):
-- 'frontend/vuejs/src/apps/home/views/HomeView.vue' — a generic placeholder landing page, routed at '/', already carrying the auth header and calls to action described above. This is the file you rewrite, and the only one you touch.
+- 'frontend/vuejs/src/apps/home/views/HomeView.vue' — placeholder landing page, routed at '/'.
+- 'frontend/vuejs/src/apps/about/views/AboutView.vue' — placeholder about page, routed at '/about'.
+- 'frontend/vuejs/src/apps/contact/views/ContactView.vue' — placeholder contact page, routed at '/contact'.
+  Exactly one of those three is yours; your brief says which. The other two belong to your siblings.
 - 'frontend/vuejs/src/apps/auth/' — the prebuilt auth app serving '/auth/signin' and '/auth/register'. Leave it alone.
-- 'frontend/vuejs/src/apps/home/router/index.ts' already maps '/' to HomeView, so your page is live the moment you write it and you never touch a router.
+- Each page's 'router/index.ts' already maps its route to its view, so your page is live the moment you write it and you never touch a router.
 - Tailwind, Vue Router, and Pinia are installed and wired up."""
 )
 
-# Full prompt for the initial build role.
+# Full prompt for the initial build role. Shared by every page subagent: which
+# page a given one owns, and what that page needs, arrives in its brief (see
+# initial_build_service.PAGE_BRIEFS).
 INITIAL_BUILD_INSTRUCTIONS = "\n\n".join(
     (INITIAL_BUILD_INTRO, INITIAL_BUILD_WORKING_STYLE, SHARED_PROJECT_GUIDANCE,
      DESIGN_DIRECTION, INITIAL_BUILD_GUIDANCE)

--- a/backend/django/apps/Imagi/Build/services/create_app_service.py
+++ b/backend/django/apps/Imagi/Build/services/create_app_service.py
@@ -14,13 +14,23 @@ from django.conf import settings
 from rest_framework.exceptions import ValidationError, NotFound
 from apps.Imagi.ProjectManager.models import Project
 from .create_file_service import CreateFileService
-from .codegen.prebuilt_apps import generate_prebuilt_app_files
+from .codegen.prebuilt_apps import (
+    PAGE_APP_MAP,
+    generate_page_app_files,
+    generate_prebuilt_app_files,
+)
 
 logger = logging.getLogger(__name__)
 
 # Apps scaffolded into every new project (see IMAGI_BUILDER in imagi/settings.py)
 DEFAULT_APPS = list(
     getattr(settings, 'IMAGI_BUILDER', {}).get('DEFAULT_APPS', ['home', 'auth'])
+)
+
+# Frontend-only page apps scaffolded alongside them. Separate from DEFAULT_APPS
+# because these have no Django side to create or register.
+PAGE_APPS = list(
+    getattr(settings, 'IMAGI_BUILDER', {}).get('PAGE_APPS', list(PAGE_APP_MAP))
 )
 
 class CreateAppService:
@@ -226,6 +236,68 @@ class CreateAppService:
                 'message': f'Failed to ensure default apps: {str(e)}'
             }
     
+    def ensure_page_apps(self, project_id: str = None) -> Dict[str, Any]:
+        """Ensure the frontend-only page apps ('about', 'contact') exist.
+
+        The initial build dispatches one subagent per page and gives each a
+        single file to rewrite, so the routes have to be on disk and resolving
+        before those subagents start. Frontend-only by design: these pages
+        serve no data, so there is no Django app to create or register.
+
+        Idempotent — an app whose frontend directory already exists is skipped,
+        so this is safe on the scaffold-repair path too.
+        """
+        try:
+            if project_id and not self.project:
+                project = self.get_project(project_id)
+                self.file_service = CreateFileService(project=project)
+            elif not self.project and not project_id:
+                raise ValidationError("No project specified")
+
+            project_path = self.file_service.get_project_path(project_id)
+            frontend_apps_dir = os.path.join(
+                project_path or '', 'frontend', 'vuejs', 'src', 'apps'
+            )
+
+            created_apps = []
+            total_files_created = 0
+            for app_name in PAGE_APPS:
+                if os.path.isdir(os.path.join(frontend_apps_dir, app_name)):
+                    continue
+                files_to_create = generate_page_app_files(app_name)
+                if not files_to_create:
+                    logger.warning(f"No prebuilt files for page app {app_name}")
+                    continue
+                created = 0
+                for file_data in files_to_create:
+                    try:
+                        self.file_service.create_file(file_data, project_id)
+                        created += 1
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to create page file {file_data.get('name')}: {e}"
+                        )
+                if created:
+                    created_apps.append(app_name)
+                    total_files_created += created
+
+            return {
+                'success': True,
+                'message': (
+                    f'Successfully ensured page apps. Created {len(created_apps)} '
+                    f'apps with {total_files_created} files.'
+                ),
+                'created_apps': created_apps,
+                'total_files_created': total_files_created,
+            }
+        except Exception as e:
+            logger.error(f"Error ensuring page apps: {str(e)}")
+            return {
+                'success': False,
+                'error': str(e),
+                'message': f'Failed to ensure page apps: {str(e)}',
+            }
+
     def _generate_app_files(self, app_name: str, cap_name: str, app_welcome: str) -> List[Dict[str, str]]:
         """
         Generate the file structure for a new app.

--- a/backend/django/apps/Imagi/Build/services/version_control_service.py
+++ b/backend/django/apps/Imagi/Build/services/version_control_service.py
@@ -69,20 +69,27 @@ def task_base_ref(conversation_id: int) -> str:
 def canonical_repo_lock(project_path):
     """Serialize canonical-repo git mutations for one project.
 
-    An exclusive flock on the project's .git directory: two near-simultaneous
-    task dispatches (or a dispatch racing a merge) would otherwise collide on
-    .git/index.lock and fail nondeterministically. When the repo does not
-    exist yet there is nothing to contend on, so the lock is skipped.
+    An exclusive flock on the project's own directory: two near-simultaneous
+    task dispatches (the initial build fires one per page, and the best-of-N
+    form fires several without awaiting), or a dispatch racing a merge, would
+    otherwise collide on .git/index.lock and fail nondeterministically.
+
+    Deliberately locks the project directory rather than '.git': the moment
+    with the *most* contention is the one before any repo exists, when several
+    dispatches for a brand-new project all reach `git init` at once. A lock
+    keyed on '.git' cannot cover that — it is not there yet to be locked —
+    which showed up as "Failed to initialize git repository" on all but one of
+    a first build's pages. The project directory always exists, so this covers
+    repo creation too.
     """
-    git_dir = os.path.join(project_path, '.git')
     fd = None
     try:
-        if os.path.isdir(git_dir):
+        if os.path.isdir(project_path):
             try:
-                fd = os.open(git_dir, os.O_RDONLY)
+                fd = os.open(project_path, os.O_RDONLY)
                 fcntl.flock(fd, fcntl.LOCK_EX)
             except OSError as e:  # pragma: no cover - defensive
-                logger.warning(f"Could not lock repo at {git_dir}: {e}")
+                logger.warning(f"Could not lock repo at {project_path}: {e}")
                 if fd is not None:
                     os.close(fd)
                     fd = None

--- a/backend/django/apps/Imagi/Build/tests/test_agents.py
+++ b/backend/django/apps/Imagi/Build/tests/test_agents.py
@@ -1001,13 +1001,12 @@ class InitialBuildAgentTests(SimpleTestCase):
             INITIAL_BUILD_INSTRUCTIONS,
         )
 
-    def test_prompt_scopes_the_build_to_the_home_page_alone(self):
+    def test_prompt_scopes_each_subagent_to_a_single_file(self):
         # Half a minute buys one good write. Anything split across files can be
-        # cut off mid-way holding a dangling import, which discards the build.
-        self.assertIn(
-            'frontend/vuejs/src/apps/home/views/HomeView.vue',
-            INITIAL_BUILD_INSTRUCTIONS,
-        )
+        # cut off mid-way holding a dangling import, which discards the page —
+        # and with several subagents running at once, a stray edit outside your
+        # own file also collides with a sibling's work at merge time.
+        self.assertIn('Your job is ONE file', INITIAL_BUILD_INSTRUCTIONS)
         for rule in (
             'Do NOT create component files',
             'do NOT add other pages',
@@ -1015,17 +1014,45 @@ class InitialBuildAgentTests(SimpleTestCase):
         ):
             self.assertIn(rule, INITIAL_BUILD_INSTRUCTIONS)
 
-    def test_prompt_wires_in_the_prebuilt_auth_pages(self):
-        # The auth app is prebuilt and left untouched; the first build's job is
-        # to bring its two pages into the home page it writes.
+    def test_every_first_build_page_is_described_in_the_shared_prompt(self):
+        # Each subagent needs to know the other pages exist and where they
+        # live, so it can link them in its own header and footer without
+        # touching a file it does not own.
+        from apps.Imagi.ProjectManager.services.initial_build_service import (
+            PAGE_BRIEFS,
+        )
+
+        for page in PAGE_BRIEFS:
+            self.assertIn(page.view_path, INITIAL_BUILD_INSTRUCTIONS)
+
+    def test_the_home_brief_wires_in_the_prebuilt_auth_pages(self):
+        # The auth app is prebuilt and left untouched; bringing its two pages
+        # into the site is the home page's job specifically, so it lives in
+        # that page's brief rather than in the prompt every page shares.
+        from apps.Imagi.ProjectManager.services.initial_build_service import (
+            PAGE_BRIEFS,
+        )
+
+        home = PAGE_BRIEFS[0]
+        self.assertEqual(home.slug, 'home')
         for path in ("'/auth/signin'", "'/auth/register'"):
-            self.assertIn(path, INITIAL_BUILD_INSTRUCTIONS)
-        self.assertIn('useAuthStore', INITIAL_BUILD_INSTRUCTIONS)
+            self.assertIn(path, home.requirements)
+        self.assertIn('useAuthStore', home.requirements)
         self.assertIn(
             "Do NOT open, restyle, or modify anything under "
             "'frontend/vuejs/src/apps/auth/'",
-            INITIAL_BUILD_INSTRUCTIONS,
+            home.requirements,
         )
+
+    def test_the_other_pages_are_told_to_leave_auth_to_home(self):
+        # Two pages both writing an auth header is duplicated work at best; at
+        # worst the about page invents its own sign-in flow.
+        from apps.Imagi.ProjectManager.services.initial_build_service import (
+            PAGE_BRIEFS,
+        )
+
+        for page in PAGE_BRIEFS[1:]:
+            self.assertIn('Do not import the auth store', page.requirements)
 
     def test_initial_build_runs_at_its_configured_effort(self):
         # Set explicitly for the role, so a per-request effort meant for the

--- a/backend/django/apps/Imagi/ProjectManager/services/initial_build_service.py
+++ b/backend/django/apps/Imagi/ProjectManager/services/initial_build_service.py
@@ -9,48 +9,59 @@ tailored starting point instead of the generic scaffold.
 
 It runs the same way every other piece of building work does: the project's
 main thread (the 'lead' conversation) opens with the founder's brief and
-dispatches it to a background subagent (a 'task' conversation). That gives
-the first build the machinery every task already has — it builds in its own
+dispatches it to background subagents ('task' conversations). That gives
+the first build the machinery every task already has — each builds in its own
 git worktree, so the project the preview serves is never half-written, and
-its result is merged in one step when it is finished and sound.
+each result is merged in one step when it is finished and sound.
 
 The build is bounded by wall-clock time, not by how much it manages to build:
-the founder is waiting on it, so the whole thing — first run plus any repair
-run — shares one deadline (IMAGI_BUILDER['INITIAL_BUILD_TIME_BUDGET_S'], sized
+the founder is waiting on it, so the whole thing — first runs plus any repair
+runs — shares one deadline (IMAGI_BUILDER['INITIAL_BUILD_TIME_BUDGET_S'], sized
 so the founder waits about half a minute) and ships whatever is finished and
 sound when that runs out. This degrades safely because the project already
-holds a working home + auth scaffold the moment it is created: a build that
-runs short means less tailoring, never a broken app.
+holds a working scaffold the moment it is created: a build that runs short
+means less tailoring, never a broken app.
 
-That deadline is what sets the scope. Half a minute buys one good write, so the
-subagent is pointed at exactly one thing (coding_agent.INITIAL_BUILD_GUIDANCE):
-rewrite the home page as a single self-contained component, with the prebuilt
-auth app's sign-in and register pages wired into its header and calls to
-action. Everything else a web app needs — the Vue and Django scaffolding, the
-auth app itself — is already on disk before this runs.
+That deadline is why the pages are built in PARALLEL rather than one after
+another. Half a minute is one good write, so a sequential build could only ever
+produce a single page. Dispatching one subagent per page instead spends the same
+half minute on all of them at once: wall-clock cost is the slowest page, not the
+sum. What it does cost is money — three pages is three concurrent agent runs, so
+roughly three times the tokens of a single-page build.
+
+Each subagent owns exactly one file (PAGE_BRIEFS below), which is what makes
+the parallelism safe on both ends. A self-contained file cannot reference a
+component its author never got around to writing, so a run stopped by the clock
+still merges; and because no two agents write the same path, the three worktree
+merges never conflict. Everything else a web app needs — the Vue and Django
+scaffolding, the auth app, and each page's route — is already on disk before
+this runs, so no agent has to create the file that would make its own page
+reachable.
 
 "Sound" is enforced, not hoped for: a build cut short by a cap can leave a page
 importing a component it never wrote, and Vite serves that as a "Failed to
-resolve import" error instead of the app. Before the worktree is merged, the
-frontend's import graph is checked; a build with dangling references gets a
+resolve import" error instead of the app. Before a worktree is merged, the
+frontend's import graph is checked; a page with dangling references gets a
 follow-up repair run from whatever time is left, and one that still doesn't
-resolve is never merged — the project keeps its clean, working scaffold. The
-one-file scope is the first line of that defense: a page that imports nothing
-it wrote itself cannot dangle in the first place.
+resolve is never merged — that page keeps its clean, working scaffold while its
+siblings ship.
 
-A third check asks whether the page the build wrote still links to the sign-in
-and register pages, since a wholesale rewrite can quietly drop them and leave
-auth nothing points at. That one earns a repair run but never costs the build:
-a page that loads and is hard to sign into still beats the scaffold, so an
-unrepaired one is merged anyway.
+A third check asks whether the home page still links to the sign-in and
+register pages, since a wholesale rewrite can quietly drop them and leave auth
+nothing points at. That one earns a repair run but never costs the build: a page
+that loads and is hard to sign into still beats the scaffold, so an unrepaired
+one is merged anyway.
 
 Build progress is tracked on the existing Project.generation_status field
-('generating' -> 'completed'/'failed').
+('generating' -> 'completed'/'failed'). Because each page stands alone, this is
+not all-or-nothing: the build counts as completed when at least one page landed,
+and every page that did not simply keeps its placeholder.
 """
 
 import logging
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 from django.conf import settings
 from django.db import close_old_connections
@@ -58,28 +69,118 @@ from django.utils import timezone
 
 logger = logging.getLogger(__name__)
 
-# Shown in the workspace as the subagent's thread name.
+# Shown in the workspace as the subagents' thread names.
 TASK_TITLE = 'Initial build'
 
-# The lead thread's one-line acknowledgement, mirroring how it reports any
-# dispatch it makes. Written directly rather than generated: the lead's only
-# job here is to hand the brief over, and a model call to produce one fixed
-# sentence would just add latency and cost to project creation.
-LEAD_ACK = (
-    "On it — I've kicked off a subagent to build the first version of your app. "
-    "You can watch it work in its thread; I'll let you know when it's done."
+
+class PageBrief:
+    """One page of the first build: who writes what, and what it should be.
+
+    ``requirements`` is the page-specific half of the brief; the shared half
+    (the clock, the one-file rule, the design direction, the hard rules) lives
+    in coding_agent.INITIAL_BUILD_INSTRUCTIONS, which every page subagent runs
+    on.
+    """
+
+    def __init__(self, slug, title, view_path, route, summary, requirements):
+        self.slug = slug
+        self.title = title
+        self.view_path = view_path
+        self.route = route
+        self.summary = summary
+        self.requirements = requirements
+
+    @property
+    def task_title(self):
+        return f'{TASK_TITLE} — {self.slug} page'
+
+
+# The three pages of a first build, each dispatched to its own subagent. Their
+# routes and placeholder views are scaffolded at project creation
+# (Build.services.codegen.prebuilt_apps), so every one of these files already
+# exists and is already routed before any agent starts.
+PAGE_BRIEFS = (
+    PageBrief(
+        slug='home',
+        title='Home page',
+        view_path='frontend/vuejs/src/apps/home/views/HomeView.vue',
+        route='/',
+        summary='the landing page — the first thing anyone sees',
+        requirements="""Build a whole landing page: a header carrying the business's name, a hero that says plainly what this business does and for whom, three or four well-differentiated sections (what it offers, how it works, proof or testimonials, FAQ — whatever this business actually needs), a closing call to action, and a footer.
+
+This page also carries the authentication wiring, which the other pages do not. The sign-in and register pages are prebuilt and already working at '/auth/signin' and '/auth/register':
+- Keep the scaffold's script setup as it stands: `import { useAuthStore } from '../../auth/stores/index'` and `const authStore = useAuthStore()`. That is the only import your page needs.
+- In the header, show the signed-in user when `authStore.isAuthenticated` (their username and a sign-out button calling `authStore.logout($router)`), and when signed out show a 'Sign in' link to '/auth/signin' plus a prominent create-account link to '/auth/register'.
+- Make the hero's primary call to action a <router-link> to '/auth/register', worded for this business ("Start your free trial", "Book a table", "Get a quote") rather than a generic "Create account".
+- Keep those two paths exact. Do NOT open, restyle, or modify anything under 'frontend/vuejs/src/apps/auth/' — those pages and their backend are prebuilt and secure.""",
+    ),
+    PageBrief(
+        slug='about',
+        title='About page',
+        view_path='frontend/vuejs/src/apps/about/views/AboutView.vue',
+        route='/about',
+        summary='the about page — who is behind this business and why it exists',
+        requirements="""Build a whole about page: a header, an opening that states what the business stands for, then the sections an about page earns its place with — the story of why it exists, what it believes or how it works, the people or the craft behind it, and a few concrete numbers or milestones if they fit the business. Close with a call to action pointing at the contact page ('/contact') and a footer.
+
+Write it as this specific business would: concrete and grounded, not "we are passionate about excellence". Do NOT add the auth header or the sign-in/register calls to action — the home page owns those. Do not import the auth store.""",
+    ),
+    PageBrief(
+        slug='contact',
+        title='Contact page',
+        view_path='frontend/vuejs/src/apps/contact/views/ContactView.vue',
+        route='/contact',
+        summary='the contact page — how a customer reaches this business',
+        requirements="""Build a whole contact page: a header, a short line on what to get in touch about, a contact form (name, email, message, and any field this business actually needs — laid out and styled properly), and the other ways to reach the business alongside it (email address, phone, location or hours) as fits.
+
+The form must be presentational only: bind it to local `ref`s and, on submit, show an inline "thanks, we'll be in touch" confirmation in the page. Do NOT post it anywhere — there is no backend endpoint for it and you must not add one. Keep all of it, `ref` imports included, inside your one file.
+
+Do NOT add the auth header or the sign-in/register calls to action — the home page owns those. Do not import the auth store.""",
+    ),
 )
 
 
-def build_initial_prompt(name: str, description: str, design_preferences: str = "") -> str:
-    """Compose the first build prompt from the founder's inputs.
+def _lead_ack(pages) -> str:
+    """The lead thread's acknowledgement of the dispatch it just made.
+
+    Written directly rather than generated: the lead's only job here is to hand
+    the briefs over, and a model call to produce one fixed sentence would add
+    latency and cost to project creation.
+    """
+    names = ', '.join(p.slug for p in pages)
+    if len(pages) == 1:
+        return (
+            "On it — I've kicked off a subagent to build the first version of "
+            "your app. You can watch it work in its thread; I'll let you know "
+            "when it's done."
+        )
+    return (
+        f"On it — I've kicked off {len(pages)} subagents to build the first "
+        f"version of your app, one per page ({names}), all working at the same "
+        "time. You can watch them in their threads; I'll let you know when "
+        "they're done."
+    )
+
+
+def build_initial_prompt(
+    name: str,
+    description: str,
+    design_preferences: str = "",
+    page: PageBrief = None,
+) -> str:
+    """Compose one page subagent's brief from the founder's inputs.
 
     Kept intentionally short: the framing, the freedom to build whatever the
     business needs, the design direction, and the guardrails (keep auth, no
     payments) all live in the initial-build system prompt
-    (coding_agent.INITIAL_BUILD_INSTRUCTIONS). This message just hands over the
-    business the agent is building.
+    (coding_agent.INITIAL_BUILD_INSTRUCTIONS), which every page shares. This
+    message hands over the business being built and the one page this subagent
+    owns.
+
+    ``page`` defaults to the home page, which is also what the founder sees as
+    the opening message of their main thread.
     """
+    page = page or PAGE_BRIEFS[0]
+
     prompt = f"""This is the first build of a brand-new project — build the first version of this business's web app.
 
 Business name: {name}
@@ -91,12 +192,14 @@ Business description (written by the founder):
     if design:
         prompt += f"\n\nDesign & style preferences (from the founder):\n{design}"
 
-    prompt += (
-        "\n\nBuild a tailored, polished home page that fits this business, "
-        "following your design direction, and wire the prebuilt sign-in and "
-        "register pages into it. When you're done, briefly summarize what you "
-        "built."
-    )
+    prompt += f"""
+
+Your page: {page.summary}.
+Rewrite '{page.view_path}' (routed at '{page.route}'), and no other file. Your siblings are building the other pages at the same time.
+
+{page.requirements}
+
+When you're done, briefly summarize what you built."""
     return prompt
 
 
@@ -218,12 +321,13 @@ def _ensure_lead_conversation(service, user, project_id, model):
     )
 
 
-def _open_lead_thread(service, lead, prompt, task):
+def _open_lead_thread(service, lead, prompt, tasks):
     """Record the dispatch in the main thread, the way a real one reads.
 
     The founder's brief becomes the opening user message and the lead's
-    acknowledgement carries a reference to the subagent's thread, so the
-    transcript and its "watch the subagent" link match every later dispatch.
+    acknowledgement carries a reference to every subagent thread it started, so
+    the transcript and its "watch the subagent" links match every later
+    dispatch.
     """
     from apps.Imagi.Build.services.base_agent import (
         build_message_metadata,
@@ -233,21 +337,22 @@ def _open_lead_thread(service, lead, prompt, task):
     service.add_user_message(lead, prompt)
     service.add_assistant_message(
         lead,
-        LEAD_ACK,
+        _lead_ack([t.page for t in tasks]),
         build_message_metadata(
             dispatched_tasks=dispatch_task_refs(
-                [{'conversation_id': task.id, 'title': task.title}]
+                [{'conversation_id': t.id, 'title': t.title} for t in tasks]
             )
         ),
     )
 
 
-def _create_build_task(user, lead, project_id, model, prompt):
-    """Create the subagent conversation the first build runs in.
+def _create_build_task(user, lead, project_id, model, prompt, page):
+    """Create the subagent conversation one page of the first build runs in.
 
     An ordinary kind='task' child of the lead: it gets a git worktree of its
     own, auto-applies when it finishes cleanly, and reports back through the
-    lead's check-in queue — all of it existing machinery.
+    lead's check-in queue — all of it existing machinery. Siblings differ only
+    in their title and the page brief they were queued with.
     """
     from apps.Imagi.Build.models import AgentConversation, SystemPrompt
     from apps.Imagi.Build.services.coding_agent import INITIAL_BUILD_INSTRUCTIONS
@@ -257,7 +362,7 @@ def _create_build_task(user, lead, project_id, model, prompt):
         model_name=model,
         project_id=project_id,
         mode='agent',
-        title=TASK_TITLE,
+        title=page.task_title,
         kind='task',
         parent=lead,
         review_status='active',
@@ -266,11 +371,50 @@ def _create_build_task(user, lead, project_id, model, prompt):
     SystemPrompt.objects.create(
         conversation=task, content=INITIAL_BUILD_INSTRUCTIONS
     )
+    # Carried in memory only, so the runner knows which page this task owns
+    # without re-deriving it from the title.
+    task.page = page
     return task
 
 
+def _run_one_page(page, task, user_id, project_id, prompt, builder, deadline_at) -> bool:
+    """Worker body: build one page and land it, on its own thread.
+
+    Gets its own agent service and its own database connection — neither is
+    safe to share across threads — and returns whether this page's work reached
+    the project. Never raises: one page failing must not take its siblings
+    down with it.
+    """
+    close_old_connections()
+    try:
+        from django.contrib.auth import get_user_model
+        from apps.Imagi.Build.services.base_agent import ImagiAgentService
+
+        user = get_user_model().objects.get(pk=user_id)
+        model = builder.get('INITIAL_BUILD_MODEL') or builder.get('DEFAULT_MODEL')
+        service = ImagiAgentService(model=model, agent_kind='initial_build')
+        return _build_and_apply(
+            service, task, user, project_id, prompt, builder, deadline_at
+        )
+    except Exception:
+        logger.exception(
+            "Initial AI build of the %s page crashed for project %s",
+            page.slug,
+            project_id,
+        )
+        return False
+    finally:
+        close_old_connections()
+
+
 def _run_initial_build(project_id: int, user_id: int) -> None:
-    """Thread body: dispatch the first build to a subagent and land its work."""
+    """Thread body: dispatch every page of the first build, then land the results.
+
+    The pages run concurrently against ONE shared deadline, so the founder waits
+    for the slowest page rather than the sum of all of them. Each page merges
+    itself as it finishes (the merge takes an exclusive lock on the project's
+    git repo, so simultaneous finishes serialize safely).
+    """
     close_old_connections()
     from ..models import Project
 
@@ -288,30 +432,74 @@ def _run_initial_build(project_id: int, user_id: int) -> None:
         # direction) onto what is otherwise a plain background task.
         service = ImagiAgentService(model=model, agent_kind='initial_build')
 
-        prompt = build_initial_prompt(
-            project.name,
-            project.description,
-            getattr(project, 'design_preferences', ''),
-        )
+        pages = _pages_to_build(builder)
+        prompts = {
+            page.slug: build_initial_prompt(
+                project.name,
+                project.description,
+                getattr(project, 'design_preferences', ''),
+                page,
+            )
+            for page in pages
+        }
 
         lead = _ensure_lead_conversation(service, user, project_id, model)
-        task = _create_build_task(user, lead, project_id, model, prompt)
-        _open_lead_thread(service, lead, prompt, task)
+        tasks = [
+            _create_build_task(
+                user, lead, project_id, model, prompts[page.slug], page
+            )
+            for page in pages
+        ]
+        # The home page's brief opens the main thread: it is the page the
+        # founder is really waiting on, and the whole business description is
+        # in it.
+        _open_lead_thread(service, lead, prompts[pages[0].slug], tasks)
 
-        applied = _build_and_apply(service, task, user, project_id, prompt, builder)
+        # One deadline for everything, started before the first agent does.
+        time_budget = builder.get('INITIAL_BUILD_TIME_BUDGET_S', 60)
+        deadline_at = time.monotonic() + time_budget if time_budget else None
 
-        if applied:
+        with ThreadPoolExecutor(
+            max_workers=len(tasks), thread_name_prefix=f'initial-build-{project_id}'
+        ) as pool:
+            futures = {
+                task.page.slug: pool.submit(
+                    _run_one_page,
+                    task.page,
+                    task,
+                    user_id,
+                    project_id,
+                    prompts[task.page.slug],
+                    builder,
+                    deadline_at,
+                )
+                for task in tasks
+            }
+            applied = {slug: future.result() for slug, future in futures.items()}
+
+        _resync_project_files(project_id)
+
+        landed = [slug for slug, ok in applied.items() if ok]
+        missed = [slug for slug, ok in applied.items() if not ok]
+
+        if landed:
             Project.objects.filter(pk=project_id).update(
                 generation_status='completed',
                 last_generated_at=timezone.now(),
             )
-            logger.info("Initial AI build completed and applied for project %s", project_id)
+            logger.info(
+                "Initial AI build completed for project %s: applied %s%s",
+                project_id,
+                ', '.join(landed),
+                f"; {', '.join(missed)} kept their scaffold" if missed else '',
+            )
         else:
             # The project still holds its complete, working scaffold — the
-            # unmerged build sits in the workspace for the user to look at.
+            # unmerged builds sit in the workspace for the user to look at.
             Project.objects.filter(pk=project_id).update(generation_status='failed')
             logger.error(
-                "Initial AI build for project %s was not applied; project kept its scaffold",
+                "No page of the initial AI build for project %s was applied; "
+                "project kept its scaffold",
                 project_id,
             )
     except Exception:
@@ -322,6 +510,56 @@ def _run_initial_build(project_id: int, user_id: int) -> None:
             pass
     finally:
         close_old_connections()
+
+
+def _pages_to_build(builder):
+    """The pages this build covers, narrowed by settings if configured.
+
+    IMAGI_BUILDER['INITIAL_BUILD_PAGES'] takes a list of slugs; an unset or
+    empty value builds all of them. Unknown slugs are ignored rather than
+    failing the build, and an empty result falls back to the home page — the
+    first build should never end up dispatching nothing.
+    """
+    wanted = builder.get('INITIAL_BUILD_PAGES')
+    if not wanted:
+        return list(PAGE_BRIEFS)
+    by_slug = {p.slug: p for p in PAGE_BRIEFS}
+    unknown = [slug for slug in wanted if slug not in by_slug]
+    if unknown:
+        logger.warning(
+            "Ignoring unknown INITIAL_BUILD_PAGES entries: %s", ', '.join(unknown)
+        )
+    pages = [by_slug[slug] for slug in wanted if slug in by_slug]
+    return pages or [PAGE_BRIEFS[0]]
+
+
+def _resync_project_files(project_id: int) -> None:
+    """Settle the database mirror once every page has merged.
+
+    Each merge re-syncs the mirror itself, but those syncs run concurrently
+    here: a sync that walked disk before a sibling's merge landed can prune the
+    rows that sibling just wrote. Disk is the source of truth and is correct
+    either way, so rather than serialize the merges, the mirror is simply
+    rebuilt once at the end, when nothing else is writing. Best-effort — a
+    stale mirror is a debugging inconvenience, not a broken project.
+    """
+    from ..models import Project
+
+    try:
+        from apps.Imagi.Build.services.project_files_service import (
+            import_project_from_disk,
+        )
+
+        project = Project.objects.get(pk=project_id)
+        if project.project_path:
+            import_project_from_disk(project)
+    except Exception as e:
+        logger.warning(
+            "Could not re-sync the file mirror for project %s after the initial "
+            "build: %s",
+            project_id,
+            e,
+        )
 
 
 def _apply_despite_lost_auth_links(service, task, user, project_id, auth_problems) -> bool:
@@ -376,8 +614,8 @@ def _apply_despite_lost_auth_links(service, task, user, project_id, auth_problem
     return True
 
 
-def _build_and_apply(service, task, user, project_id, prompt, builder):
-    """Run the build, repairing what stands between it and the project.
+def _build_and_apply(service, task, user, project_id, prompt, builder, deadline_at=None):
+    """Run one page's build, repairing what stands between it and the project.
 
     Each run ends in the usual task finalization, which merges the worktree
     only when its frontend actually resolves, its app routers still export
@@ -387,17 +625,19 @@ def _build_and_apply(service, task, user, project_id, prompt, builder):
     the project.
 
     The three defects are not weighted the same when the repairs run out. A
-    dangling import or a broken router means an app that does not load, so
-    that build is abandoned and the project keeps its scaffold. A missing auth
-    link only means a page that loads and is harder to sign into, so that one
-    ships anyway.
+    dangling import or a broken router means a page that does not load, so
+    that page is abandoned and keeps its scaffold. A missing auth link only
+    means a page that loads and is harder to sign into, so that one ships
+    anyway.
 
-    The founder's wait is the binding constraint, so every run in this loop
-    shares ONE deadline rather than getting a fresh budget: a build plus its
-    repairs is held to INITIAL_BUILD_TIME_BUDGET_S in total. When too little
-    time is left for a repair to plausibly finish, it is skipped — starting one
-    that gets killed mid-edit tends to leave more dangling references than it
-    fixes.
+    The founder's wait is the binding constraint, so every run here shares ONE
+    deadline rather than getting a fresh budget — and when the pages are built
+    in parallel that deadline is shared across all of them too, passed in by
+    the caller so the clock starts once for the whole build rather than per
+    page. A build plus its repairs is held to INITIAL_BUILD_TIME_BUDGET_S in
+    total. When too little time is left for a repair to plausibly finish, it is
+    skipped — starting one that gets killed mid-edit tends to leave more
+    dangling references than it fixes.
     """
     from apps.Imagi.Build.services.frontend_integrity import (
         find_auth_link_problems,
@@ -406,9 +646,10 @@ def _build_and_apply(service, task, user, project_id, prompt, builder):
     )
 
     attempts = builder.get('INITIAL_BUILD_REPAIR_ATTEMPTS', 2)
-    time_budget = builder.get('INITIAL_BUILD_TIME_BUDGET_S', 60)
     min_repair_seconds = builder.get('INITIAL_BUILD_MIN_REPAIR_SECONDS', 12)
-    deadline_at = time.monotonic() + time_budget if time_budget else None
+    if deadline_at is None:
+        time_budget = builder.get('INITIAL_BUILD_TIME_BUDGET_S', 60)
+        deadline_at = time.monotonic() + time_budget if time_budget else None
 
     user_input = prompt
     max_turns = builder.get('INITIAL_BUILD_MAX_TURNS')

--- a/backend/django/apps/Imagi/ProjectManager/services/project_creation_service.py
+++ b/backend/django/apps/Imagi/ProjectManager/services/project_creation_service.py
@@ -54,6 +54,34 @@ class ProjectCreationService:
             except Exception as app_err:
                 logger.warning(f"Failed to ensure default apps: {app_err}")
 
+            # Ensure the frontend-only page apps (about, contact). The initial
+            # build gives each of its parallel subagents one of these views to
+            # rewrite, so the routes must already resolve before it starts.
+            try:
+                create_app_service = CreateAppService(user=self.user)
+                pages_result = create_app_service.ensure_page_apps(project_id=str(project.id))
+                logger.info(f"Page apps ensure result: {pages_result}")
+            except Exception as page_err:
+                logger.warning(f"Failed to ensure page apps: {page_err}")
+
+            # Put the finished scaffold under git before anything else touches
+            # it. The repo is created lazily otherwise, on whichever agent run
+            # first needs a worktree — which the initial build now reaches from
+            # several page subagents at once, all racing to 'git init' the same
+            # directory. Creating it here means they each find a repo that is
+            # already there, with the clean scaffold as its first commit.
+            try:
+                from apps.Imagi.Build.services.version_control_service import (
+                    VersionControlService,
+                )
+                if not VersionControlService().initialize_repo(project_path):
+                    logger.warning(
+                        f"Could not initialize a git repository at {project_path}; "
+                        "the first agent run will retry"
+                    )
+            except Exception as git_err:
+                logger.warning(f"Failed to initialize the project repository: {git_err}")
+
             # Store the database copy of every scaffolded file, so the
             # project can be served (and rebuilt on disk) from the database.
             try:

--- a/backend/django/apps/Imagi/ProjectManager/tests.py
+++ b/backend/django/apps/Imagi/ProjectManager/tests.py
@@ -11,12 +11,13 @@ does not pollute the repository or depend on npm/Django scaffolding.
 import os
 import shutil
 import tempfile
+import threading
 from unittest.mock import patch
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
-from django.test import TestCase, override_settings
+from django.test import TestCase, TransactionTestCase, override_settings
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.authtoken.models import Token
@@ -370,8 +371,18 @@ class ProjectManagerAPITests(APITestCase):
 
 
 @override_settings(PROJECTS_ROOT=_TMP_PROJECTS_ROOT)
-class InitialBuildServiceTests(TestCase):
-    """Tests for the initial AI build kicked off at project creation."""
+class InitialBuildServiceTests(TransactionTestCase):
+    """Tests for the initial AI build kicked off at project creation.
+
+    A TransactionTestCase rather than a TestCase because the build fans its
+    pages out across worker threads: those threads open their own database
+    connections, which cannot see data still sitting in an uncommitted test
+    transaction.
+
+    Most of these cover per-page behaviour (repairs, deadlines, what does and
+    does not get merged), so they pin the build to the home page alone and stay
+    deterministic. The fan-out itself is covered by ParallelInitialBuildTests.
+    """
 
     def setUp(self):
         self.user = User.objects.create_user(username='owner', password='pw123456')
@@ -403,7 +414,7 @@ class InitialBuildServiceTests(TestCase):
         mock_thread.assert_called_once()
         mock_thread.return_value.start.assert_called_once()
 
-    def _run_build(self, outcomes, unresolved=()):
+    def _run_build(self, outcomes, unresolved=(), pages=('home',)):
         """Drive a full initial build with the agent run itself stubbed out.
 
         Everything around the model call is real — the lead and task
@@ -417,6 +428,9 @@ class InitialBuildServiceTests(TestCase):
                 without being applied, and 'fail' for a failed run.
             unresolved: dangling imports the integrity check should report on
                 an unapplied worktree, which is what triggers a repair run.
+            pages: which pages the build covers. Defaults to home alone, so a
+                test about repair or deadline behaviour drives one subagent and
+                the run order stays deterministic.
 
         Returns the kwargs of every process() call made.
         """
@@ -442,7 +456,10 @@ class InitialBuildServiceTests(TestCase):
                 ).update(review_status='ready')
             return {'success': True, 'files_changed': []}
 
-        with patch.object(ImagiAgentService, 'process', fake_process), patch(
+        builder = {**settings.IMAGI_BUILDER, 'INITIAL_BUILD_PAGES': list(pages)}
+        with override_settings(IMAGI_BUILDER=builder), patch.object(
+            ImagiAgentService, 'process', fake_process
+        ), patch(
             'apps.Imagi.Build.services.frontend_integrity.find_unresolved_imports',
             return_value=list(unresolved),
         ):
@@ -484,7 +501,7 @@ class InitialBuildServiceTests(TestCase):
         # thread, so it inherits the worktree isolation and review lifecycle
         # every dispatched task has.
         self.assertEqual(task.parent_id, lead.id)
-        self.assertEqual(task.title, 'Initial build')
+        self.assertEqual(task.title, 'Initial build — home page')
         self.assertEqual(task.system_prompt.content, INITIAL_BUILD_INSTRUCTIONS)
         self.assertEqual(calls[0]['conversation_id'], task.id)
 
@@ -495,7 +512,7 @@ class InitialBuildServiceTests(TestCase):
         self.assertIn('Beanline', messages[0].content)
         self.assertEqual(
             messages[1].metadata['dispatched_tasks'],
-            [{'conversation_id': task.id, 'title': 'Initial build'}],
+            [{'conversation_id': task.id, 'title': 'Initial build — home page'}],
         )
 
     def test_build_runs_on_the_configured_initial_build_model(self):
@@ -723,30 +740,289 @@ class InitialBuildServiceTests(TestCase):
 
     def test_repair_is_skipped_when_too_little_time_remains(self):
         # Starting a repair that will be killed mid-edit tends to leave more
-        # dangling references than it fixes, so a build with no time left keeps
+        # dangling references than it fixes, so a page with no time left keeps
         # its scaffold instead.
+        #
+        # Driven through _build_and_apply with an all-but-expired deadline
+        # rather than by faking the clock: time.monotonic is module-global, so
+        # patching it also feeds Django's own connection bookkeeping and the
+        # scripted readings stop lining up with this code's.
+        import time as real_time
+
+        from apps.Imagi.Build.models import AgentConversation
         from apps.Imagi.ProjectManager.services import initial_build_service
 
-        budget = settings.IMAGI_BUILDER['INITIAL_BUILD_TIME_BUDGET_S']
         min_repair = settings.IMAGI_BUILDER['INITIAL_BUILD_MIN_REPAIR_SECONDS']
-        # First reading sets the deadline; the second is checked before repair,
-        # by which point less than the repair minimum is left.
-        clock = iter([0.0, budget - (min_repair / 2)])
+        task = AgentConversation.objects.create(
+            user=self.user,
+            model_name='gpt-5.6-terra',
+            project_id=self.project.pk,
+            mode='agent',
+            title='Initial build — home page',
+            kind='task',
+            review_status='active',
+        )
 
-        with patch.object(
-            initial_build_service.time, 'monotonic', side_effect=lambda: next(clock)
+        calls = []
+
+        class FakeService:
+            def process(self, **kwargs):
+                calls.append(kwargs)
+                AgentConversation.objects.filter(id=task.id).update(
+                    review_status='ready'
+                )
+                return {'success': True, 'files_changed': []}
+
+        with patch(
+            'apps.Imagi.Build.services.frontend_integrity.find_unresolved_imports',
+            return_value=[{
+                'file': 'frontend/vuejs/src/apps/home/views/HomeView.vue',
+                'import': '@/shared/components/SiteHeader.vue',
+            }],
         ):
-            calls = self._run_build(
-                ['leave', 'accept'],
-                unresolved=[{
-                    'file': 'frontend/vuejs/src/apps/home/views/HomeView.vue',
-                    'import': '@/shared/components/SiteHeader.vue',
-                }],
+            applied = initial_build_service._build_and_apply(
+                FakeService(),
+                task,
+                self.user,
+                self.project.pk,
+                'brief',
+                settings.IMAGI_BUILDER,
+                deadline_at=real_time.monotonic() + (min_repair / 2),
             )
 
         self.assertEqual(len(calls), 1, 'a repair ran with no time budget left')
+        self.assertFalse(applied)
+
+
+class ParallelInitialBuildTests(TransactionTestCase):
+    """The first build fans out across pages instead of writing just one.
+
+    A sequential build can only produce one page inside the founder's
+    half-minute wait. Dispatching a subagent per page spends that same half
+    minute on all of them at once — which only works if the pages stay
+    genuinely independent: one file each, one deadline for the lot, and no page
+    able to take another down with it.
+    """
+
+    def setUp(self):
+        self.user = User.objects.create_user(username='owner', password='pw123456')
+        self.project = Project.objects.create(
+            user=self.user, name='Beanline', description=VALID_DESCRIPTION
+        )
+
+    def _run(self, outcome_by_slug=None):
+        """Run a full three-page build, stubbing out only the model call.
+
+        outcome_by_slug maps a page slug to 'accept' (its worktree merged),
+        'leave' (finished but unmerged) or 'fail' (the run errored); anything
+        unnamed accepts. Returns the process() kwargs keyed by page slug.
+        """
+        from apps.Imagi.ProjectManager.services import initial_build_service
+        from apps.Imagi.Build.models import AgentConversation
+        from apps.Imagi.Build.services.base_agent import ImagiAgentService
+
+        outcome_by_slug = outcome_by_slug or {}
+        calls = {}
+
+        def slug_of(conversation_id):
+            title = AgentConversation.objects.get(id=conversation_id).title
+            return title.rsplit('—', 1)[-1].strip().split(' ')[0]
+
+        def fake_process(_self, **kwargs):
+            slug = slug_of(kwargs['conversation_id'])
+            calls.setdefault(slug, []).append(kwargs)
+            outcome = outcome_by_slug.get(slug, 'accept')
+            if outcome == 'fail':
+                return {'success': False, 'error': 'model error'}
+            AgentConversation.objects.filter(id=kwargs['conversation_id']).update(
+                review_status='accepted' if outcome == 'accept' else 'ready'
+            )
+            return {'success': True, 'files_changed': []}
+
+        with patch.object(ImagiAgentService, 'process', fake_process), patch(
+            'apps.Imagi.Build.services.frontend_integrity.find_unresolved_imports',
+            return_value=[],
+        ):
+            initial_build_service._run_initial_build(self.project.pk, self.user.pk)
+        return calls
+
+    def test_every_page_gets_its_own_subagent_and_its_own_file(self):
+        from apps.Imagi.ProjectManager.services.initial_build_service import PAGE_BRIEFS
+
+        calls = self._run()
+
+        self.assertEqual(set(calls), {'home', 'about', 'contact'})
+        # Each subagent is told to rewrite its own view and no other.
+        for page in PAGE_BRIEFS:
+            prompt = calls[page.slug][0]['user_input']
+            self.assertIn(page.view_path, prompt)
+            for other in PAGE_BRIEFS:
+                if other.slug != page.slug:
+                    self.assertNotIn(other.view_path, prompt)
+
+    def test_no_two_pages_are_given_the_same_file(self):
+        # The merge-safety invariant: the three worktrees are merged one after
+        # another, so two agents writing the same path would conflict and lose
+        # somebody's page.
+        from apps.Imagi.ProjectManager.services.initial_build_service import PAGE_BRIEFS
+
+        paths = [p.view_path for p in PAGE_BRIEFS]
+        self.assertEqual(len(paths), len(set(paths)))
+
+    def test_pages_run_against_one_shared_deadline(self):
+        # The founder waits for the slowest page, not the sum of all three, so
+        # the clock has to start once for the whole build rather than per page.
+        calls = self._run()
+
+        deadlines = {
+            call['deadline_at'] for runs in calls.values() for call in runs
+        }
+        self.assertEqual(len(deadlines), 1, 'each page got its own deadline')
+        self.assertIsNotNone(next(iter(deadlines)))
+
+    def test_all_three_subagents_are_dispatched_from_the_one_main_thread(self):
+        from apps.Imagi.Build.models import AgentConversation
+
+        self._run()
+
+        leads = AgentConversation.objects.filter(
+            user=self.user, project_id=self.project.pk, kind='lead'
+        )
+        self.assertEqual(leads.count(), 1)
+        lead = leads.get()
+        tasks = AgentConversation.objects.filter(
+            user=self.user, project_id=self.project.pk, kind='task'
+        )
+        self.assertEqual(tasks.count(), 3)
+        self.assertTrue(all(t.parent_id == lead.id for t in tasks))
+
+        # The thread opens with the founder's brief and one acknowledgement
+        # carrying a link to every subagent thread it started.
+        messages = list(lead.messages.order_by('created_at'))
+        self.assertEqual([m.role for m in messages], ['user', 'assistant'])
+        self.assertIn('Beanline', messages[0].content)
+        dispatched = messages[1].metadata['dispatched_tasks']
+        self.assertEqual(
+            {d['conversation_id'] for d in dispatched},
+            set(tasks.values_list('id', flat=True)),
+        )
+
+    def test_a_page_that_fails_does_not_stop_its_siblings(self):
+        # Pages stand alone: one agent erroring out must not cost the founder
+        # the other two, and the build still counts as completed.
+        calls = self._run({'about': 'fail'})
+
+        self.assertEqual(set(calls), {'home', 'about', 'contact'})
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.generation_status, 'completed')
+
+    def test_a_page_left_unmerged_does_not_stop_its_siblings(self):
+        calls = self._run({'contact': 'leave'})
+
+        self.assertEqual(set(calls), {'home', 'about', 'contact'})
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.generation_status, 'completed')
+
+    def test_the_build_fails_only_when_no_page_lands(self):
+        self._run({'home': 'fail', 'about': 'fail', 'contact': 'fail'})
+
         self.project.refresh_from_db()
         self.assertEqual(self.project.generation_status, 'failed')
+
+    def test_the_page_set_is_configurable(self):
+        from apps.Imagi.ProjectManager.services import initial_build_service
+
+        builder = {**settings.IMAGI_BUILDER, 'INITIAL_BUILD_PAGES': ['home', 'contact']}
+        with override_settings(IMAGI_BUILDER=builder):
+            calls = self._run()
+        self.assertEqual(set(calls), {'home', 'contact'})
+
+    def test_an_unknown_page_never_leaves_the_build_with_nothing_to_do(self):
+        from apps.Imagi.ProjectManager.services.initial_build_service import (
+            _pages_to_build,
+        )
+
+        pages = _pages_to_build({'INITIAL_BUILD_PAGES': ['nonsense']})
+        self.assertEqual([p.slug for p in pages], ['home'])
+
+
+class ConcurrentWorktreeSetupTests(TransactionTestCase):
+    """Several subagents claiming worktrees on a brand-new project at once.
+
+    Seen live: all three of a first build's pages reached `git init` on the
+    same fresh directory together and two died with "Failed to initialize git
+    repository". The repo lock could not cover it because it keyed on '.git',
+    which does not exist yet at exactly that moment.
+    """
+
+    def setUp(self):
+        self.project_dir = tempfile.mkdtemp(prefix='imagi_concurrent_git_')
+        with open(os.path.join(self.project_dir, 'seed.txt'), 'w') as f:
+            f.write('scaffold\n')
+
+    def tearDown(self):
+        shutil.rmtree(self.project_dir, ignore_errors=True)
+
+    def test_the_repo_lock_covers_creating_the_repo(self):
+        from apps.Imagi.Build.services.version_control_service import (
+            canonical_repo_lock,
+        )
+
+        # A directory with no repo in it must still be lockable, or the one
+        # moment that needs serializing most is the one moment left unguarded.
+        holder_entered = threading.Event()
+        second_acquired = threading.Event()
+
+        def hold():
+            with canonical_repo_lock(self.project_dir):
+                holder_entered.set()
+                second_acquired.wait(timeout=0.5)
+
+        def contend():
+            with canonical_repo_lock(self.project_dir):
+                second_acquired.set()
+
+        holder = threading.Thread(target=hold)
+        holder.start()
+        self.assertTrue(holder_entered.wait(timeout=5))
+        contender = threading.Thread(target=contend)
+        contender.start()
+        # The contender must NOT get in while the holder has it.
+        self.assertFalse(
+            second_acquired.wait(timeout=0.2),
+            'the lock let a second holder in on a repo-less project directory',
+        )
+        holder.join(timeout=5)
+        contender.join(timeout=5)
+        self.assertTrue(second_acquired.is_set())
+
+    def test_parallel_worktree_creation_on_a_fresh_project_all_succeed(self):
+        from apps.Imagi.Build.services.version_control_service import (
+            VersionControlService,
+        )
+
+        results = {}
+
+        def make(conversation_id):
+            results[conversation_id] = VersionControlService().create_task_worktree(
+                self.project_dir, conversation_id
+            )
+
+        threads = [
+            threading.Thread(target=make, args=(cid,)) for cid in (901, 902, 903)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=60)
+
+        self.assertEqual(len(results), 3)
+        for cid, result in results.items():
+            self.assertTrue(
+                result.get('success'),
+                f'worktree {cid} failed: {result.get("message")}',
+            )
+            self.assertTrue(os.path.isdir(result['worktree_path']))
 
 
 @override_settings(PROJECTS_ROOT=_TMP_PROJECTS_ROOT)
@@ -829,6 +1105,36 @@ class ScaffoldWiringTests(TestCase):
         )
 
         self.assertEqual(find_auth_link_problems(self.project.project_path), [])
+
+    def test_every_first_build_page_is_scaffolded_and_routed(self):
+        # Each page subagent rewrites one already-routed view. If the scaffold
+        # were missing, the agent would have to create its own route file too —
+        # two files, and a run cut off between them leaves a dangling import
+        # that discards the page.
+        from apps.Imagi.ProjectManager.services.initial_build_service import (
+            PAGE_BRIEFS,
+        )
+
+        for page in PAGE_BRIEFS:
+            view = os.path.join(self.project.project_path, page.view_path)
+            self.assertTrue(
+                os.path.isfile(view), f'{page.slug} view missing: {page.view_path}'
+            )
+            app_dir = os.path.dirname(os.path.dirname(view))
+            router = self._read(app_dir, 'router', 'index.ts')
+            self.assertIn(f"path: '{page.route}'", router)
+            self.assertIn('export { routes }', router)
+
+    def test_page_apps_are_frontend_only(self):
+        # about/contact are static marketing pages: giving them a Django app
+        # would add INSTALLED_APPS entries and migrations for nothing.
+        for app in ('about', 'contact'):
+            self.assertTrue(os.path.isdir(os.path.join(
+                self.project.project_path, 'frontend', 'vuejs', 'src', 'apps', app
+            )))
+            self.assertFalse(os.path.isdir(os.path.join(
+                self.backend_root, 'apps', app
+            )))
 
     def test_scaffolded_files_are_mirrored_to_database(self):
         # Disk is the source of truth; the DB mirror should hold the same

--- a/backend/django/imagi/settings.py
+++ b/backend/django/imagi/settings.py
@@ -157,6 +157,17 @@ else:
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
             'NAME': BASE_DIR / 'db.sqlite3',
+            # The initial build runs one agent per page concurrently, so several
+            # threads now write here at once — which SQLite's default rollback
+            # journal handles badly: a single writer blocks readers too, and a
+            # blocked writer gives up with "database is locked". WAL lets
+            # readers run through a write, and the longer timeout makes a
+            # contended writer wait its turn instead of failing the page it was
+            # building. Development only; production is Postgres above.
+            'OPTIONS': {
+                'init_command': 'PRAGMA journal_mode=WAL;',
+                'timeout': 20,
+            },
         }
     }
 
@@ -273,25 +284,37 @@ IMAGI_BUILDER = {
     # project already holds a working home + auth scaffold from the moment it is
     # created, so a build that stops early degrades to "less tailoring", never
     # to a broken or empty app.
-    # The target is a 30-second wait, so the agent's own run gets 28: the
-    # founder additionally waits on the work either side of it (worktree setup,
-    # then the merge and database mirror on the way out) — measured at ~2s
-    # combined. Half a minute is what the scope below is sized for: one
-    # self-contained home page, which is all a founder needs to see to know the
-    # build understood their business.
+    # The target is a 30-second wait, so the agents' own runs get 28: the
+    # founder additionally waits on the work either side of them (worktree
+    # setup, then the merges and database mirror on the way out) — measured at
+    # ~2s combined.
+    #
+    # The budget is shared by every page, not spent per page: the pages below
+    # are built CONCURRENTLY, one subagent each, so half a minute buys all of
+    # them rather than just one. Wall clock is the slowest page; what scales
+    # with the list is spend, roughly linearly (three pages ≈ three times the
+    # tokens), which is why COST_BUDGET_USD below is per page.
     'INITIAL_BUILD_MODEL': 'gpt-5.6-terra',
     'INITIAL_BUILD_TIME_BUDGET_S': 28,
+    # Pages the first build writes, one subagent per entry, each owning a
+    # single already-routed view file (see initial_build_service.PAGE_BRIEFS
+    # for the briefs and prebuilt_apps/pages.py for the scaffold they rewrite).
+    # Empty or unset builds all of them; trimming the list is the direct lever
+    # on what a project creation costs.
+    'INITIAL_BUILD_PAGES': ['home', 'about', 'contact'],
     # First builds create UI from a description rather than reasoning about
     # existing code, so they run at low effort: it roughly halves per-turn
     # latency, which buys more pages inside the time budget than deeper
     # reasoning does.
     'INITIAL_BUILD_REASONING_EFFORT': 'low',
     # Cost and turns are runaway backstops now, not the operative limit — the
-    # time budget stops a normal build long before either binds. NOTE: the cost
-    # figure is priced with the *suite retail* rates in models_service (what a
-    # run is displayed as costing), which are a multiple of the underlying API
-    # price — so this is deliberately well above real expected spend. Sized so
-    # it never cuts a build short on its own; time does that.
+    # time budget stops a normal build long before either binds. Both are PER
+    # PAGE, so the ceiling for a whole build is this times the page count.
+    # NOTE: the cost figure is priced with the *suite retail* rates in
+    # models_service (what a run is displayed as costing), which are a multiple
+    # of the underlying API price — so this is deliberately well above real
+    # expected spend. Sized so it never cuts a build short on its own; time
+    # does that.
     'INITIAL_BUILD_COST_BUDGET_USD': 1.50,
     'INITIAL_BUILD_MAX_TURNS': 12,
     # A build that stops at a cap can leave a page importing a component it


### PR DESCRIPTION
## What changed

The initial build was one subagent writing one page. Its binding constraint is wall clock — the founder is sitting there waiting — so a sequential build could never produce more than a single page no matter how the budget was spent.

It now dispatches **one subagent per page** (home, about, contact), all running concurrently against a single shared deadline. Each merges itself as it finishes; the merges serialize on the project's git lock.

## Why it's safe to parallelize

The whole design turns on **each subagent owning exactly one file**:

- **A self-contained file can't dangle.** It cannot reference a component its author never got around to writing, so a run stopped by the clock still merges. This is why `about` and `contact` are now pre-scaffolded as frontend-only page apps with their routes already resolving — an agent that had to write both its view *and* the route pointing at it would leave a dangling import if cut off between the two, and the page would be discarded.
- **No two agents write the same path,** so the three worktree merges never conflict.

Pages are independent end to end: one failing or going unmerged costs only that page (which keeps its placeholder), and the build counts as completed when at least one lands. `INITIAL_BUILD_PAGES` controls the set.

## Two races this exposed

Both were pre-existing latent bugs that only a concurrent build could surface:

**`canonical_repo_lock` left the highest-contention moment unguarded.** It keyed on `.git` and skipped locking when that didn't exist — precisely the moment several dispatches for a brand-new project all reach `git init` together. Seen live as `Failed to initialize git repository` on two of three pages. It now locks the project directory, which always exists, and the project gets its repo at creation so agents find one already there.

**SQLite write contention.** Concurrent writers hit `database table is locked`. Enabled WAL and a 20s timeout on the dev config; production is Postgres and unaffected.

## Testing

- **437 tests pass** across `apps.Imagi`.
- New coverage: per-page fan-out, the shared deadline, one page failing without taking down its siblings, the file-disjointness invariant, and the two concurrency races. Both race regression tests were verified to **fail against the old lock** and pass against the fix.
- Verified live through the UI: all three tasks `accepted`, all three pages written with real copy (205/223/188 lines), nav cross-linked home ↔ about ↔ contact, auth wiring on home alone, contact form presentational-only with no backend calls, no console errors.

## Reviewer note: the wait is still ~56s

Worth being explicit, since the point of parallelism was speed. Measured create-to-completed:

| | |
|---|---|
| Single page (before) | 48.0s |
| Three pages (after) | 56.0s |

So this buys 3× the pages for +8s — but it does **not** bring the build to the 30s the settings aim at, and neither did the previous single-page build. `INITIAL_BUILD_TIME_BUDGET_S` (28s) is enforced in a hook at *turn boundaries*, and a page is one large `update_file` turn that runs to completion regardless. Closing that gap means shrinking what each page writes, not lowering the number — a product call, so it is deliberately not made here.

Cost note: three concurrent agents is roughly 3× the tokens per project creation, and `INITIAL_BUILD_COST_BUDGET_USD` is per page, so a build's ceiling is that figure times the page count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)