### PR TITLE
Give the agent panes one motion and material system

### DIFF
--- a/frontend/vuejs/src/apps/imagi/build/components/molecules/chat/AgentActivityFeed.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/molecules/chat/AgentActivityFeed.vue
@@ -1,34 +1,48 @@
+<!--
+  AgentActivityFeed.vue — what the agent is doing, step by step.
+
+  Live, this is the transcript's ticker: each tool call lands as a new line
+  under a spinner. Once the run is over the whole thing folds into a single
+  quiet summary the user can open again if they care how it was done.
+
+  Steps arrive one at a time over SSE, so they enter as a group (each new line
+  slides up into place rather than materialising), and the fold opens by
+  animating its own height rather than snapping.
+-->
 <template>
   <div class="text-xs">
     <!-- Once the run is over the feed folds into a one-line summary -->
     <button
       v-if="!streaming"
       type="button"
-      class="inline-flex items-center gap-1.5 text-blue-950/50 dark:text-white/45 hover:text-blue-950/80 dark:hover:text-white/75 transition-colors"
+      class="feed-toggle inline-flex items-center gap-1.5 rounded text-blue-950/50 dark:text-white/45 hover:text-blue-950/80 dark:hover:text-white/75"
       :aria-expanded="expanded"
       @click="expanded = !expanded"
     >
       <i
-        class="fas fa-chevron-right text-[8px] transition-transform duration-150"
-        :class="{ 'rotate-90': expanded }"
+        class="fas fa-chevron-right feed-chevron text-[8px]"
+        :class="{ 'is-open': expanded }"
       ></i>
       <span>Completed {{ steps.length }} {{ steps.length === 1 ? 'step' : 'steps' }}</span>
     </button>
 
-    <ul
-      v-if="streaming || expanded"
-      class="space-y-1"
-      :class="{ 'mt-1.5': !streaming }"
+    <!-- Streaming: the list is simply there, growing. Settled: it lives in a
+         fold that opens to whatever height it needs. -->
+    <TransitionGroup
+      v-if="streaming"
+      name="feed-step"
+      tag="ul"
+      class="feed-list"
       aria-label="Agent activity"
     >
       <li
         v-for="(step, index) in steps"
-        :key="index"
-        class="flex items-start gap-2 min-w-0 leading-relaxed"
+        :key="`${index}-${step.label}`"
+        class="feed-step flex items-start gap-2 min-w-0 leading-relaxed"
       >
         <span class="flex w-3.5 shrink-0 items-center justify-center mt-[3px]">
           <i
-            v-if="streaming && index === steps.length - 1"
+            v-if="index === steps.length - 1"
             class="fas fa-circle-notch fa-spin text-[9px] text-blue-600 dark:text-blue-300"
           ></i>
           <i v-else class="fas fa-check text-[9px] text-blue-600/60 dark:text-blue-300/60"></i>
@@ -40,13 +54,34 @@
           :title="step.detail"
         >{{ step.detail }}</span>
       </li>
-    </ul>
+    </TransitionGroup>
+
+    <FoldTransition v-else>
+      <ul v-if="expanded" class="feed-list mt-1.5" aria-label="Agent activity">
+        <li
+          v-for="(step, index) in steps"
+          :key="index"
+          class="flex items-start gap-2 min-w-0 leading-relaxed"
+        >
+          <span class="flex w-3.5 shrink-0 items-center justify-center mt-[3px]">
+            <i class="fas fa-check text-[9px] text-blue-600/60 dark:text-blue-300/60"></i>
+          </span>
+          <span class="shrink-0 text-blue-950/70 dark:text-white/65">{{ step.label }}</span>
+          <span
+            v-if="step.detail"
+            class="min-w-0 flex-1 truncate font-mono text-[10px] leading-relaxed text-blue-950/45 dark:text-white/40 mt-px"
+            :title="step.detail"
+          >{{ step.detail }}</span>
+        </li>
+      </ul>
+    </FoldTransition>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref } from 'vue'
 import type { AgentActivityStep } from '@/apps/imagi/build/types/services'
+import FoldTransition from '@/apps/imagi/build/components/molecules/common/FoldTransition.vue'
 
 defineProps<{
   steps: AgentActivityStep[]
@@ -55,3 +90,45 @@ defineProps<{
 
 const expanded = ref(false)
 </script>
+
+<style scoped>
+.feed-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.feed-toggle {
+  transition: color var(--iw-dur-2) var(--iw-ease-out);
+}
+
+.feed-toggle:focus-visible {
+  outline: none;
+  box-shadow: var(--iw-focus-ring);
+}
+
+.feed-chevron {
+  transition: transform var(--iw-dur-3) var(--iw-ease-inout);
+}
+
+.feed-chevron.is-open {
+  transform: rotate(90deg);
+}
+
+/* A step lands from below as the agent reports it, so the ticker reads as
+   work accumulating rather than as text being rewritten. */
+.feed-step-enter-active {
+  transition:
+    opacity var(--iw-dur-2) var(--iw-ease-out),
+    transform var(--iw-dur-3) var(--iw-ease-out);
+}
+
+.feed-step-enter-from {
+  opacity: 0;
+  transform: translateY(4px);
+}
+
+.feed-step-move {
+  transition: transform var(--iw-dur-3) var(--iw-ease-out);
+}
+</style>

--- a/frontend/vuejs/src/apps/imagi/build/components/molecules/chat/AgentPlanChecklist.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/molecules/chat/AgentPlanChecklist.vue
@@ -1,25 +1,41 @@
+<!--
+  AgentPlanChecklist.vue — the agent's plan, ticking itself off.
+
+  The list is written once and then re-graded as the run proceeds: pending →
+  in progress → completed. Because the same row changes state under the user's
+  eye, the interesting motion here is not entrance but transition — the marker
+  swaps with a small pop, and the text settles into (or fades out of) its new
+  weight rather than switching between two different-looking rows.
+-->
 <template>
-  <ul class="space-y-1" aria-label="Agent plan">
+  <ul class="plan-list" aria-label="Agent plan">
     <li
       v-for="(step, index) in steps"
       :key="index"
       class="flex items-start gap-2 min-w-0 text-xs leading-relaxed"
     >
       <span class="flex w-3.5 shrink-0 items-center justify-center mt-[3px]">
-        <i
-          v-if="step.status === 'completed'"
-          class="fas fa-check text-[9px] text-blue-600/70 dark:text-blue-300/70"
-        ></i>
-        <i
-          v-else-if="step.status === 'in_progress'"
-          class="fas fa-circle-notch fa-spin text-[9px] text-blue-600 dark:text-blue-300"
-        ></i>
-        <span
-          v-else
-          class="w-[7px] h-[7px] rounded-full border border-blue-950/25 dark:border-white/25"
-        ></span>
+        <!-- Keyed on the status so each grade change plays its own pop
+             instead of one icon silently becoming another. -->
+        <Transition name="plan-mark" mode="out-in">
+          <i
+            v-if="step.status === 'completed'"
+            key="done"
+            class="fas fa-check text-[9px] text-blue-600/70 dark:text-blue-300/70"
+          ></i>
+          <i
+            v-else-if="step.status === 'in_progress'"
+            key="running"
+            class="fas fa-circle-notch fa-spin text-[9px] text-blue-600 dark:text-blue-300"
+          ></i>
+          <span
+            v-else
+            key="pending"
+            class="w-[7px] h-[7px] rounded-full border border-blue-950/25 dark:border-white/25"
+          ></span>
+        </Transition>
       </span>
-      <span class="min-w-0 break-words" :class="stepTextClass(step)">{{ step.step }}</span>
+      <span class="plan-step min-w-0 break-words" :class="stepTextClass(step)">{{ step.step }}</span>
     </li>
   </ul>
 </template>
@@ -37,3 +53,39 @@ function stepTextClass(step: AgentPlanStep): string {
   return 'text-blue-950/65 dark:text-white/60'
 }
 </script>
+
+<style scoped>
+.plan-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+/* The row the agent is on brightens, and finished rows recede — both over the
+   same interval, so the plan reads as one thing being re-graded. */
+.plan-step {
+  transition: color var(--iw-dur-3) var(--iw-ease-out);
+}
+
+.plan-mark-enter-active {
+  transition:
+    opacity var(--iw-dur-1) var(--iw-ease-out),
+    transform var(--iw-dur-2) var(--iw-ease-spring);
+}
+
+.plan-mark-leave-active {
+  transition:
+    opacity var(--iw-dur-1) var(--iw-ease-out),
+    transform var(--iw-dur-1) var(--iw-ease-out);
+}
+
+.plan-mark-enter-from {
+  opacity: 0;
+  transform: scale(0.4);
+}
+
+.plan-mark-leave-to {
+  opacity: 0;
+  transform: scale(0.6);
+}
+</style>

--- a/frontend/vuejs/src/apps/imagi/build/components/molecules/common/FoldTransition.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/molecules/common/FoldTransition.vue
@@ -1,0 +1,77 @@
+<!--
+  FoldTransition.vue — a section that opens and closes to its own height.
+
+  Two places in the workspace hide a list behind a disclosure: the Subagents
+  pane's History section and a settled activity feed's step list. Both were
+  snapping open, which is the one thing that makes an otherwise smooth pane
+  feel abrupt — the content below jumps by however tall the list happens to be.
+
+  Height cannot be transitioned from `auto`, so this measures the element at
+  the moment it enters and animates to that number, then hands height back to
+  the layout once it lands (so a list that grows while open is not pinned to a
+  stale pixel value). The content stays behind `v-if` in the caller, so a
+  collapsed section costs nothing until it is first opened.
+
+  Usage:
+    <FoldTransition>
+      <div v-if="open">…</div>
+    </FoldTransition>
+-->
+<template>
+  <Transition
+    name="fold"
+    @enter="onEnter"
+    @after-enter="onAfterEnter"
+    @enter-cancelled="onAfterEnter"
+    @leave="onLeave"
+    @after-leave="onAfterEnter"
+    @leave-cancelled="onAfterEnter"
+  >
+    <slot />
+  </Transition>
+</template>
+
+<script setup lang="ts">
+/**
+ * Opening: start at zero, then animate to the height the content actually
+ * wants. The reflow read between the two writes is what makes the browser
+ * treat them as two states rather than collapsing them into one.
+ */
+function onEnter(el: Element) {
+  const node = el as HTMLElement
+  node.style.overflow = 'hidden'
+  node.style.height = '0px'
+  void node.offsetHeight
+  node.style.height = `${node.scrollHeight}px`
+}
+
+/** Landed (or interrupted): give height back to the layout. */
+function onAfterEnter(el: Element) {
+  const node = el as HTMLElement
+  node.style.height = ''
+  node.style.overflow = ''
+}
+
+/** Closing: pin the current height, then collapse from it. */
+function onLeave(el: Element) {
+  const node = el as HTMLElement
+  node.style.overflow = 'hidden'
+  node.style.height = `${node.scrollHeight}px`
+  void node.offsetHeight
+  node.style.height = '0px'
+}
+</script>
+
+<style scoped>
+.fold-enter-active,
+.fold-leave-active {
+  transition:
+    height var(--iw-dur-3) var(--iw-ease-out),
+    opacity var(--iw-dur-2) var(--iw-ease-out);
+}
+
+.fold-enter-from,
+.fold-leave-to {
+  opacity: 0;
+}
+</style>

--- a/frontend/vuejs/src/apps/imagi/build/components/molecules/sidebar/AgentInstanceCard.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/molecules/sidebar/AgentInstanceCard.vue
@@ -171,18 +171,22 @@ function relativeTime(iso: string): string {
   align-items: flex-start;
   gap: 0.375rem;
   padding: 0.4375rem 0.5rem 0.4375rem 0.75rem;
-  border-radius: 0.625rem;
+  border-radius: var(--iw-r-md);
   border: 1px solid rgba(23, 37, 84, 0.07);
   background: rgba(239, 246, 255, 0.4);
+  box-shadow: none;
   cursor: pointer;
   overflow: hidden;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  /* Transform is animated on its own line: hover raises the card and the
+     press pushes it back down, and both need to compose without fighting the
+     colour fade's timing. */
   transition:
-    background-color 0.2s ease,
-    border-color 0.2s ease,
-    box-shadow 0.2s ease,
-    transform 0.2s cubic-bezier(0.22, 1, 0.36, 1);
-  animation: agent-card-in 0.45s cubic-bezier(0.22, 1, 0.36, 1) both;
-  animation-delay: var(--stagger, 0ms);
+    background-color var(--iw-dur-2) var(--iw-ease-out),
+    border-color var(--iw-dur-2) var(--iw-ease-out),
+    box-shadow var(--iw-dur-2) var(--iw-ease-out),
+    transform var(--iw-dur-2) var(--iw-ease-out);
 }
 
 .dark .agent-card {
@@ -192,10 +196,14 @@ function relativeTime(iso: string): string {
   background: rgba(255, 255, 255, 0.02);
 }
 
+/* Hover lifts the card off the column rather than nudging it sideways: a
+   sideways shift re-lays the text out by a pixel, which reads as a wobble in
+   a list this dense. Rising is silent. */
 .agent-card:hover {
   background: rgba(239, 246, 255, 0.95);
-  border-color: rgba(23, 37, 84, 0.14);
-  transform: translateX(1px);
+  border-color: rgba(23, 37, 84, 0.13);
+  box-shadow: var(--iw-shadow-2);
+  transform: translateY(-1px);
 }
 
 .dark .agent-card:hover {
@@ -203,13 +211,17 @@ function relativeTime(iso: string): string {
   border-color: rgba(255, 255, 255, 0.17);
 }
 
-.agent-card:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.45);
+/* And the press puts it back down, slightly compressed — the whole row
+   behaves like one physical control. */
+.agent-card:active {
+  transform: translateY(0) scale(0.985);
+  box-shadow: var(--iw-shadow-1);
+  transition-duration: var(--iw-dur-1);
 }
 
-.dark .agent-card:focus-visible {
-  box-shadow: 0 0 0 2px rgba(147, 197, 253, 0.5);
+.agent-card:focus-visible {
+  outline: none;
+  box-shadow: var(--iw-focus-ring);
 }
 
 /* Selected — the soft baby-blue wash the workspace uses for "you are here" */
@@ -218,13 +230,17 @@ function relativeTime(iso: string): string {
   background: linear-gradient(155deg, rgba(219, 238, 255, 0.9) 0%, rgba(183, 221, 247, 0.45) 100%);
   box-shadow:
     0 1px 2px rgba(30, 58, 138, 0.08),
-    0 3px 8px -3px rgba(30, 58, 138, 0.12),
+    0 4px 12px -5px rgba(30, 58, 138, 0.16),
     inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
 .agent-card--active:hover {
   background: linear-gradient(155deg, rgba(219, 238, 255, 1) 0%, rgba(183, 221, 247, 0.55) 100%);
   border-color: rgba(147, 197, 253, 1);
+  box-shadow:
+    0 2px 4px rgba(30, 58, 138, 0.1),
+    0 10px 24px -10px rgba(30, 58, 138, 0.28),
+    inset 0 1px 0 rgba(255, 255, 255, 0.6);
 }
 
 .dark .agent-card--active,
@@ -238,6 +254,7 @@ function relativeTime(iso: string): string {
 
 .agent-card--archived {
   opacity: 0.72;
+  transition: opacity var(--iw-dur-2) var(--iw-ease-out);
 }
 
 .agent-card--archived:hover {
@@ -253,6 +270,7 @@ function relativeTime(iso: string): string {
   bottom: 0;
   width: 0.1875rem;
   background: var(--rail);
+  transition: background-color var(--iw-dur-3) var(--iw-ease-out);
 }
 
 /* Live run: ink travels down the rail, and the card breathes with the faintest
@@ -267,6 +285,25 @@ function relativeTime(iso: string): string {
   --status: theme('colors.blue.300');
 }
 
+/* The glow the rail casts into the card — light bleeding off a lit edge, so a
+   working agent is legible from the corner of the eye without the row having
+   to shout. Sits under the content (::before on the card itself). */
+.agent-card--working::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 40%;
+  pointer-events: none;
+  background: linear-gradient(90deg, rgba(59, 130, 246, 0.09) 0%, rgba(59, 130, 246, 0) 100%);
+  animation: rail-breathe 3.2s var(--iw-ease-ambient) infinite;
+}
+
+.dark .agent-card--working::before {
+  background: linear-gradient(90deg, rgba(147, 197, 253, 0.1) 0%, rgba(147, 197, 253, 0) 100%);
+}
+
 .agent-card--working .agent-card__rail::after {
   content: '';
   position: absolute;
@@ -278,7 +315,7 @@ function relativeTime(iso: string): string {
     theme('colors.blue.400') 60%,
     transparent 100%
   );
-  animation: rail-travel 2.1s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+  animation: rail-travel 2.6s var(--iw-ease-ambient) infinite;
 }
 
 .dark .agent-card--working .agent-card__rail::after {
@@ -335,7 +372,11 @@ function relativeTime(iso: string): string {
 
 /* ── Contents ───────────────────────────────────────────────────────────── */
 
+/* Above the working card's edge glow, which is absolutely positioned and
+   would otherwise paint over this static content. */
 .agent-card__body {
+  position: relative;
+  z-index: 1;
   flex: 1;
   min-width: 0;
 }
@@ -355,7 +396,7 @@ function relativeTime(iso: string): string {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  transition: color 0.2s ease;
+  transition: color var(--iw-dur-2) var(--iw-ease-out);
 }
 
 .dark .agent-card__title {
@@ -395,6 +436,8 @@ function relativeTime(iso: string): string {
   color: rgba(219, 234, 254, 0.6);
 }
 
+/* "Finished while you were away" — it arrives with a small pop so a card that
+   gains one while you are looking at the list actually announces itself. */
 .agent-card__unread {
   flex-shrink: 0;
   width: 0.375rem;
@@ -403,11 +446,17 @@ function relativeTime(iso: string): string {
   border-radius: 9999px;
   background: theme('colors.blue.950');
   box-shadow: 0 0 0 2px rgba(219, 238, 255, 0.9);
+  animation: unread-in var(--iw-dur-3) var(--iw-ease-spring) both;
 }
 
 .dark .agent-card__unread {
   background: #f3ede2;
   box-shadow: 0 0 0 2px rgba(10, 10, 10, 0.9);
+}
+
+@keyframes unread-in {
+  from { opacity: 0; transform: scale(0.2); }
+  to { opacity: 1; transform: none; }
 }
 
 .agent-card__status {
@@ -418,7 +467,7 @@ function relativeTime(iso: string): string {
   font-size: 0.625rem;
   line-height: 1.35;
   color: var(--status);
-  transition: color 0.2s ease;
+  transition: color var(--iw-dur-3) var(--iw-ease-out);
 }
 
 .agent-card__status-icon {
@@ -451,13 +500,17 @@ function relativeTime(iso: string): string {
 
 /* Quiet until hover — the row is clickable, but it does not advertise it */
 .agent-card__chevron {
+  position: relative;
+  z-index: 1;
   flex-shrink: 0;
   align-self: center;
   font-size: 0.5rem;
   color: rgba(23, 37, 84, 0.3);
   opacity: 0;
-  transform: translateX(-3px);
-  transition: opacity 0.2s ease, transform 0.2s ease;
+  transform: translateX(-4px);
+  transition:
+    opacity var(--iw-dur-2) var(--iw-ease-out),
+    transform var(--iw-dur-2) var(--iw-ease-out);
 }
 
 .dark .agent-card__chevron {
@@ -478,14 +531,15 @@ function relativeTime(iso: string): string {
   100% { transform: translateY(100%); }
 }
 
-@keyframes agent-card-in {
-  from { opacity: 0; transform: translateY(4px); }
-  to { opacity: 1; transform: none; }
+@keyframes rail-breathe {
+  0%, 100% { opacity: 0.55; }
+  50% { opacity: 1; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .agent-card {
+  .agent-card--working::before {
     animation: none;
+    opacity: 0.8;
   }
 
   .agent-card--working .agent-card__rail::after {
@@ -493,7 +547,8 @@ function relativeTime(iso: string): string {
     background: theme('colors.blue.500');
   }
 
-  .agent-card:hover {
+  .agent-card:hover,
+  .agent-card:active {
     transform: none;
   }
 }

--- a/frontend/vuejs/src/apps/imagi/build/components/molecules/sidebar/CheckInQueue.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/molecules/sidebar/CheckInQueue.vue
@@ -49,7 +49,7 @@
               type="button"
               title="Open this task"
               aria-label="Open this task"
-              class="check-in__open"
+              class="check-in__open iw-press"
               @click="emit('view', current)"
             >
               <i class="fas fa-arrow-up-right-from-square text-[9px]"></i>
@@ -93,7 +93,7 @@
               <button
                 type="button"
                 :disabled="!answer.trim()"
-                class="btn-primary flex-1 rounded-full px-2.5 py-1 text-[11px] font-semibold transition-all duration-200"
+                class="btn-primary iw-press flex-1 rounded-full px-2.5 py-1 text-[11px] font-semibold"
                 :class="answer.trim()
                   ? 'btn-primary--active text-[#fdf9f2] dark:text-blue-950'
                   : 'bg-blue-100/60 dark:bg-white/[0.05] text-blue-950/40 dark:text-white/40 cursor-not-allowed border border-blue-200/70 dark:border-white/[0.12]'"
@@ -104,7 +104,7 @@
               <button
                 type="button"
                 title="Deal with this later"
-                class="btn-ghost rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors"
+                class="btn-ghost iw-press rounded-full px-2.5 py-1 text-[11px] font-medium"
                 @click="emit('skip', current)"
               >
                 Later
@@ -120,7 +120,7 @@
             <button
               type="button"
               :disabled="busy"
-              class="btn-primary btn-primary--active flex-1 rounded-full px-2.5 py-1 text-[11px] font-semibold text-[#fdf9f2] dark:text-blue-950 transition-all duration-200 disabled:opacity-50"
+              class="btn-primary btn-primary--active iw-press flex-1 rounded-full px-2.5 py-1 text-[11px] font-semibold text-[#fdf9f2] dark:text-blue-950 disabled:opacity-50"
               @click="emit('accept', current)"
             >
               <i v-if="busy" class="fas fa-circle-notch fa-spin text-[10px]"></i>
@@ -129,7 +129,7 @@
             <button
               type="button"
               :disabled="busy"
-              class="btn-ghost flex-1 rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors disabled:opacity-50"
+              class="btn-ghost iw-press flex-1 rounded-full px-2.5 py-1 text-[11px] font-medium disabled:opacity-50"
               @click="emit('dismiss', current)"
             >
               Discard
@@ -140,14 +140,14 @@
           <div v-else class="flex items-center gap-1.5 mt-2">
             <button
               type="button"
-              class="btn-ghost flex-1 rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors"
+              class="btn-ghost iw-press flex-1 rounded-full px-2.5 py-1 text-[11px] font-medium"
               @click="emit('view', current)"
             >
               See what happened
             </button>
             <button
               type="button"
-              class="btn-ghost flex-1 rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors"
+              class="btn-ghost iw-press flex-1 rounded-full px-2.5 py-1 text-[11px] font-medium"
               @click="emit('skip', current)"
             >
               Dismiss
@@ -294,17 +294,24 @@ function sendAnswer() {
 /* ── The pile ───────────────────────────────────────────────────────────── */
 
 /* Two hairline layers peeking out below the card: the queue has depth, and
-   the depth is worth seeing without opening anything. */
+   the depth is worth seeing without opening anything.
+
+   Both layers are always drawn and revealed by opacity rather than being
+   created by the class — a pseudo-element that springs into existence cannot
+   be transitioned, and the pile gaining a layer should look like something
+   sliding under the card, not like a line appearing from nowhere. */
 .queue-stack {
   position: relative;
+  padding-bottom: 0;
+  transition: padding-bottom var(--iw-dur-3) var(--iw-ease-out);
 }
 
 .queue-stack.is-stacked {
   padding-bottom: 0.3125rem;
 }
 
-.queue-stack.is-stacked::before,
-.queue-stack.is-deep::after {
+.queue-stack::before,
+.queue-stack::after {
   content: '';
   position: absolute;
   left: 0.375rem;
@@ -312,28 +319,43 @@ function sendAnswer() {
   height: 0.625rem;
   border: 1px solid rgba(23, 37, 84, 0.09);
   border-top: none;
-  border-radius: 0 0 0.625rem 0.625rem;
+  border-radius: 0 0 var(--iw-r-md) var(--iw-r-md);
   background: rgba(239, 246, 255, 0.7);
+  opacity: 0;
+  transform: translateY(-0.25rem);
+  transition:
+    opacity var(--iw-dur-3) var(--iw-ease-out),
+    transform var(--iw-dur-3) var(--iw-ease-out);
 }
 
-.dark .queue-stack.is-stacked::before,
-.dark .queue-stack.is-deep::after {
+.dark .queue-stack::before,
+.dark .queue-stack::after {
   border-color: rgba(255, 255, 255, 0.09);
   background: rgba(255, 255, 255, 0.03);
 }
 
-.queue-stack.is-stacked::before {
+.queue-stack::before {
   bottom: 0.0625rem;
   z-index: 1;
 }
 
+.queue-stack.is-stacked::before {
+  opacity: 1;
+  transform: none;
+}
+
 /* The second layer only appears once three or more are queued — it would be a
    lie about the pile's depth otherwise. */
-.queue-stack.is-deep::after {
+.queue-stack::after {
   bottom: -0.125rem;
   left: 0.6875rem;
   right: 0.6875rem;
   z-index: 0;
+}
+
+.queue-stack.is-deep::after {
+  opacity: 1;
+  transform: none;
 }
 
 /* ── The card ───────────────────────────────────────────────────────────── */
@@ -345,11 +367,17 @@ function sendAnswer() {
   position: relative;
   z-index: 2;
   display: flex;
-  border-radius: 0.75rem;
+  border-radius: var(--iw-r-md);
   border: 1px solid rgba(23, 37, 84, 0.1);
   background: rgba(239, 246, 255, 0.75);
+  box-shadow: var(--iw-shadow-1);
   overflow: hidden;
-  animation: check-in-arrive 0.4s cubic-bezier(0.22, 1, 0.36, 1) both;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  animation: check-in-arrive var(--iw-dur-4) var(--iw-ease-spring) both;
+  transition:
+    border-color var(--iw-dur-3) var(--iw-ease-out),
+    background-color var(--iw-dur-3) var(--iw-ease-out);
 }
 
 .dark .check-in {
@@ -436,9 +464,17 @@ function sendAnswer() {
   width: 1.25rem;
   height: 1.25rem;
   margin: -0.0625rem -0.125rem 0 0;
-  border-radius: 0.375rem;
+  border-radius: var(--iw-r-xs);
   color: rgba(23, 37, 84, 0.35);
-  transition: background-color 0.18s ease, color 0.18s ease;
+  transition:
+    background-color var(--iw-dur-2) var(--iw-ease-out),
+    color var(--iw-dur-2) var(--iw-ease-out),
+    transform var(--iw-dur-1) var(--iw-ease-out);
+}
+
+.check-in__open:focus-visible {
+  outline: none;
+  box-shadow: var(--iw-focus-ring);
 }
 
 .check-in__open:hover {
@@ -487,7 +523,7 @@ function sendAnswer() {
   font-size: 0.625rem;
   font-weight: 500;
   color: rgba(23, 37, 84, 0.45);
-  transition: color 0.18s ease;
+  transition: color var(--iw-dur-2) var(--iw-ease-out);
 }
 
 .check-in__more:hover {
@@ -503,9 +539,11 @@ function sendAnswer() {
 }
 
 /* A check-in lands rather than blinks — the card is keyed on the check-in id,
-   so each new one plays this as it takes the front of the queue. */
+   so each new one plays this as it takes the front of the queue. It rises
+   slightly out of the pile it was waiting in, which is where the next one
+   genuinely comes from. */
 @keyframes check-in-arrive {
-  from { opacity: 0; transform: translateY(-4px); }
+  from { opacity: 0; transform: translateY(6px) scale(0.97); }
   to { opacity: 1; transform: none; }
 }
 
@@ -515,35 +553,42 @@ function sendAnswer() {
 
 /* ── Buttons (the workspace's navy-ink pairing, unchanged) ──────────────── */
 
+/* Both buttons share one transition contract, so the pair reacts as a pair —
+   .iw-press supplies the scale under the pointer on top of this. */
+.btn-primary,
+.btn-ghost {
+  transition:
+    background-color var(--iw-dur-2) var(--iw-ease-out),
+    border-color var(--iw-dur-2) var(--iw-ease-out),
+    color var(--iw-dur-2) var(--iw-ease-out),
+    box-shadow var(--iw-dur-2) var(--iw-ease-out),
+    opacity var(--iw-dur-2) var(--iw-ease-out),
+    transform var(--iw-dur-1) var(--iw-ease-out);
+}
+
+.btn-primary:focus-visible,
+.btn-ghost:focus-visible {
+  outline: none;
+  box-shadow: var(--iw-focus-ring);
+}
+
 /* Navy ink primary - matching the composer's send button */
 .btn-primary--active {
   background: theme('colors.blue.950');
-  box-shadow:
-    0 1px 2px rgba(23, 37, 84, 0.2),
-    0 3px 8px -2px rgba(23, 37, 84, 0.25),
-    inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  box-shadow: var(--iw-shadow-2), inset 0 1px 0 rgba(255, 255, 255, 0.12);
 }
 
 .btn-primary--active:hover:not(:disabled) {
   background: theme('colors.blue.900');
-  box-shadow:
-    0 2px 3px rgba(23, 37, 84, 0.22),
-    0 5px 12px -2px rgba(23, 37, 84, 0.3),
-    inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  box-shadow: var(--iw-shadow-3), inset 0 1px 0 rgba(255, 255, 255, 0.12);
 }
 
 .dark .btn-primary--active {
   background: #f3ede2;
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.4),
-    0 3px 8px -2px rgba(0, 0, 0, 0.45);
 }
 
 .dark .btn-primary--active:hover:not(:disabled) {
   background: #ffffff;
-  box-shadow:
-    0 2px 3px rgba(0, 0, 0, 0.4),
-    0 5px 12px -2px rgba(0, 0, 0, 0.5);
 }
 
 /* Ghost secondary - quiet outline that only tints on hover */
@@ -555,6 +600,7 @@ function sendAnswer() {
 
 .btn-ghost:hover:not(:disabled) {
   background: rgba(239, 246, 255, 0.9);
+  border-color: rgba(147, 197, 253, 0.9);
   color: rgb(23, 37, 84);
 }
 
@@ -585,13 +631,18 @@ function sendAnswer() {
   background: rgba(245, 158, 11, 0.12);
 }
 
+/* Focus is a ring rather than a border swap: the field's edge stays where it
+   was and gains a halo, so nothing shifts by a pixel as you click into it. */
 .answer-textarea {
-  transition: border-color 0.18s ease;
+  transition:
+    border-color var(--iw-dur-2) var(--iw-ease-out),
+    box-shadow var(--iw-dur-2) var(--iw-ease-out);
   outline: none;
 }
 
 .answer-textarea:focus {
   border-color: rgba(23, 37, 84, 0.45);
+  box-shadow: 0 0 0 3px rgba(var(--iw-accent), 0.14);
 }
 
 .dark .answer-textarea:focus {

--- a/frontend/vuejs/src/apps/imagi/build/components/molecules/sidebar/WorkspacePaneHeader.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/molecules/sidebar/WorkspacePaneHeader.vue
@@ -20,7 +20,16 @@
 
     <div class="flex-1 min-w-0">
       <h2 class="pane-title truncate">{{ title }}</h2>
-      <p v-if="status" class="pane-status truncate">{{ status }}</p>
+      <!-- The status line is the most-changing text in the workspace ("Reading
+           files…" → "Editing…" → "Ready when you are"). Swapping it in place
+           reads as a flicker; cross-fading reads as the same line being
+           updated, which is what it is. Keyed on the text so each new reading
+           gets its own fade. -->
+      <div v-if="status" class="pane-status-line">
+        <Transition name="pane-status" mode="out-in">
+          <p :key="status" class="pane-status truncate">{{ status }}</p>
+        </Transition>
+      </div>
     </div>
 
     <!-- Desktop pane switch. Mobile navigates from the navbar switcher, so
@@ -28,7 +37,7 @@
     <button
       v-if="switchLabel"
       type="button"
-      class="pane-switch group max-md:hidden"
+      class="pane-switch iw-press group max-md:hidden"
       :aria-label="`Switch to ${switchLabel}`"
       @click="emit('switch')"
     >
@@ -44,8 +53,12 @@
         <span v-if="switchLive" class="pane-switch-pulse" aria-hidden="true"></span>
       </span>
       <span class="pane-switch-label">{{ switchLabel }}</span>
-      <!-- Ambient count of what is waiting on the other side -->
-      <span v-if="switchCount" class="pane-switch-count">{{ switchCount }}</span>
+      <!-- Ambient count of what is waiting on the other side. Keyed on the
+           number so it springs when the fleet grows instead of silently
+           becoming a different digit. -->
+      <Transition name="pane-count" mode="out-in">
+        <span v-if="switchCount" :key="switchCount" class="pane-switch-count">{{ switchCount }}</span>
+      </Transition>
       <i
         v-if="switchDirection === 'forward'"
         class="fas fa-chevron-right pane-switch-chevron"
@@ -81,16 +94,46 @@ const emit = defineEmits<{ (e: 'switch'): void }>()
 </script>
 
 <style scoped>
-/* The plate: a hairline rule plus the faintest wash, so the header reads as
-   its own surface rather than the transcript's first row. */
+/* The plate: a translucent material rather than a painted strip. The pane
+   scrolls beneath it, so the masthead takes its colour from whatever is
+   passing underneath — saturated and blurred past legibility — and closes
+   with a true hairline. This is what keeps the header feeling like a layer
+   above the transcript instead of its first row. */
 .pane-header {
-  background: linear-gradient(180deg, rgba(239, 246, 255, 0.5) 0%, rgba(239, 246, 255, 0) 100%);
-  border-bottom: 1px solid rgba(23, 37, 84, 0.08);
+  position: relative;
+  z-index: 20;
+  background: var(--iw-material-bg);
+  -webkit-backdrop-filter: var(--iw-material-filter);
+  backdrop-filter: var(--iw-material-filter);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
-.dark .pane-header {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.035) 0%, rgba(255, 255, 255, 0) 100%);
-  border-bottom-color: rgba(255, 255, 255, 0.12);
+/* The separator is drawn rather than bordered: at 1px a border rounds up to a
+   full device pixel on retina and reads as a line; a scaled pseudo-element
+   stays a true hairline at any density. */
+.pane-header::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 1px;
+  background: var(--iw-hairline);
+  transform: scaleY(0.5);
+  transform-origin: bottom;
+}
+
+/* No backdrop-filter (older Firefox, some Linux GPUs): fall back to the
+   opaque wash the header used to carry, so it never turns see-through. */
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .pane-header {
+    background: linear-gradient(180deg, rgba(239, 246, 255, 0.92) 0%, rgba(239, 246, 255, 0.6) 100%);
+  }
+
+  .dark .pane-header {
+    background: linear-gradient(180deg, rgba(24, 24, 27, 0.96) 0%, rgba(18, 18, 20, 0.85) 100%);
+  }
 }
 
 /* Mark: navy ink for the thread you drive, a quiet tint for panes you watch */
@@ -100,8 +143,11 @@ const emit = defineEmits<{ (e: 'switch'): void }>()
   justify-content: center;
   width: 1.875rem;
   height: 1.875rem;
-  border-radius: 0.625rem;
-  transition: transform 0.18s ease, box-shadow 0.18s ease;
+  border-radius: var(--iw-r-md);
+  transition:
+    transform var(--iw-dur-2) var(--iw-ease-spring),
+    box-shadow var(--iw-dur-2) var(--iw-ease-out),
+    background-color var(--iw-dur-2) var(--iw-ease-out);
 }
 
 .pane-mark--primary {
@@ -109,8 +155,8 @@ const emit = defineEmits<{ (e: 'switch'): void }>()
   color: #fdf9f2;
   box-shadow:
     0 1px 2px rgba(23, 37, 84, 0.22),
-    0 3px 8px -3px rgba(23, 37, 84, 0.28),
-    inset 0 1px 0 rgba(255, 255, 255, 0.14);
+    0 4px 12px -4px rgba(23, 37, 84, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.16);
 }
 
 .dark .pane-mark--primary {
@@ -118,7 +164,7 @@ const emit = defineEmits<{ (e: 'switch'): void }>()
   color: theme('colors.blue.950');
   box-shadow:
     0 1px 2px rgba(0, 0, 0, 0.4),
-    0 3px 8px -3px rgba(0, 0, 0, 0.45);
+    0 4px 12px -4px rgba(0, 0, 0, 0.5);
 }
 
 .pane-mark--muted {
@@ -133,7 +179,10 @@ const emit = defineEmits<{ (e: 'switch'): void }>()
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
-/* Live-run dot, ringed against the header so it reads on either surface */
+/* Live-run dot, ringed against the header so it reads on either surface. The
+   dot itself holds steady — a marker that flickers looks like a rendering
+   fault — and a halo breathes outward from under it. Reads as a signal
+   radiating rather than a light being switched. */
 .pane-pulse {
   position: absolute;
   right: -1px;
@@ -142,23 +191,41 @@ const emit = defineEmits<{ (e: 'switch'): void }>()
   height: 0.5rem;
   border-radius: 9999px;
   background: theme('colors.blue.500');
-  box-shadow: 0 0 0 2px #ffffff;
-  animation: pane-pulse 1.8s ease-in-out infinite;
+  box-shadow: 0 0 0 2px rgba(var(--iw-surface), 1);
+  animation: pane-pulse-core 2.4s var(--iw-ease-ambient) infinite;
+}
+
+.pane-pulse::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 9999px;
+  background: inherit;
+  animation: pane-pulse-halo 2.4s var(--iw-ease-ambient) infinite;
 }
 
 .dark .pane-pulse {
   background: theme('colors.blue.300');
-  box-shadow: 0 0 0 2px #0a0a0a;
 }
 
-@keyframes pane-pulse {
-  0%, 100% { opacity: 1; transform: scale(1); }
-  50% { opacity: 0.55; transform: scale(0.86); }
+@keyframes pane-pulse-core {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.78; }
+}
+
+@keyframes pane-pulse-halo {
+  0% { opacity: 0.45; transform: scale(1); }
+  70%, 100% { opacity: 0; transform: scale(2.4); }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .pane-pulse,
-  .pane-switch-pulse { animation: none; }
+  .pane-pulse::after,
+  .pane-switch-pulse,
+  .pane-switch-pulse::after { animation: none; }
+
+  .pane-pulse::after,
+  .pane-switch-pulse::after { opacity: 0; }
 }
 
 /* The name carries the brand serif (Fraunces) — the same face as the Imagi
@@ -179,6 +246,12 @@ const emit = defineEmits<{ (e: 'switch'): void }>()
   color: rgba(255, 255, 255, 0.94);
 }
 
+/* Reserves the line's height so the masthead never resizes underneath a
+   cross-fade — the two readings swap inside a box that does not move. */
+.pane-status-line {
+  min-height: 0.9375rem;
+}
+
 .pane-status {
   margin-top: 0.0625rem;
   font-size: 0.65625rem;
@@ -191,7 +264,28 @@ const emit = defineEmits<{ (e: 'switch'): void }>()
   color: rgba(219, 234, 254, 0.45);
 }
 
-/* Switch: names its destination instead of hiding behind a tooltip */
+/* One reading giving way to the next: down and out, up and in — the direction
+   of a line being replaced from below. */
+.pane-status-enter-active,
+.pane-status-leave-active {
+  transition:
+    opacity var(--iw-dur-1) var(--iw-ease-out),
+    transform var(--iw-dur-1) var(--iw-ease-out);
+}
+
+.pane-status-enter-from {
+  opacity: 0;
+  transform: translateY(3px);
+}
+
+.pane-status-leave-to {
+  opacity: 0;
+  transform: translateY(-3px);
+}
+
+/* Switch: names its destination instead of hiding behind a tooltip. Rests
+   flush with the masthead and lifts on hover — a control that comes to meet
+   the pointer, then gives under the press (.iw-press). */
 .pane-switch {
   display: inline-flex;
   align-items: center;
@@ -205,23 +299,33 @@ const emit = defineEmits<{ (e: 'switch'): void }>()
   font-size: 0.6875rem;
   font-weight: 500;
   cursor: pointer;
-  transition: background-color 0.18s ease, border-color 0.18s ease, color 0.18s ease, transform 0.18s ease;
+  box-shadow: var(--iw-shadow-1);
+  transition:
+    background-color var(--iw-dur-2) var(--iw-ease-out),
+    border-color var(--iw-dur-2) var(--iw-ease-out),
+    color var(--iw-dur-2) var(--iw-ease-out),
+    box-shadow var(--iw-dur-2) var(--iw-ease-out),
+    transform var(--iw-dur-2) var(--iw-ease-out);
 }
 
 .pane-switch:hover {
   background: #ffffff;
-  border-color: rgba(23, 37, 84, 0.2);
+  border-color: rgba(23, 37, 84, 0.18);
   color: theme('colors.blue.950');
+  box-shadow: var(--iw-shadow-2);
   transform: translateY(-1px);
 }
 
+/* .iw-press owns the pressed scale; the lift simply returns to rest under it */
 .pane-switch:active {
-  transform: translateY(0);
+  transform: translateY(0) scale(0.97);
+  box-shadow: var(--iw-shadow-1);
+  transition-duration: var(--iw-dur-1);
 }
 
 .pane-switch:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px rgba(59, 130, 246, 0.4);
+  box-shadow: var(--iw-focus-ring);
 }
 
 .dark .pane-switch {
@@ -236,10 +340,6 @@ const emit = defineEmits<{ (e: 'switch'): void }>()
   color: #ffffff;
 }
 
-.dark .pane-switch:focus-visible {
-  box-shadow: 0 0 0 2px #0a0a0a, 0 0 0 4px rgba(147, 197, 253, 0.5);
-}
-
 .pane-switch-icon-wrap {
   position: relative;
   display: inline-flex;
@@ -249,6 +349,11 @@ const emit = defineEmits<{ (e: 'switch'): void }>()
 .pane-switch-icon {
   font-size: 0.625rem;
   opacity: 0.7;
+  transition: opacity var(--iw-dur-2) var(--iw-ease-out);
+}
+
+.pane-switch:hover .pane-switch-icon {
+  opacity: 0.95;
 }
 
 /* Same pulse as the pane mark, sized down for the switch icon — the link to a
@@ -261,19 +366,29 @@ const emit = defineEmits<{ (e: 'switch'): void }>()
   height: 0.375rem;
   border-radius: 9999px;
   background: theme('colors.blue.500');
-  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.9);
-  animation: pane-pulse 1.8s ease-in-out infinite;
+  box-shadow: 0 0 0 2px rgba(var(--iw-surface), 0.9);
+  animation: pane-pulse-core 2.4s var(--iw-ease-ambient) infinite;
+}
+
+.pane-switch-pulse::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 9999px;
+  background: inherit;
+  animation: pane-pulse-halo 2.4s var(--iw-ease-ambient) infinite;
 }
 
 .dark .pane-switch-pulse {
   background: theme('colors.blue.300');
-  box-shadow: 0 0 0 2px rgba(10, 10, 10, 0.9);
 }
 
 .pane-switch-chevron {
   font-size: 0.5rem;
   opacity: 0.45;
-  transition: transform 0.18s ease, opacity 0.18s ease;
+  transition:
+    transform var(--iw-dur-2) var(--iw-ease-out),
+    opacity var(--iw-dur-2) var(--iw-ease-out);
 }
 
 .pane-switch:hover .pane-switch-chevron {
@@ -281,11 +396,11 @@ const emit = defineEmits<{ (e: 'switch'): void }>()
 }
 
 .group:hover .fa-chevron-right.pane-switch-chevron {
-  transform: translateX(1px);
+  transform: translateX(2px);
 }
 
 .group:hover .fa-chevron-left.pane-switch-chevron {
-  transform: translateX(-1px);
+  transform: translateX(-2px);
 }
 
 .pane-switch-label {
@@ -313,5 +428,29 @@ const emit = defineEmits<{ (e: 'switch'): void }>()
 .dark .pane-switch-count {
   background: #f3ede2;
   color: theme('colors.blue.950');
+}
+
+/* The badge springs in rather than appearing already there — the one place in
+   the masthead where a change in the number is itself the news. */
+.pane-count-enter-active {
+  transition:
+    opacity var(--iw-dur-2) var(--iw-ease-out),
+    transform var(--iw-dur-2) var(--iw-ease-spring);
+}
+
+.pane-count-leave-active {
+  transition:
+    opacity var(--iw-dur-1) var(--iw-ease-out),
+    transform var(--iw-dur-1) var(--iw-ease-out);
+}
+
+.pane-count-enter-from {
+  opacity: 0;
+  transform: scale(0.5);
+}
+
+.pane-count-leave-to {
+  opacity: 0;
+  transform: scale(0.7);
 }
 </style>

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/chat/ChatConversation.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/chat/ChatConversation.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="h-full flex flex-col relative z-10 transition-colors duration-300" :class="{'mode-transition': disableAllAnimations}">
     <!-- Messages Container -->
-    <div ref="messagesContainer" class="flex-grow overflow-y-auto overflow-x-hidden px-4 py-6">
+    <div ref="messagesContainer" class="iw-scroll iw-surface flex-grow overflow-y-auto overflow-x-hidden px-4 py-6">
       <!-- Empty state: one quiet line, nothing to dismiss or click -->
       <div v-if="!processedMessages.length" class="h-full flex items-center justify-center px-6 py-4 text-center min-h-0">
         <p class="text-xs text-blue-950/45 dark:text-blue-100/45 max-w-[230px] leading-relaxed">
@@ -16,7 +16,7 @@
             <div v-if="message.role === 'user'"
               class="msg-row user-row group flex flex-col items-end"
               :class="{ 'animate-message-in': message.isNew }"
-              :style="message.isNew ? { 'animation-delay': `${index * 0.05}s` } : {}">
+              :style="message.isNew ? { 'animation-delay': `${message.enterDelay}ms` } : {}">
               <div class="user-bubble">
                 <p class="whitespace-pre-wrap break-words text-sm leading-relaxed">{{ message.content }}</p>
               </div>
@@ -29,7 +29,7 @@
               <button
                 v-if="message.checkpoint && message.dbId && restoreAllowed"
                 type="button"
-                class="restore-chip mt-1 inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-medium text-blue-950/40 dark:text-white/35 hover:text-blue-950/75 dark:hover:text-white/75 hover:bg-blue-50/80 dark:hover:bg-white/[0.06] opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity duration-150"
+                class="restore-chip mt-1 inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-medium text-blue-950/40 dark:text-white/35 hover:text-blue-950/75 dark:hover:text-white/75 hover:bg-blue-50/80 dark:hover:bg-white/[0.06] opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
                 title="Restore your app and this conversation to the moment before this message"
                 @click="emit('restore-checkpoint', message)"
               >
@@ -42,7 +42,7 @@
             <div v-else-if="message.role === 'assistant'"
               class="msg-row assistant-response"
               :class="{ 'animate-message-in': message.isNew }"
-              :style="message.isNew ? { 'animation-delay': `${index * 0.05}s` } : {}">
+              :style="message.isNew ? { 'animation-delay': `${message.enterDelay}ms` } : {}">
               <AgentActivityFeed
                 v-if="message.activity?.length"
                 :steps="message.activity"
@@ -67,7 +67,7 @@
                   v-for="task in message.dispatchedTasks"
                   :key="task.conversationId"
                   type="button"
-                  class="dispatch-card group flex items-start gap-2.5 w-full rounded-xl border border-blue-950/[0.08] dark:border-white/[0.12] bg-blue-50/50 dark:bg-white/[0.04] px-3 py-2 text-left transition-colors hover:bg-blue-100/60 dark:hover:bg-white/[0.07]"
+                  class="dispatch-card group flex items-start gap-2.5 w-full border border-blue-950/[0.08] dark:border-white/[0.12] bg-blue-50/50 dark:bg-white/[0.04] px-3 py-2 text-left hover:bg-blue-100/60 dark:hover:bg-white/[0.07]"
                   :title="`Open this subagent's thread`"
                   @click="emit('open-task', task.conversationId)"
                 >
@@ -91,7 +91,7 @@
                       {{ dispatchSummary(task.conversationId) }}
                     </span>
                   </span>
-                  <i class="fas fa-chevron-right text-[10px] mt-0.5 text-blue-950/30 dark:text-white/30 group-hover:text-blue-950/60 dark:group-hover:text-white/60 transition-colors shrink-0"></i>
+                  <i class="fas fa-chevron-right dispatch-chevron text-[10px] mt-0.5 text-blue-950/30 dark:text-white/30 group-hover:text-blue-950/60 dark:group-hover:text-white/60 shrink-0"></i>
                 </button>
               </div>
               <div v-if="message.filesChanged?.length" class="mt-2">
@@ -119,7 +119,7 @@
             <div v-else-if="message.role === 'system'"
               class="msg-row flex justify-center"
               :class="{ 'animate-fade-in': message.isNew }"
-              :style="message.isNew ? { 'animation-delay': `${index * 0.05}s` } : {}">
+              :style="message.isNew ? { 'animation-delay': `${message.enterDelay}ms` } : {}">
               <span class="text-xs text-blue-950/40 dark:text-blue-100/40 px-3 py-1">{{ message.content }}</span>
             </div>
 
@@ -127,19 +127,27 @@
             <div v-else
               class="msg-row flex justify-center"
               :class="{ 'animate-message-in': message.isNew }"
-              :style="message.isNew ? { 'animation-delay': `${index * 0.05}s` } : {}">
+              :style="message.isNew ? { 'animation-delay': `${message.enterDelay}ms` } : {}">
               <span class="text-xs text-blue-950/40 dark:text-blue-100/40 px-3 py-1">{{ message.content }}</span>
             </div>
           </template>
 
           <!-- Agent activity indicator. Hidden while the reply itself is
-               streaming in — the growing message already shows progress. -->
-          <div v-if="showActivityIndicator" class="msg-row assistant-response animate-fade-in">
-            <div class="agent-status flex items-center gap-2.5">
-              <span class="status-orb"></span>
-              <span class="status-shimmer text-sm font-medium">{{ props.statusText || 'Working…' }}</span>
+               streaming in — the growing message already shows progress.
+               It fades both ways: when the reply starts arriving this hands
+               over to the text rather than vanishing out from under it. -->
+          <Transition name="status">
+            <div v-if="showActivityIndicator" class="msg-row assistant-response">
+              <div class="agent-status flex items-center gap-2.5">
+                <span class="status-orb"></span>
+                <!-- Keyed on the reading so each new step cross-fades in
+                     place, the same way the pane masthead's status does. -->
+                <Transition name="status-text" mode="out-in">
+                  <span :key="statusLabel" class="status-shimmer text-sm font-medium">{{ statusLabel }}</span>
+                </Transition>
+              </div>
             </div>
-          </div>
+          </Transition>
         </div>
       </template>
     </div>
@@ -164,6 +172,8 @@ marked.setOptions({
 interface ProcessedMessage extends AIMessage {
   isNew?: boolean;
   isTyping?: boolean;
+  /** Milliseconds this message waits before playing its entrance */
+  enterDelay?: number;
 }
 
 const props = defineProps<{
@@ -193,6 +203,10 @@ const showActivityIndicator = computed(() => {
   const last = props.messages[props.messages.length - 1]
   return !(last?.role === 'assistant' && (last.content || '').trim().length > 0)
 })
+
+/** The indicator's current reading, with the generic fallback applied once so
+ *  the cross-fade keys off the text actually on screen. */
+const statusLabel = computed(() => props.statusText || 'Working…')
 
 const emit = defineEmits<{
   (e: 'apply-code', code: string): void
@@ -234,17 +248,31 @@ const messagesContainer = ref<HTMLElement | null>(null)
 const previousMessageCount = ref(0)
 const disableAllAnimations = ref(false)
 
+/** How far apart consecutive arrivals are spaced, and how many get spaced. */
+const ENTER_STAGGER_MS = 60
+const ENTER_STAGGER_MAX = 4
+
 // Process messages to add isNew flag for animations
 const processedMessages = computed<ProcessedMessage[]>(() => {
+  const firstNew = previousMessageCount.value
   return props.messages.map((message, index) => {
     // Only mark messages as new if they're newly added and animations
     // aren't globally disabled
-    const isNew = (index >= previousMessageCount.value)
-      && !disableAllAnimations.value;
+    const isNew = (index >= firstNew) && !disableAllAnimations.value;
+
+    // The stagger counts from the first *new* message, not from the top of
+    // the conversation. Keyed off the absolute index it grew with the
+    // transcript — message 40 of a long thread waited two seconds to fade in,
+    // which read as the reply having stalled. Capped as well, so a batch
+    // arriving at once still resolves promptly.
+    const enterDelay = isNew
+      ? Math.min(index - firstNew, ENTER_STAGGER_MAX) * ENTER_STAGGER_MS
+      : 0;
 
     return {
       ...message,
-      isNew
+      isNew,
+      enterDelay
     };
   });
 });
@@ -420,11 +448,59 @@ const copyToClipboard = (code: string) => {
   margin-top: 1rem;
 }
 
+/* A subagent handed off mid-reply. It is the one clickable object inside the
+   transcript, so it behaves like the cards in the crew ledger do: rises to
+   meet the pointer, gives under the press. */
+.dispatch-card {
+  border-radius: var(--iw-r-lg);
+  transition:
+    background-color var(--iw-dur-2) var(--iw-ease-out),
+    border-color var(--iw-dur-2) var(--iw-ease-out),
+    box-shadow var(--iw-dur-2) var(--iw-ease-out),
+    transform var(--iw-dur-2) var(--iw-ease-out);
+}
+
+.dispatch-card:hover {
+  border-color: rgba(23, 37, 84, 0.14);
+  box-shadow: var(--iw-shadow-2);
+  transform: translateY(-1px);
+}
+
+.dark .dispatch-card:hover {
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.dispatch-card:active {
+  transform: translateY(0) scale(0.99);
+  box-shadow: var(--iw-shadow-1);
+  transition-duration: var(--iw-dur-1);
+}
+
+.dispatch-card:focus-visible {
+  outline: none;
+  box-shadow: var(--iw-focus-ring);
+}
+
+.dispatch-chevron {
+  transition:
+    color var(--iw-dur-2) var(--iw-ease-out),
+    transform var(--iw-dur-2) var(--iw-ease-out);
+}
+
+.dispatch-card:hover .dispatch-chevron {
+  transform: translateX(2px);
+}
+
 /* Dispatch-card chip: same navy-ink / cream pairing as the check-in queue. */
 .dispatch-chip {
   background: rgba(23, 37, 84, 0.08);
   box-shadow: inset 0 0 0 1px rgba(23, 37, 84, 0.06);
   color: rgba(23, 37, 84, 0.8);
+  transition: background-color var(--iw-dur-2) var(--iw-ease-out);
+}
+
+.dispatch-card:hover .dispatch-chip {
+  background: rgba(23, 37, 84, 0.12);
 }
 
 .dark .dispatch-chip {
@@ -433,8 +509,25 @@ const copyToClipboard = (code: string) => {
   color: rgba(243, 237, 226, 0.9);
 }
 
+.dark .dispatch-card:hover .dispatch-chip {
+  background: rgba(243, 237, 226, 0.18);
+}
+
 .msg-row + .user-row {
   margin-top: 2rem;
+}
+
+/* Quiet until the turn is hovered, then it fades up in place. */
+.restore-chip {
+  transition:
+    opacity var(--iw-dur-2) var(--iw-ease-out),
+    background-color var(--iw-dur-2) var(--iw-ease-out),
+    color var(--iw-dur-2) var(--iw-ease-out);
+}
+
+.restore-chip:focus-visible {
+  outline: none;
+  box-shadow: var(--iw-focus-ring);
 }
 
 /* Touch screens have no hover: keep the restore chip faintly visible so the
@@ -449,10 +542,11 @@ const copyToClipboard = (code: string) => {
 .user-bubble {
   max-width: 85%;
   padding: 0.625rem 0.875rem;
-  border-radius: 1rem;
-  border-bottom-right-radius: 0.375rem;
+  border-radius: var(--iw-r-lg);
+  border-bottom-right-radius: var(--iw-r-xs);
   background-color: theme('colors.blue.50');
   border: 1px solid rgba(191, 219, 254, 0.6);
+  box-shadow: var(--iw-shadow-1);
   color: theme('colors.blue.950');
   /* Long unbroken strings (paths, URLs) wrap instead of widening the chat
      and dragging in a horizontal scrollbar. */
@@ -493,7 +587,7 @@ const copyToClipboard = (code: string) => {
 .prose :deep(pre) {
   background: rgba(239, 246, 255, 0.6);
   border: 1px solid theme('colors.blue.100');
-  border-radius: 0.625rem;
+  border-radius: var(--iw-r-md);
   padding: 0.75rem 0.875rem;
   margin: 0.75rem 0;
   overflow-x: auto;
@@ -596,15 +690,16 @@ const copyToClipboard = (code: string) => {
   margin-bottom: 0.5rem;
 }
 
-/* Message animations */
+/* Message animations. A message settles up into place with a trace of
+   overshoot — closer to something being set down than to a fade. */
 @keyframes message-in {
   from {
     opacity: 0;
-    transform: translateY(12px);
+    transform: translateY(10px) scale(0.99);
   }
   to {
     opacity: 1;
-    transform: translateY(0);
+    transform: none;
   }
 }
 
@@ -618,69 +713,84 @@ const copyToClipboard = (code: string) => {
 }
 
 .animate-message-in {
-  animation: message-in 0.3s ease-out forwards;
+  animation: message-in var(--iw-dur-3) var(--iw-ease-spring) both;
 }
 
 .animate-fade-in {
-  animation: fade-in 0.3s ease-out forwards;
+  animation: fade-in var(--iw-dur-3) var(--iw-ease-out) both;
 }
 
-/* Minimal scrollbar */
-.overflow-y-auto {
-  scrollbar-width: thin;
+/* The indicator hands over to the streaming reply rather than blinking out */
+.status-enter-active,
+.status-leave-active {
+  transition:
+    opacity var(--iw-dur-2) var(--iw-ease-out),
+    transform var(--iw-dur-2) var(--iw-ease-out);
 }
 
-.overflow-y-auto::-webkit-scrollbar {
-  width: 6px;
+.status-enter-from,
+.status-leave-to {
+  opacity: 0;
+  transform: translateY(4px);
 }
 
-.overflow-y-auto::-webkit-scrollbar-track {
-  background: transparent;
+/* And each reading of it cross-fades in place */
+.status-text-enter-active,
+.status-text-leave-active {
+  transition:
+    opacity var(--iw-dur-1) var(--iw-ease-out),
+    transform var(--iw-dur-1) var(--iw-ease-out);
 }
 
-.overflow-y-auto::-webkit-scrollbar-thumb {
-  background: rgba(0, 0, 0, 0.1);
-  border-radius: 3px;
+.status-text-enter-from {
+  opacity: 0;
+  transform: translateY(3px);
 }
 
-.overflow-y-auto::-webkit-scrollbar-thumb:hover {
-  background: rgba(0, 0, 0, 0.15);
+.status-text-leave-to {
+  opacity: 0;
+  transform: translateY(-3px);
 }
 
-:root.dark .overflow-y-auto::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.1);
-}
-
-:root.dark .overflow-y-auto::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.15);
-}
-
-/* Agent activity indicator: a softly breathing orb next to status text with
-   a light shimmer sweeping across it. */
+/* Agent activity indicator: a lit orb radiating a halo, next to status text
+   with a shimmer sweeping across it. Same construction as the pane
+   masthead's live dot — the orb holds steady while the halo travels — so
+   "something is running" looks identical wherever it is reported. */
 .status-orb {
+  position: relative;
   flex-shrink: 0;
   width: 8px;
   height: 8px;
   border-radius: 50%;
   background: radial-gradient(circle at 30% 30%, #93c5fd, #3b82f6);
-  box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.35);
-  animation: orb-breathe 2s ease-in-out infinite;
+  animation: orb-breathe 2.4s var(--iw-ease-ambient) infinite;
+}
+
+.status-orb::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: theme('colors.blue.500');
+  animation: orb-halo 2.4s var(--iw-ease-ambient) infinite;
 }
 
 .dark .status-orb {
   background: radial-gradient(circle at 30% 30%, #bfdbfe, #60a5fa);
-  box-shadow: 0 0 0 0 rgba(147, 197, 253, 0.3);
+}
+
+.dark .status-orb::after {
+  background: theme('colors.blue.300');
 }
 
 @keyframes orb-breathe {
-  0%, 100% {
-    transform: scale(0.9);
-    box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.35);
-  }
-  50% {
-    transform: scale(1);
-    box-shadow: 0 0 0 5px rgba(59, 130, 246, 0);
-  }
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.8; }
+}
+
+@keyframes orb-halo {
+  0% { opacity: 0.4; transform: scale(1); }
+  70%, 100% { opacity: 0; transform: scale(2.6); }
 }
 
 .status-shimmer {
@@ -718,10 +828,15 @@ const copyToClipboard = (code: string) => {
 
 @media (prefers-reduced-motion: reduce) {
   .status-orb,
+  .status-orb::after,
   .status-shimmer,
   .animate-message-in,
   .animate-fade-in {
     animation: none;
+  }
+
+  .status-orb::after {
+    opacity: 0;
   }
 
   .status-shimmer {

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/AgentManagerPanel.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/AgentManagerPanel.vue
@@ -8,11 +8,17 @@
   agent's check-in queue, so this pane's whole job is legibility.
 -->
 <template>
-  <div class="flex flex-col h-full bg-white dark:bg-[#0a0a0a] transition-colors duration-300">
+  <div class="iw-surface relative overflow-hidden h-full bg-white dark:bg-[#0a0a0a] transition-colors duration-300">
+    <!-- Opening a subagent is a navigation, so it moves like one: the list
+         slides out to the left as the thread comes in from the right, and
+         back the other way on the return. The leaving pane is taken out of
+         flow (see .pane-nav-leave-active) so the two cross in place rather
+         than one waiting for the other to finish. -->
+    <Transition :name="opened ? 'pane-nav-push' : 'pane-nav-pop'">
     <!-- Reading one subagent's thread. It happens here rather than in the chat
          pane on purpose: a subagent is something you look in on, so opening one
          must not displace the thread you are actually talking in. -->
-    <template v-if="opened">
+    <div v-if="opened" key="opened" class="pane-nav-view flex flex-col h-full">
       <WorkspacePaneHeader
         icon="fas fa-robot"
         tone="muted"
@@ -49,16 +55,16 @@
           </p>
           <button
             type="button"
-            class="btn-back mt-2 w-full rounded-full px-3 py-1.5 text-[11px] font-semibold text-[#fdf9f2] dark:text-blue-950 transition-all duration-200"
+            class="btn-back iw-press mt-2 w-full rounded-full px-3 py-1.5 text-[11px] font-semibold text-[#fdf9f2] dark:text-blue-950"
             @click="closeOpened"
           >
             Back to subagents
           </button>
         </div>
       </div>
-    </template>
+    </div>
 
-    <template v-else>
+    <div v-else key="list" class="pane-nav-view flex flex-col h-full">
     <!-- Header: the same plate the chat pane wears, switching back the other
          way. The status line reports the fleet, which is what the removed
          "view only" badge was gesturing at — except it carries real news. -->
@@ -88,7 +94,7 @@
     </div>
 
     <!-- Team view -->
-    <div class="flex-1 min-h-0 overflow-y-auto px-2 py-2">
+    <div class="iw-scroll flex-1 min-h-0 overflow-y-auto px-2 py-2">
       <!-- Loading: the shape of the list, before the list -->
       <div v-if="store.instancesLoading && store.instances.length === 0" class="space-y-1.5 pt-1">
         <div v-for="n in 3" :key="n" class="skeleton-card" :style="{ '--stagger': `${n * 90}ms` }">
@@ -112,7 +118,19 @@
           <span class="section-head__rule"></span>
         </div>
 
-        <div v-if="activeAgents.length > 0" class="space-y-1">
+        <!-- The crew reorders itself as agents finish and new ones are
+             dispatched. TransitionGroup makes that a movement rather than a
+             re-render: a new agent falls in, a settled one fades out of the
+             column, and everyone in between slides to their new place. The
+             per-card --stagger becomes the enter delay, so a batch of
+             parallel takes arrives in sequence instead of all at once. -->
+        <TransitionGroup
+          v-if="activeAgents.length > 0"
+          name="agent-list"
+          tag="div"
+          class="agent-list"
+          appear
+        >
           <InstanceCard
             v-for="(instance, i) in activeAgents"
             :key="instance.id"
@@ -123,7 +141,7 @@
             :variant-count="variantPlace(instance).count"
             @select="handleSelect(instance)"
           />
-        </div>
+        </TransitionGroup>
 
         <!-- Nothing running: say what would put something here -->
         <div v-else class="empty-plate">
@@ -148,29 +166,38 @@
             <span class="section-head__count">{{ history.length }}</span>
             <span class="section-head__rule"></span>
           </button>
-          <div v-if="showHistory" class="space-y-1">
-            <InstanceCard
-              v-for="(instance, i) in history"
-              :key="instance.id"
-              :instance="instance"
-              :index="i"
-              :is-active="instance.id === store.openedSubagentId || instance.id === store.activeInstanceId"
-              :is-archived="!!instance.archivedAt"
-              @select="handleSelect(instance)"
-            />
-          </div>
+          <!-- Unfolds to its own height instead of appearing. Still behind
+               v-if, so a collapsed History costs nothing until it is opened. -->
+          <FoldTransition>
+            <div v-if="showHistory" class="agent-list">
+              <InstanceCard
+                v-for="(instance, i) in history"
+                :key="instance.id"
+                :instance="instance"
+                :index="i"
+                :is-active="instance.id === store.openedSubagentId || instance.id === store.activeInstanceId"
+                :is-archived="!!instance.archivedAt"
+                @select="handleSelect(instance)"
+              />
+            </div>
+          </FoldTransition>
         </template>
       </template>
     </div>
-    </template>
+    </div>
+    </Transition>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { useAgentStore } from '../../../stores/agentStore'
+// This pane's half of the workspace's shared motion + material vocabulary
+// (see BuilderSidebarChat for why each pane imports it directly).
+import '../../../styles/workspace.css'
 import InstanceCard from '../../molecules/sidebar/AgentInstanceCard.vue'
 import WorkspacePaneHeader from '../../molecules/sidebar/WorkspacePaneHeader.vue'
+import FoldTransition from '../../molecules/common/FoldTransition.vue'
 import { ChatConversation } from '../../organisms/chat'
 import type { AgentInstance } from '../../../types/services'
 
@@ -283,6 +310,54 @@ async function openByConversation(conversationId: number) {
 </script>
 
 <style scoped>
+/* ── Pane navigation ────────────────────────────────────────────────────── */
+
+/* Each view fills the pane. The one on its way out is lifted out of flow so
+   both occupy the same box while they cross — otherwise the incoming view
+   would stack below the outgoing one and the pane would visibly grow to twice
+   its height mid-transition. */
+.pane-nav-view {
+  width: 100%;
+}
+
+.pane-nav-push-enter-active,
+.pane-nav-push-leave-active,
+.pane-nav-pop-enter-active,
+.pane-nav-pop-leave-active {
+  transition:
+    opacity var(--iw-dur-3) var(--iw-ease-out),
+    transform var(--iw-dur-3) var(--iw-ease-out);
+}
+
+.pane-nav-push-leave-active,
+.pane-nav-pop-leave-active {
+  position: absolute;
+  inset: 0;
+}
+
+/* Push (opening a subagent): the thread arrives from the right, the list
+   recedes to the left — the deeper view comes forward. */
+.pane-nav-push-enter-from {
+  opacity: 0;
+  transform: translateX(14px);
+}
+
+.pane-nav-push-leave-to {
+  opacity: 0;
+  transform: translateX(-10px);
+}
+
+/* Pop (back to the crew): the same movement, reversed. */
+.pane-nav-pop-enter-from {
+  opacity: 0;
+  transform: translateX(-14px);
+}
+
+.pane-nav-pop-leave-to {
+  opacity: 0;
+  transform: translateX(10px);
+}
+
 /* ── Fleet meter ────────────────────────────────────────────────────────── */
 
 .fleet-meter {
@@ -294,10 +369,13 @@ async function openByConversation(conversationId: number) {
   box-sizing: content-box;
 }
 
+/* Re-proportioning is the slowest thing in the pane on purpose: the bar is
+   reporting a change in the crew's shape, and a bar that snaps to a new
+   division reads as a glitch rather than as news. */
 .fleet-meter__seg {
   flex-basis: 0;
   border-radius: 9999px;
-  transition: flex-grow 0.35s cubic-bezier(0.22, 1, 0.36, 1);
+  transition: flex-grow var(--iw-dur-4) var(--iw-ease-out);
 }
 
 /* Same three tones the card rails use, so the bar reads as a key to the list */
@@ -343,6 +421,53 @@ async function openByConversation(conversationId: number) {
   to { background-position: 0 0; }
 }
 
+/* ── The crew, as a moving list ─────────────────────────────────────────── */
+
+/* gap rather than margin utilities: leaving cards are taken out of flow, and
+   a margin-based rhythm would collapse around them as they go. */
+.agent-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+/* A card joining the crew drops into place; the per-card --stagger spaces a
+   batch of parallel takes so they arrive as a sequence. */
+.agent-list-enter-active {
+  transition:
+    opacity var(--iw-dur-3) var(--iw-ease-out),
+    transform var(--iw-dur-3) var(--iw-ease-spring);
+  transition-delay: var(--stagger, 0ms);
+}
+
+.agent-list-enter-from {
+  opacity: 0;
+  transform: translateY(-6px) scale(0.97);
+}
+
+/* Leaving is quicker and quieter than arriving — a settled agent should not
+   take the eye with it on the way out. */
+.agent-list-leave-active {
+  position: absolute;
+  left: 0.5rem;
+  right: 0.5rem;
+  transition:
+    opacity var(--iw-dur-2) var(--iw-ease-out),
+    transform var(--iw-dur-2) var(--iw-ease-out);
+}
+
+.agent-list-leave-to {
+  opacity: 0;
+  transform: scale(0.96);
+}
+
+/* The rest of the column closing the gap. This is the move that makes the
+   list feel like objects rather than rows. */
+.agent-list-move {
+  transition: transform var(--iw-dur-4) var(--iw-ease-out);
+}
+
+
 /* ── Section heads ──────────────────────────────────────────────────────── */
 
 /* Uppercase micro-label, its count, then a hairline running to the edge —
@@ -359,9 +484,9 @@ async function openByConversation(conversationId: number) {
 
 .section-head--button {
   margin-top: 0.75rem;
-  border-radius: 0.375rem;
+  border-radius: var(--iw-r-xs);
   cursor: pointer;
-  transition: background-color 0.18s ease;
+  transition: background-color var(--iw-dur-2) var(--iw-ease-out);
 }
 
 .section-head--button:hover {
@@ -374,7 +499,7 @@ async function openByConversation(conversationId: number) {
 
 .section-head--button:focus-visible {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.45);
+  box-shadow: var(--iw-focus-ring);
 }
 
 .section-head__label {
@@ -383,7 +508,7 @@ async function openByConversation(conversationId: number) {
   text-transform: uppercase;
   letter-spacing: 0.09em;
   color: rgba(23, 37, 84, 0.45);
-  transition: color 0.18s ease;
+  transition: color var(--iw-dur-2) var(--iw-ease-out);
 }
 
 .dark .section-head__label {
@@ -407,6 +532,9 @@ async function openByConversation(conversationId: number) {
   background: rgba(23, 37, 84, 0.06);
   color: rgba(23, 37, 84, 0.5);
   line-height: 0.9375rem;
+  transition:
+    background-color var(--iw-dur-2) var(--iw-ease-out),
+    color var(--iw-dur-2) var(--iw-ease-out);
 }
 
 .dark .section-head__count {
@@ -427,7 +555,7 @@ async function openByConversation(conversationId: number) {
 .section-head__chevron {
   font-size: 0.5rem;
   color: rgba(23, 37, 84, 0.35);
-  transition: transform 0.2s cubic-bezier(0.22, 1, 0.36, 1);
+  transition: transform var(--iw-dur-3) var(--iw-ease-inout);
 }
 
 .dark .section-head__chevron {
@@ -446,9 +574,17 @@ async function openByConversation(conversationId: number) {
   margin: 0.125rem 0.125rem 0;
   padding: 1.125rem 0.875rem 1.25rem;
   border: 1px dashed rgba(23, 37, 84, 0.14);
-  border-radius: 0.75rem;
+  border-radius: var(--iw-r-md);
   background: linear-gradient(180deg, rgba(239, 246, 255, 0.55) 0%, rgba(239, 246, 255, 0) 100%);
   text-align: center;
+  animation: plate-in var(--iw-dur-4) var(--iw-ease-out) both;
+}
+
+/* The pane settling into "nothing running" should feel like the list coming
+   to rest, not like an error state flashing up. */
+@keyframes plate-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: none; }
 }
 
 .dark .empty-plate {
@@ -508,10 +644,10 @@ async function openByConversation(conversationId: number) {
   gap: 0.625rem;
   padding: 0.5rem 0.5rem 0.5rem 0.75rem;
   border: 1px solid rgba(23, 37, 84, 0.06);
-  border-radius: 0.625rem;
+  border-radius: var(--iw-r-md);
   overflow: hidden;
   opacity: 0;
-  animation: skeleton-in 0.4s ease both;
+  animation: skeleton-in var(--iw-dur-3) var(--iw-ease-out) both;
   animation-delay: var(--stagger, 0ms);
 }
 
@@ -573,11 +709,13 @@ async function openByConversation(conversationId: number) {
 @media (prefers-reduced-motion: reduce) {
   .fleet-meter__seg--working,
   .skeleton-line,
-  .skeleton-card {
+  .skeleton-card,
+  .empty-plate {
     animation: none;
   }
 
-  .skeleton-card {
+  .skeleton-card,
+  .empty-plate {
     opacity: 1;
   }
 }
@@ -585,21 +723,25 @@ async function openByConversation(conversationId: number) {
 /* Navy ink primary — the same recipe the chat pane's back button wears */
 .btn-back {
   background: theme('colors.blue.950');
-  box-shadow:
-    0 1px 2px rgba(23, 37, 84, 0.2),
-    0 3px 8px -2px rgba(23, 37, 84, 0.25),
-    inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  box-shadow: var(--iw-shadow-2), inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  transition:
+    background-color var(--iw-dur-2) var(--iw-ease-out),
+    box-shadow var(--iw-dur-2) var(--iw-ease-out),
+    transform var(--iw-dur-1) var(--iw-ease-out);
 }
 
 .btn-back:hover {
   background: theme('colors.blue.900');
+  box-shadow: var(--iw-shadow-3), inset 0 1px 0 rgba(255, 255, 255, 0.12);
+}
+
+.btn-back:focus-visible {
+  outline: none;
+  box-shadow: var(--iw-focus-ring);
 }
 
 .dark .btn-back {
   background: #f3ede2;
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.4),
-    0 3px 8px -2px rgba(0, 0, 0, 0.45);
 }
 
 .dark .btn-back:hover {

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="!isCollapsed" class="flex flex-col h-full bg-white dark:bg-[#0a0a0a] transition-colors duration-300">
+  <div v-if="!isCollapsed" class="iw-surface flex flex-col h-full bg-white dark:bg-[#0a0a0a] transition-colors duration-300">
     <!-- Header: who you're talking to, and a way over to the agents. There is
          only one thread the user drives, so it is simply "Main agent" — no
          conversation name to track. A subagent's read-only thread keeps its
@@ -44,13 +44,19 @@
          so a panel anchored to its narrow button couldn't fit. -->
     <div class="shrink-0 relative bg-white dark:bg-[#0a0a0a] transition-colors duration-300">
       <!-- Model slider panel (opens upward above the composer): one slider
-           across the three models, faster → smarter -->
+           across the three models, faster → smarter.
+
+           The three panels share one popover treatment: a translucent
+           material that grows out of the chip that opened it (transform-origin
+           sits at the bottom edge), so opening reads as the control
+           unfolding rather than a card being dealt onto the pane. -->
+      <Transition name="popover">
       <div
         v-if="modelOpen"
         ref="modelPanel"
-        class="absolute bottom-full left-2 right-2 mb-1 z-50 rounded-xl border border-blue-100 dark:border-white/[0.08] bg-white dark:bg-[#0f0f0f] shadow-xl overflow-hidden"
+        class="popover absolute bottom-full left-2 right-2 mb-1.5 z-50 overflow-hidden"
       >
-        <div class="flex items-center justify-between gap-2 px-3 py-2 border-b border-blue-100 dark:border-white/[0.08]">
+        <div class="popover__head flex items-center justify-between gap-2 px-3 py-2">
           <span class="text-[11px] font-semibold uppercase tracking-wider text-blue-950/50 dark:text-white/50">
             Model
           </span>
@@ -79,14 +85,16 @@
           </p>
         </div>
       </div>
+      </Transition>
 
       <!-- Reasoning effort slider panel (opens upward above the composer) -->
+      <Transition name="popover">
       <div
         v-if="effortOpen"
         ref="effortPanel"
-        class="absolute bottom-full left-2 right-2 mb-1 z-50 rounded-xl border border-blue-100 dark:border-white/[0.08] bg-white dark:bg-[#0f0f0f] shadow-xl overflow-hidden"
+        class="popover absolute bottom-full left-2 right-2 mb-1.5 z-50 overflow-hidden"
       >
-        <div class="flex items-center justify-between gap-2 px-3 py-2 border-b border-blue-100 dark:border-white/[0.08]">
+        <div class="popover__head flex items-center justify-between gap-2 px-3 py-2">
           <span class="text-[11px] font-semibold uppercase tracking-wider text-blue-950/50 dark:text-white/50">
             Reasoning
           </span>
@@ -115,14 +123,16 @@
           </p>
         </div>
       </div>
+      </Transition>
 
       <!-- Usage limits panel (opens upward above the composer) -->
+      <Transition name="popover">
       <div
         v-if="usageOpen"
         ref="usagePanel"
-        class="absolute bottom-full left-2 right-2 mb-1 z-50 rounded-xl border border-blue-100 dark:border-white/[0.08] bg-white dark:bg-[#0f0f0f] shadow-xl overflow-hidden"
+        class="popover absolute bottom-full left-2 right-2 mb-1.5 z-50 overflow-hidden"
       >
-        <div class="flex items-center justify-between gap-2 px-3 py-2 border-b border-blue-100 dark:border-white/[0.08]">
+        <div class="popover__head flex items-center justify-between gap-2 px-3 py-2">
           <span class="text-[11px] font-semibold uppercase tracking-wider text-blue-950/50 dark:text-white/50">
             Usage
           </span>
@@ -133,7 +143,7 @@
         <!-- Body scrolls on short viewports (like the version-history list)
              so the panel never grows past the top of the sidebar; the calc
              budget covers the navbar + composer + panel header. -->
-        <div class="max-h-[min(20rem,calc(100vh-19rem))] overflow-y-auto">
+        <div class="iw-scroll max-h-[min(20rem,calc(100vh-19rem))] overflow-y-auto">
           <div class="px-3 py-2.5 space-y-3">
             <div v-for="meter in usageMeters" :key="meter.key">
               <div class="flex items-baseline justify-between gap-2">
@@ -155,6 +165,7 @@
           </div>
         </div>
       </div>
+      </Transition>
 
       <!-- A background task's thread is read-only: it is driven by the main
            thread (dispatch, and answers relayed from the check-in queue), so
@@ -167,7 +178,7 @@
           </p>
           <button
             type="button"
-            class="btn-back-to-lead mt-2 w-full rounded-full px-3 py-1.5 text-[11px] font-semibold text-[#fdf9f2] dark:text-blue-950 transition-all duration-200"
+            class="btn-back-to-lead iw-press mt-2 w-full rounded-full px-3 py-1.5 text-[11px] font-semibold text-[#fdf9f2] dark:text-blue-950"
             @click="goToLead"
           >
             Back to main thread
@@ -188,10 +199,13 @@
           @view="onViewCheckIn"
         />
 
-        <!-- Queued prompt: one message held while the agent works -->
+        <!-- Queued prompt: one message held while the agent works. It slides
+             in above the composer and slides back out when it fires, so the
+             hand-off from "held" to "sent" is something you watch happen. -->
+        <Transition name="queued">
         <div
           v-if="activeInstance?.queuedPrompt"
-          class="flex items-center gap-2 rounded-xl border border-blue-100 dark:border-white/[0.08] bg-blue-50/60 dark:bg-white/[0.04] px-2.5 py-1.5 mb-1.5"
+          class="queued-row flex items-center gap-2 rounded-xl border border-blue-100 dark:border-white/[0.08] bg-blue-50/60 dark:bg-white/[0.04] px-2.5 py-1.5 mb-1.5"
         >
           <i class="fas fa-hourglass-half text-[10px] text-blue-950/40 dark:text-white/40 shrink-0"></i>
           <div class="flex-1 min-w-0">
@@ -204,12 +218,13 @@
             type="button"
             title="Cancel queued message"
             aria-label="Cancel queued message"
-            class="shrink-0 inline-flex items-center justify-center w-6 h-6 rounded-full text-blue-950/40 dark:text-white/40 hover:bg-blue-100/70 dark:hover:bg-white/[0.08] hover:text-blue-950/70 dark:hover:text-white/70 transition-colors"
+            class="queued-cancel iw-press shrink-0 inline-flex items-center justify-center w-6 h-6 rounded-full text-blue-950/40 dark:text-white/40 hover:bg-blue-100/70 dark:hover:bg-white/[0.08] hover:text-blue-950/70 dark:hover:text-white/70"
             @click="cancelQueuedPrompt"
           >
             <i class="fas fa-times text-[10px]"></i>
           </button>
         </div>
+        </Transition>
 
         <!-- Input shell: textarea on top, controls toolbar below -->
         <div class="chat-input-shell rounded-2xl bg-blue-50/40 dark:bg-white/[0.03] border border-blue-950/[0.08] dark:border-white/[0.14] shadow-sm">
@@ -239,7 +254,7 @@
                   aria-label="Model"
                   :aria-expanded="modelOpen"
                   :disabled="!activeInstance"
-                  class="control-chip"
+                  class="control-chip iw-press"
                   :class="{ 'control-chip--active': modelOpen }"
                   @click="toggleModel"
                 >
@@ -257,7 +272,7 @@
                   aria-label="Reasoning effort"
                   :aria-expanded="effortOpen"
                   :disabled="!activeInstance"
-                  class="control-chip"
+                  class="control-chip iw-press"
                   :class="{ 'control-chip--active': effortOpen }"
                   @click="toggleEffort"
                 >
@@ -274,7 +289,7 @@
                   title="Plan usage limits"
                   aria-label="Usage limits"
                   :aria-expanded="usageOpen"
-                  class="control-chip"
+                  class="control-chip iw-press"
                   :class="{ 'control-chip--active': usageOpen }"
                   @click="toggleUsage"
                 >
@@ -290,7 +305,7 @@
               @click="handleStopClick"
               aria-label="Stop agent"
               title="Stop agent"
-              class="btn-send btn-send--active flex shrink-0 items-center justify-center w-9 h-9 rounded-full transition-all duration-300 text-[#fdf9f2] dark:text-blue-950"
+              class="btn-send btn-send--active iw-press flex shrink-0 items-center justify-center w-9 h-9 rounded-full text-[#fdf9f2] dark:text-blue-950"
             >
               <i class="fas fa-stop text-sm"></i>
             </button>
@@ -301,7 +316,7 @@
               @click="handlePrompt"
               :disabled="!prompt.trim() || !activeInstance"
               aria-label="Send message"
-              class="btn-send flex shrink-0 items-center justify-center w-9 h-9 rounded-full transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/40 dark:focus-visible:ring-blue-300/50 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-[#0a0a0a]"
+              class="btn-send iw-press flex shrink-0 items-center justify-center w-9 h-9 rounded-full"
               :class="prompt.trim() && activeInstance
                 ? 'btn-send--active text-[#fdf9f2] dark:text-blue-950'
                 : 'bg-blue-100/60 dark:bg-white/[0.05] text-blue-950/40 dark:text-blue-100/40 cursor-not-allowed border border-blue-200/70 dark:border-white/[0.12] shadow-sm'"
@@ -318,6 +333,11 @@
 <script setup lang="ts">
 import { ref, computed, nextTick, onMounted, onBeforeUnmount } from 'vue'
 import { useAgentStore } from '../../../stores/agentStore'
+// The workspace's shared motion + material vocabulary (curves, durations,
+// radii, elevation, focus ring). Imported by each pane that spends it rather
+// than by an ancestor layout: a var(--iw-*) with no token behind it resolves
+// to nothing, which would leave this pane's popovers transparent.
+import '../../../styles/workspace.css'
 import { useUsageStore, formatResetTime } from '@/shared/stores/usage'
 import { ChatConversation } from '../../organisms/chat'
 import CheckInQueue from '../../molecules/sidebar/CheckInQueue.vue'
@@ -718,17 +738,111 @@ async function handleEffortSelect(effort: ReasoningEffort) {
 </script>
 
 <style scoped>
-/* Input shell wraps the textarea + controls toolbar as one field */
+/* ── Popovers ───────────────────────────────────────────────────────────── */
+
+/* Model, reasoning and usage share one surface: a translucent material lifted
+   off the composer, so the transcript behind it stays present as colour. */
+.popover {
+  border-radius: var(--iw-r-lg);
+  border: 1px solid var(--iw-material-border);
+  background: var(--iw-material-bg);
+  -webkit-backdrop-filter: var(--iw-material-filter);
+  backdrop-filter: var(--iw-material-filter);
+  box-shadow: var(--iw-shadow-3);
+}
+
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .popover {
+    background: #ffffff;
+  }
+
+  .dark .popover {
+    background: #0f0f0f;
+  }
+}
+
+.popover__head {
+  border-bottom: 1px solid var(--iw-hairline);
+}
+
+/* Grows from its bottom edge — the edge nearest the chip that opened it — so
+   the panel reads as unfolding out of the control rather than arriving from
+   somewhere off-screen. Closing is faster than opening: dismissals should
+   feel immediate, arrivals deliberate. */
+.popover-enter-active {
+  transition:
+    opacity var(--iw-dur-2) var(--iw-ease-out),
+    transform var(--iw-dur-3) var(--iw-ease-spring);
+  transform-origin: bottom center;
+}
+
+.popover-leave-active {
+  transition:
+    opacity var(--iw-dur-1) var(--iw-ease-out),
+    transform var(--iw-dur-1) var(--iw-ease-out);
+  transform-origin: bottom center;
+}
+
+.popover-enter-from {
+  opacity: 0;
+  transform: translateY(8px) scale(0.96);
+}
+
+.popover-leave-to {
+  opacity: 0;
+  transform: translateY(4px) scale(0.98);
+}
+
+/* ── Composer ───────────────────────────────────────────────────────────── */
+
+/* Input shell wraps the textarea + controls toolbar as one field. Focus adds
+   a soft halo outside the existing edge rather than thickening the border,
+   so the field never changes size as you click into it. */
 .chat-input-shell {
-  transition: border-color 0.18s ease;
+  transition:
+    border-color var(--iw-dur-2) var(--iw-ease-out),
+    box-shadow var(--iw-dur-2) var(--iw-ease-out);
 }
 
 .chat-input-shell:focus-within {
-  border-color: rgba(23, 37, 84, 0.45);
+  border-color: rgba(23, 37, 84, 0.4);
+  box-shadow: 0 0 0 3px rgba(var(--iw-accent), 0.13);
 }
 
 .dark .chat-input-shell:focus-within {
-  border-color: rgba(255, 255, 255, 0.45);
+  border-color: rgba(255, 255, 255, 0.4);
+}
+
+/* ── Queued prompt ──────────────────────────────────────────────────────── */
+
+/* Held above the composer while the agent works. It opens and closes its own
+   space (grid rows) so the composer glides down and back rather than jumping
+   when a message is queued or fires. */
+.queued-enter-active,
+.queued-leave-active {
+  transition:
+    opacity var(--iw-dur-2) var(--iw-ease-out),
+    transform var(--iw-dur-3) var(--iw-ease-out),
+    margin-bottom var(--iw-dur-3) var(--iw-ease-out);
+}
+
+.queued-enter-from,
+.queued-leave-to {
+  opacity: 0;
+  transform: translateY(8px) scale(0.98);
+  margin-bottom: -2.25rem;
+}
+
+.queued-cancel {
+  transition:
+    background-color var(--iw-dur-2) var(--iw-ease-out),
+    color var(--iw-dur-2) var(--iw-ease-out),
+    transform var(--iw-dur-1) var(--iw-ease-out);
+}
+
+.queued-cancel:focus-visible {
+  outline: none;
+  box-shadow: var(--iw-focus-ring);
 }
 
 /* Control chip: the compact model / reasoning / usage buttons. Ghost until
@@ -739,7 +853,7 @@ async function handleEffortSelect(effort: ReasoningEffort) {
   gap: 0.3rem;
   max-width: 100%;
   padding: 0.3rem 0.55rem;
-  border-radius: 0.5rem;
+  border-radius: var(--iw-r-sm);
   border: 1px solid transparent;
   background-color: transparent;
   color: rgba(23, 37, 84, 0.75);
@@ -747,7 +861,11 @@ async function handleEffortSelect(effort: ReasoningEffort) {
   font-weight: 500;
   letter-spacing: 0.01em;
   cursor: pointer;
-  transition: background-color 0.18s ease, color 0.18s ease, box-shadow 0.18s ease;
+  transition:
+    background-color var(--iw-dur-2) var(--iw-ease-out),
+    color var(--iw-dur-2) var(--iw-ease-out),
+    box-shadow var(--iw-dur-2) var(--iw-ease-out),
+    transform var(--iw-dur-1) var(--iw-ease-out);
   outline: none;
 }
 
@@ -767,7 +885,7 @@ async function handleEffortSelect(effort: ReasoningEffort) {
 }
 
 .control-chip:focus-visible {
-  box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px rgba(59, 130, 246, 0.4);
+  box-shadow: var(--iw-focus-ring);
 }
 
 .dark .control-chip {
@@ -782,10 +900,6 @@ async function handleEffortSelect(effort: ReasoningEffort) {
 .dark .control-chip--active {
   background-color: rgba(255, 255, 255, 0.1);
   color: #ffffff;
-}
-
-.dark .control-chip:focus-visible {
-  box-shadow: 0 0 0 2px #0a0a0a, 0 0 0 4px rgba(147, 197, 253, 0.5);
 }
 
 .control-chip-icon {
@@ -804,7 +918,7 @@ async function handleEffortSelect(effort: ReasoningEffort) {
   font-size: 0.5rem;
   opacity: 0.6;
   flex-shrink: 0;
-  transition: transform 0.18s ease;
+  transition: transform var(--iw-dur-3) var(--iw-ease-inout);
 }
 
 /* Faster ↔ smarter slider: navy ink track + thumb (cream in dark), matching
@@ -829,6 +943,8 @@ async function handleEffortSelect(effort: ReasoningEffort) {
   cursor: not-allowed;
 }
 
+/* The thumb grows to meet the pointer and compresses under the press — the
+   same contract every other control in the workspace honours. */
 .control-slider::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
@@ -837,13 +953,20 @@ async function handleEffortSelect(effort: ReasoningEffort) {
   border-radius: 9999px;
   background: theme('colors.blue.950');
   border: 2px solid #ffffff;
-  box-shadow: 0 1px 3px rgba(23, 37, 84, 0.35);
+  box-shadow: var(--iw-shadow-2);
   cursor: pointer;
-  transition: transform 0.15s ease;
+  transition:
+    transform var(--iw-dur-1) var(--iw-ease-out),
+    box-shadow var(--iw-dur-2) var(--iw-ease-out);
 }
 
-.control-slider::-webkit-slider-thumb:hover {
-  transform: scale(1.12);
+.control-slider:hover::-webkit-slider-thumb {
+  transform: scale(1.15);
+  box-shadow: var(--iw-shadow-3);
+}
+
+.control-slider:active::-webkit-slider-thumb {
+  transform: scale(1.05);
 }
 
 .control-slider::-moz-range-thumb {
@@ -852,16 +975,21 @@ async function handleEffortSelect(effort: ReasoningEffort) {
   border-radius: 9999px;
   background: theme('colors.blue.950');
   border: 2px solid #ffffff;
-  box-shadow: 0 1px 3px rgba(23, 37, 84, 0.35);
+  box-shadow: var(--iw-shadow-2);
   cursor: pointer;
+  transition: transform var(--iw-dur-1) var(--iw-ease-out);
+}
+
+.control-slider:hover::-moz-range-thumb {
+  transform: scale(1.15);
 }
 
 .control-slider:focus-visible::-webkit-slider-thumb {
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.35);
+  box-shadow: 0 0 0 4px rgba(var(--iw-accent), 0.35);
 }
 
 .control-slider:focus-visible::-moz-range-thumb {
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.35);
+  box-shadow: 0 0 0 4px rgba(var(--iw-accent), 0.35);
 }
 
 .dark .control-slider::-webkit-slider-thumb {
@@ -895,7 +1023,7 @@ async function handleEffortSelect(effort: ReasoningEffort) {
   left: 0;
   border-radius: 9999px;
   background: theme('colors.blue.950');
-  transition: width 0.3s ease;
+  transition: width var(--iw-dur-4) var(--iw-ease-out);
 }
 
 .dark .usage-meter-fill {
@@ -924,86 +1052,65 @@ textarea:active {
    recipe as the composer's send button */
 .btn-back-to-lead {
   background: theme('colors.blue.950');
-  box-shadow:
-    0 1px 2px rgba(23, 37, 84, 0.2),
-    0 3px 8px -2px rgba(23, 37, 84, 0.25),
-    inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  box-shadow: var(--iw-shadow-2), inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  transition:
+    background-color var(--iw-dur-2) var(--iw-ease-out),
+    box-shadow var(--iw-dur-2) var(--iw-ease-out),
+    transform var(--iw-dur-1) var(--iw-ease-out);
 }
 
 .btn-back-to-lead:hover {
   background: theme('colors.blue.900');
+  box-shadow: var(--iw-shadow-3), inset 0 1px 0 rgba(255, 255, 255, 0.12);
+}
+
+.btn-back-to-lead:focus-visible {
+  outline: none;
+  box-shadow: var(--iw-focus-ring);
 }
 
 .dark .btn-back-to-lead {
   background: #f3ede2;
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.4),
-    0 3px 8px -2px rgba(0, 0, 0, 0.45);
 }
 
 .dark .btn-back-to-lead:hover {
   background: #ffffff;
 }
 
-/* Navy ink send button - matching the site's primary "Start Building" button */
+/* Navy ink send button - matching the site's primary "Start Building" button.
+   Send and stop are the same button in two states, so the swap between them
+   is a colour and shadow change on one shape rather than two controls trading
+   places. */
 .btn-send {
-  transform: translateY(0) translateZ(0);
+  transform: translateZ(0);
+  transition:
+    background-color var(--iw-dur-2) var(--iw-ease-out),
+    border-color var(--iw-dur-2) var(--iw-ease-out),
+    color var(--iw-dur-2) var(--iw-ease-out),
+    box-shadow var(--iw-dur-2) var(--iw-ease-out),
+    transform var(--iw-dur-1) var(--iw-ease-out);
+}
+
+.btn-send:focus-visible {
+  outline: none;
+  box-shadow: var(--iw-focus-ring);
 }
 
 .btn-send--active {
   background: theme('colors.blue.950');
-  box-shadow:
-    0 1px 2px rgba(23, 37, 84, 0.2),
-    0 3px 8px -2px rgba(23, 37, 84, 0.25),
-    inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  box-shadow: var(--iw-shadow-2), inset 0 1px 0 rgba(255, 255, 255, 0.12);
 }
 
 .btn-send--active:hover {
   background: theme('colors.blue.900');
-  box-shadow:
-    0 2px 3px rgba(23, 37, 84, 0.22),
-    0 5px 12px -2px rgba(23, 37, 84, 0.3),
-    inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  box-shadow: var(--iw-shadow-3), inset 0 1px 0 rgba(255, 255, 255, 0.12);
 }
 
 .dark .btn-send--active {
   background: #f3ede2;
-  box-shadow:
-    0 1px 2px rgba(0, 0, 0, 0.4),
-    0 3px 8px -2px rgba(0, 0, 0, 0.45);
 }
 
 .dark .btn-send--active:hover {
   background: #ffffff;
-  box-shadow:
-    0 2px 3px rgba(0, 0, 0, 0.4),
-    0 5px 12px -2px rgba(0, 0, 0, 0.5);
-}
-
-/* Refined minimal scrollbar - matching homepage */
-:deep(::-webkit-scrollbar) {
-  width: 8px;
-}
-
-:deep(::-webkit-scrollbar-track) {
-  background: transparent;
-}
-
-:deep(::-webkit-scrollbar-thumb) {
-  background: rgba(0, 0, 0, 0.12);
-  border-radius: 4px;
-  transition: background 0.2s ease;
-}
-
-:deep(::-webkit-scrollbar-thumb:hover) {
-  background: rgba(0, 0, 0, 0.2);
-}
-
-:root.dark :deep(::-webkit-scrollbar-thumb) {
-  background: rgba(255, 255, 255, 0.12);
-}
-
-:root.dark :deep(::-webkit-scrollbar-thumb:hover) {
-  background: rgba(255, 255, 255, 0.2);
 }
 </style>

--- a/frontend/vuejs/src/apps/imagi/build/styles/workspace.css
+++ b/frontend/vuejs/src/apps/imagi/build/styles/workspace.css
@@ -1,0 +1,206 @@
+/*
+  workspace.css — the build workspace's motion and material system.
+
+  The agent panes (main thread, subagents, check-in queue) were each carrying
+  their own durations and easing curves: 0.15s here, 0.18s there, `ease` next
+  to `ease-out` next to a bespoke cubic-bezier. Individually fine, together
+  slightly out of step — the workspace felt like several good components
+  rather than one instrument.
+
+  This file is the shared vocabulary. Four curves, four durations, one focus
+  ring, one shadow ladder, one translucent material. Components spend these
+  tokens instead of inventing numbers, so a hover in the crew ledger decays at
+  exactly the rate a hover in the composer does.
+
+  Loaded once by BuilderLayout, so the tokens only ship with the workspace
+  chunk. Everything is namespaced --iw-* (Imagi workspace).
+*/
+
+:root {
+  /* ── Curves ───────────────────────────────────────────────────────────────
+     Motion should feel like something being set down, not something being
+     switched on: a fast start that spends most of its time settling. */
+
+  /* The workhorse. Leaves immediately, lands softly — hovers, presses,
+     colour and opacity changes. */
+  --iw-ease-out: cubic-bezier(0.32, 0.72, 0, 1);
+
+  /* Entrances that should feel physical: a card arriving, a popover opening.
+     A touch of overshoot, kept small enough to read as weight, not bounce. */
+  --iw-ease-spring: cubic-bezier(0.34, 1.4, 0.64, 1);
+
+  /* Symmetric — for things that travel and return: rotations, reorders. */
+  --iw-ease-inout: cubic-bezier(0.65, 0, 0.35, 1);
+
+  /* Long ambient loops (breathing dots, travelling rails) want an even pace
+     rather than a settle. */
+  --iw-ease-ambient: cubic-bezier(0.45, 0, 0.55, 1);
+
+  /* ── Durations ────────────────────────────────────────────────────────────
+     Anything under ~100ms reads as instant, anything past ~400ms reads as
+     waiting. The whole interface lives in between. */
+  --iw-dur-1: 120ms;  /* pressed / hovered — must not lag the finger */
+  --iw-dur-2: 200ms;  /* state changes: selection, expansion, tone */
+  --iw-dur-3: 320ms;  /* entrances and exits */
+  --iw-dur-4: 480ms;  /* deliberate: a pane resolving, a meter re-proportioning */
+
+  /* ── Radii ────────────────────────────────────────────────────────────────
+     A consistent ladder so nested corners stay concentric. */
+  --iw-r-xs: 0.375rem;
+  --iw-r-sm: 0.5rem;
+  --iw-r-md: 0.75rem;
+  --iw-r-lg: 1rem;
+  --iw-r-xl: 1.25rem;
+
+  /* ── Ink ─────────────────────────────────────────────────────────────────
+     The workspace is navy ink on paper in light, cream on black in dark.
+     Components tint from these rather than re-typing the rgb triplet. */
+  --iw-ink: 23, 37, 84;              /* blue-950 */
+  --iw-accent: 59, 130, 246;         /* blue-500 */
+  --iw-surface: 255, 255, 255;
+
+  /* ── Elevation ────────────────────────────────────────────────────────────
+     Two-part shadows — a tight contact shadow plus a wide soft one — so a
+     raised surface looks lit rather than outlined. */
+  --iw-shadow-1:
+    0 1px 1px rgba(var(--iw-ink), 0.04),
+    0 1px 2px rgba(var(--iw-ink), 0.06);
+  --iw-shadow-2:
+    0 1px 2px rgba(var(--iw-ink), 0.06),
+    0 4px 12px -4px rgba(var(--iw-ink), 0.14);
+  --iw-shadow-3:
+    0 2px 4px rgba(var(--iw-ink), 0.07),
+    0 12px 32px -10px rgba(var(--iw-ink), 0.22);
+
+  /* ── Material ─────────────────────────────────────────────────────────────
+     Floating surfaces (pane mastheads, popovers) sit on a translucent,
+     saturated blur so what is behind them stays present as colour without
+     ever being legible. */
+  --iw-material-filter: saturate(180%) blur(20px);
+  --iw-material-bg: rgba(255, 255, 255, 0.74);
+  --iw-material-border: rgba(var(--iw-ink), 0.09);
+
+  /* ── Hairlines ────────────────────────────────────────────────────────────
+     One separator weight for the whole workspace. */
+  --iw-hairline: rgba(var(--iw-ink), 0.08);
+
+  /* ── Focus ────────────────────────────────────────────────────────────────
+     One ring everywhere: a halo the width of the surface behind it, then the
+     accent. Components set --iw-focus-base to whatever they sit on. */
+  --iw-focus-base: #ffffff;
+  --iw-focus-tint: rgba(var(--iw-accent), 0.45);
+  --iw-focus-ring:
+    0 0 0 2px var(--iw-focus-base),
+    0 0 0 4px var(--iw-focus-tint);
+}
+
+:root.dark {
+  --iw-ink: 255, 255, 255;
+  --iw-accent: 147, 197, 253;
+  --iw-surface: 10, 10, 10;
+
+  /* Dark surfaces take light rather than casting shade, so the ladder is
+     mostly black plus a hairline of lift along the top edge. */
+  --iw-shadow-1:
+    0 1px 2px rgba(0, 0, 0, 0.4),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  --iw-shadow-2:
+    0 2px 4px rgba(0, 0, 0, 0.4),
+    0 8px 20px -8px rgba(0, 0, 0, 0.6);
+  --iw-shadow-3:
+    0 4px 8px rgba(0, 0, 0, 0.45),
+    0 20px 44px -16px rgba(0, 0, 0, 0.7);
+
+  --iw-material-bg: rgba(18, 18, 20, 0.76);
+  --iw-material-border: rgba(255, 255, 255, 0.1);
+  --iw-hairline: rgba(255, 255, 255, 0.1);
+
+  --iw-focus-base: #0a0a0a;
+  --iw-focus-tint: rgba(var(--iw-accent), 0.5);
+}
+
+/*
+  Type in the workspace is small and dense — status lines at 10px, meta rows
+  at tabular figures. Antialiasing keeps those legible instead of gluey, and
+  is the single biggest contributor to the panes reading as "crisp".
+*/
+.iw-surface {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+/*
+  Press feedback. A control that only changes colour on click feels like a
+  picture of a button; one that gives half a percent under the pointer feels
+  like a button. Applied via class so every control presses identically.
+*/
+.iw-press {
+  transition: transform var(--iw-dur-1) var(--iw-ease-out);
+}
+
+.iw-press:active:not(:disabled) {
+  transform: scale(0.97);
+}
+
+/*
+  Overlay scrollbars: present while you are moving through a list, gone the
+  moment you stop. The track never takes layout width, so text does not
+  reflow when the thumb appears.
+*/
+.iw-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+  transition: scrollbar-color var(--iw-dur-3) var(--iw-ease-out);
+}
+
+.iw-scroll:hover,
+.iw-scroll:focus-within {
+  scrollbar-color: rgba(var(--iw-ink), 0.2) transparent;
+}
+
+.iw-scroll::-webkit-scrollbar {
+  width: 0.5rem;
+  height: 0.5rem;
+}
+
+.iw-scroll::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.iw-scroll::-webkit-scrollbar-thumb {
+  border: 2px solid transparent;
+  border-radius: 9999px;
+  background-clip: content-box;
+  background-color: transparent;
+  transition: background-color var(--iw-dur-3) var(--iw-ease-out);
+}
+
+.iw-scroll:hover::-webkit-scrollbar-thumb,
+.iw-scroll:focus-within::-webkit-scrollbar-thumb {
+  background-color: rgba(var(--iw-ink), 0.18);
+}
+
+.iw-scroll::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(var(--iw-ink), 0.3);
+}
+
+/*
+  Reduced motion is honoured per-component for the ambient loops (a spinner
+  that stops spinning is worse than one that never span). Here we collapse the
+  durations themselves, which flattens every transition in the workspace at
+  once without any component having to opt in.
+*/
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --iw-dur-1: 1ms;
+    --iw-dur-2: 1ms;
+    --iw-dur-3: 1ms;
+    --iw-dur-4: 1ms;
+    --iw-ease-spring: linear;
+  }
+
+  .iw-press:active:not(:disabled) {
+    transform: none;
+  }
+}

--- a/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
+++ b/frontend/vuejs/src/apps/imagi/build/views/Workspace.vue
@@ -142,6 +142,9 @@ import { useUsageStore, formatResetTime } from '@/shared/stores/usage'
 import { useNotification } from '@/shared/composables/useNotification'
 import { useWindowSize } from '@/shared/composables/useWindowSize'
 import { useConfirm } from '../composables/useConfirm'
+// The pane-swap transition below is timed with the workspace's shared
+// motion tokens, so this view loads them too.
+import '../styles/workspace.css'
 
 // Builder Components
 import { BuilderLayout } from '@/apps/imagi/build/layouts'
@@ -1264,21 +1267,34 @@ onBeforeUnmount(() => {
   opacity: 0;
 }
 
-/* Manager <-> chat pane swap: a light fade+slide. The preview lives in the
-   main content area and is untouched by this transition. */
-.sidebar-view-enter-active,
+/* Manager <-> chat pane swap. The preview lives in the main content area and
+   is untouched by this transition.
+
+   out-in, so the two panes never overlap in the sidebar's clipped column —
+   which means the user waits through both halves. The leave is therefore
+   kept short and the enter carries the weight: the outgoing pane slips away
+   quickly, the incoming one settles. Both ride the workspace's shared easing
+   so this swap decays at the same rate as everything inside the panes. */
+.sidebar-view-enter-active {
+  transition:
+    opacity var(--iw-dur-2) var(--iw-ease-out),
+    transform var(--iw-dur-3) var(--iw-ease-out);
+}
+
 .sidebar-view-leave-active {
-  transition: opacity 0.15s ease, transform 0.15s ease;
+  transition:
+    opacity var(--iw-dur-1) var(--iw-ease-out),
+    transform var(--iw-dur-1) var(--iw-ease-out);
 }
 
 .sidebar-view-enter-from {
   opacity: 0;
-  transform: translateX(8px);
+  transform: translateX(12px) scale(0.995);
 }
 
 .sidebar-view-leave-to {
   opacity: 0;
-  transform: translateX(-8px);
+  transform: translateX(-10px) scale(0.995);
 }
 
 /* Refined minimal scrollbar - Matching Homepage */


### PR DESCRIPTION
The main agent and the subagents were each carrying their own timings and easing curves — `0.15s` here, `0.18s` there, `ease` next to `ease-out` next to a bespoke cubic-bezier — so the build workspace read as several good components rather than one instrument. This adds a shared vocabulary (`src/apps/imagi/build/styles/workspace.css`) and spends it everywhere: four curves, four durations, one radius ladder, one focus ring, one elevation ladder, one translucent material.

## What changed

**Materials.** Pane mastheads are a real material now — they blur and saturate whatever scrolls beneath them and close with a true hairline (a scaled pseudo-element, so it stays sub-pixel on retina) rather than painting an opaque strip. The composer's model / reasoning / usage popovers get the same surface and grow out of the chip that opened them. Both fall back to an opaque wash where `backdrop-filter` is unsupported.

**Navigation.** Opening a subagent moves like the navigation it is: the crew list slides left as the thread comes in from the right, and back on the return, with the outgoing view lifted out of flow so the two genuinely cross instead of one waiting on the other.

**The crew ledger is a moving list.** Cards enter, leave, and — most of all — slide to their new place as agents finish and new ones are dispatched. Hover now lifts a card off the column instead of nudging it sideways, which was re-laying its text out by a pixel and reading as a wobble in a list that dense.

**Live state is drawn one way.** A steady lit core with a halo breathing outward, used identically in the masthead dot, the pane-switch dot, and the transcript's status orb. Status lines cross-fade between readings rather than swapping in place, in both the masthead and the transcript.

**Disclosures unfold.** A new shared `FoldTransition` opens a section to its own measured height; the Subagents pane's History and a settled activity feed both use it instead of snapping open and shoving everything below them down. Content stays behind `v-if`, so a collapsed section still costs nothing.

**Every control presses.** One `.iw-press` class gives buttons, chips, cards and the sliders the same give under the pointer, and the focus ring is the same halo everywhere instead of five hand-rolled variants.

## Two fixes that fell out of the work

- A new message's entrance delay was keyed off its absolute index in the transcript, so message 40 of a long thread waited two seconds to fade in — it read as the reply having stalled. The stagger now counts from the first *new* message and is capped.
- The tokens are imported by each pane that spends them rather than by an ancestor layout. A `var(--iw-*)` with nothing behind it resolves to nothing, which left the popovers fully transparent whenever a pane was mounted outside `BuilderLayout` — found while building a throwaway harness to look at this work.

## Accessibility

Ambient loops still stop under `prefers-reduced-motion`, and the token durations collapse there too, which flattens every transition in the workspace without each component having to opt in. The History fold keeps collapsed content out of the tab order.

## Testing

- `npm run type-check`, `npm run build`, `npm run lint` — clean (no new warnings)
- `npx vitest run src/apps/imagi/build` — 74 tests, 6 files, all passing
- Rendered both panes against fixture data in light and dark, and captured the list, an opened subagent, the usage popover, an open History fold, a mid-flight pane push, and a `prefers-reduced-motion` pass. Icon glyphs could not be checked in this environment (the FontAwesome CDN is blocked by the sandbox proxy); no icon classes were changed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ss9Jcc6KAK7irSc7Z7jnJj)_