### PR TITLE
Report the workspace's required binaries from the ops endpoint

### DIFF
--- a/backend/django/apps/Home/api/views.py
+++ b/backend/django/apps/Home/api/views.py
@@ -1,10 +1,50 @@
 import os
+import shutil
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
+
+# External programs the build workspace shells out to, and what breaks without
+# each. Every one of these is present on a developer's machine and has to be
+# installed into the image on purpose (backend/django/Dockerfile), which is
+# exactly the kind of gap that survives code review and passing tests.
+#
+# This list exists because 'git' once did not: generated projects are git repos
+# and every subagent builds in a worktree of one, so its absence in production
+# made dispatched subagents die the instant they started — visible only as
+# threads that never said anything, three layers below the UI. Presence here is
+# a PATH lookup, so a missing binary is one curl away instead of a log dig.
+REQUIRED_BINARIES = (
+    # Generated projects are git repos; each subagent run forks a worktree.
+    ('git', None),
+    # Generated projects run their own Vite + Django dev servers for preview.
+    ('node', None),
+    ('npm', None),
+    # Headless render of the preview for the workspace UI. Path is pinned by
+    # env var (BROWSER_PREVIEW_EXECUTABLE) rather than found on PATH.
+    ('chromium', 'BROWSER_PREVIEW_EXECUTABLE'),
+)
+
+
+def _binary_status():
+    """Which of the workspace's external programs this container actually has.
+
+    Returns {name: path-or-None}. Cheap enough to serve on every request: a
+    PATH scan (or a stat, for the env-pinned entries), never a subprocess —
+    asking each binary for its version would turn a diagnostic into four
+    process spawns.
+    """
+    found = {}
+    for name, env_var in REQUIRED_BINARIES:
+        pinned = os.environ.get(env_var) if env_var else None
+        if pinned:
+            found[name] = pinned if os.path.exists(pinned) else None
+        else:
+            found[name] = shutil.which(name)
+    return found
 
 
 def _database_status():
@@ -46,8 +86,16 @@ def version_info(request):
 
     Matching commits => the tiers are in sync. Different => the stale tier
     needs a redeploy. Values come from Railway's injected build vars.
+
+    It also reports the external programs the build workspace shells out to
+    (REQUIRED_BINARIES). `missing_binaries` is the field to read: non-empty
+    means this container cannot do part of its job no matter how current its
+    commit is, which looks nothing like a deploy problem from the UI. It
+    matters most on the workspace tier, but both tiers run the same image, so
+    both answer.
     """
     commit = os.environ.get('RAILWAY_GIT_COMMIT_SHA', '') or ''
+    binaries = _binary_status()
     return Response({
         'status': 'healthy',
         'service': 'imagi-backend',
@@ -57,4 +105,8 @@ def version_info(request):
         'branch': os.environ.get('RAILWAY_GIT_BRANCH') or 'unknown',
         'deployment_id': os.environ.get('RAILWAY_DEPLOYMENT_ID') or 'unknown',
         'database': _database_status(),
+        'binaries': binaries,
+        'missing_binaries': sorted(
+            name for name, path in binaries.items() if not path
+        ),
     })

--- a/backend/django/apps/Home/tests.py
+++ b/backend/django/apps/Home/tests.py
@@ -1,2 +1,63 @@
+"""Tests for the ops/diagnostic endpoints."""
 
-# Create your tests here.
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.urls import reverse
+
+
+class VersionInfoBinariesTests(TestCase):
+    """The version endpoint reports the workspace's external programs.
+
+    These exist because a missing binary is invisible everywhere else: the
+    image installs git/node/npm/chromium on purpose, the developer's machine
+    has them anyway, and nothing in the test suite runs inside the image. When
+    git went missing in production, the only symptom was subagents that never
+    said anything.
+    """
+
+    def test_reports_binaries_that_are_present(self):
+        response = self.client.get(reverse('home_ops:version_web'))
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        # Whatever this machine has, the two fields must agree with each other.
+        self.assertIn('binaries', body)
+        self.assertEqual(
+            body['missing_binaries'],
+            sorted(name for name, path in body['binaries'].items() if not path),
+        )
+
+    def test_missing_binary_is_named(self):
+        """A binary that is not on PATH is listed, not silently omitted."""
+        with patch('apps.Home.api.views.shutil.which', return_value=None):
+            body = self.client.get(reverse('home_ops:version_web')).json()
+
+        self.assertIn('git', body['missing_binaries'])
+        self.assertIsNone(body['binaries']['git'])
+
+    def test_env_pinned_binary_is_checked_at_its_pinned_path(self):
+        """chromium is found by env var, not PATH — a stale pin reads missing."""
+        with patch.dict(
+            'os.environ', {'BROWSER_PREVIEW_EXECUTABLE': '/nope/chromium'}
+        ):
+            body = self.client.get(reverse('home_ops:version_web')).json()
+
+        self.assertIn('chromium', body['missing_binaries'])
+
+    def test_missing_binaries_is_empty_when_all_present(self):
+        with patch(
+            'apps.Home.api.views.shutil.which', side_effect=lambda n: f'/usr/bin/{n}'
+        ), patch.dict(
+            'os.environ', {'BROWSER_PREVIEW_EXECUTABLE': __file__}
+        ):
+            body = self.client.get(reverse('home_ops:version_web')).json()
+
+        self.assertEqual(body['missing_binaries'], [])
+
+    def test_both_tiers_answer(self):
+        """Same view under both prefixes: you can compare web against workspace."""
+        for name in ('home_ops:version_web', 'home_ops:version_workspace'):
+            with self.subTest(route=name):
+                response = self.client.get(reverse(name))
+                self.assertEqual(response.status_code, 200)
+                self.assertIn('missing_binaries', response.json())

--- a/railway/README.md
+++ b/railway/README.md
@@ -15,6 +15,15 @@ otherwise, and a stale tier serving old code is the cause of "my change isn't
 live in prod, sometimes". Compare `/api/v1/ops/web/version/` against
 `/api/v1/ops/workspace/version/` to check: same `commit` means no drift.
 
+Those same two responses carry `missing_binaries`, which answers the other
+question a healthy-looking-but-broken tier raises: whether the container has the
+programs the build workspace shells out to (`git`, `node`, `npm`, `chromium`).
+They come from the image, not the code, so a correct commit can still be unable
+to build anything — which is what happened when `git` was absent and every
+dispatched subagent died on `git worktree` with nothing visible in the UI. A
+non-empty `missing_binaries` on the workspace tier means fix
+`backend/django/Dockerfile`, not the deploy.
+
 ## Wiring these files to the services
 
 Railway only picks a config file up automatically when it is `railway.json` or


### PR DESCRIPTION
Follow-up to #135, which fixed a production outage caused by `git` missing from the backend image.

## Why

That outage was invisible everywhere we normally look. The deployed commit was current, the database connected, the health check green — and the only symptom was three subagent threads that never said anything, because `create_task_worktree` died on a missing program three layers below the UI.

Binaries are the one part of production that neither tests nor code review can see: they come from the image, and a developer's machine has `git`, `node`, `npm` and `chromium` whether or not the Dockerfile installs them. So a container can be running exactly the right commit and still be unable to do its job.

## What

`/api/v1/ops/{web,workspace}/version/` now also reports:

```json
"binaries": {
  "git": "/usr/bin/git",
  "node": "/usr/bin/node",
  "npm": "/usr/bin/npm",
  "chromium": "/usr/bin/chromium"
},
"missing_binaries": []
```

`missing_binaries` is the field to read — non-empty on the workspace tier means fix `backend/django/Dockerfile`, not the deploy.

Implementation notes:
- A `shutil.which` lookup per binary, never a subprocess. Asking each one for its version would turn a diagnostic into four process spawns per request.
- `chromium` is checked at the path `BROWSER_PREVIEW_EXECUTABLE` pins rather than on PATH, matching how the preview service actually launches it — so a stale pin reads as missing.
- Both tiers answer since they share an image, but the workspace tier is the one that does the building.

## Tests

5 tests in `apps/Home/tests.py` (the file was previously an empty stub), covering: the two fields agreeing with each other, a missing binary being named rather than silently omitted, the env-pinned path being honored, the all-present case, and both routes answering. All pass.

`railway/README.md` documents the new field next to the existing commit-drift check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)