### PR TITLE
Install git in the backend image so subagent runs can start

### DIFF
--- a/backend/django/Dockerfile
+++ b/backend/django/Dockerfile
@@ -9,8 +9,16 @@ WORKDIR /app
 # projects run their Vite + Django dev servers inside this container, and a
 # headless Chromium renders them for the workspace UI — the same setup used
 # in local development, which is what makes preview work on Railway.
+#
+# git is load-bearing, not a convenience: every generated project is a git repo
+# (VersionControlService), and every subagent run builds in a git worktree
+# forked from it. Without the binary, `git init` at project creation and
+# `create_task_worktree` on each run both die with "No such file or directory:
+# 'git'", so dispatched subagents fail the instant they start — a failure a
+# developer never sees, because their machine has git and the container does
+# not.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl gnupg ca-certificates \
+    && apt-get install -y --no-install-recommends curl gnupg ca-certificates git \
     && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y --no-install-recommends nodejs chromium \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## The bug

In production, the lead agent dispatches its three page subagents at project creation and they never run — the workspace shows three threads (`home`, `about`, `contact`) that never say anything, and the project silently keeps its scaffold.

## Root cause

`git` is not installed in the backend image. From the Workspace service logs:

```
Could not initialize a git repository at /data/projects/1/...; the first agent run will retry
Error in imagi_agent run: Error creating task worktree: [Errno 2] No such file or directory: 'git'
  File "/app/apps/Imagi/Build/services/base_agent.py", line 967, in _ensure_task_worktree
Initial AI build run failed for project 15: ... No such file or directory: 'git'   (x3, one per page)
No page of the initial AI build for project 15 was applied; project kept its scaffold
```

The image is `python:3.13-slim` and installs `curl gnupg ca-certificates` then `nodejs chromium` — never `git`. But every generated project is a git repo (`VersionControlService`) and every subagent run builds in a worktree forked from it (`_ensure_task_worktree` -> `create_task_worktree`), so both `git init` at project creation and the worktree setup on each run fail immediately.

The failure is invisible from the UI: the lead posts its dispatch ack and creates the task conversations *before* any run starts, and the runs then throw on background threads inside the `ThreadPoolExecutor`. Developers never hit it because their machine has `git` on PATH and the container does not.

## Fix

Add `git` to the apt install line. Both tiers run this image, and `backend.json`/`workspace.json` both watch `backend/django/**`, so one push redeploys both.

Existing production projects self-heal after the redeploy: `commit_changes` calls `initialize_repo` when `.git` is missing, and `initialize_repo` sets the repo-local `user.name`/`user.email`, so no host git config is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)