### PR TITLE
Confine user-supplied file paths and make credit grants idempotent

### DIFF
--- a/backend/django/apps/Imagi/Build/api/views.py
+++ b/backend/django/apps/Imagi/Build/api/views.py
@@ -33,6 +33,7 @@ from ..services.create_file_service import CreateFileService
 from ..services.view_file_service import ViewFileService
 from ..services.delete_file_service import DeleteFileService
 from ..services.models_service import get_model_by_id
+from ..services.safe_paths import resolve_safe
 from ..services.browser_preview_service import (
     BrowserNotRunning,
     BrowserPreviewError,
@@ -131,14 +132,17 @@ class FileContentView(APIView):
             # Get content from request
             content = request.data.get('content', '')
             
-            # Create parent directories if needed
+            # Create parent directories if needed. file_path is the raw
+            # <path:file_path> URL segment, so it is confined to the project
+            # before anything is created on disk.
             import os
             dir_path = os.path.dirname(file_path)
             if dir_path:
+                target_dir = resolve_safe(project.project_path, dir_path)
                 try:
                     # Create all necessary parent directories
                     logger.info(f"Creating directory structure for {file_path}: {dir_path}")
-                    os.makedirs(os.path.join(project.project_path, dir_path), exist_ok=True)
+                    os.makedirs(target_dir, exist_ok=True)
                 except Exception as dir_error:
                     logger.error(f"Error creating directory structure: {str(dir_error)}")
                     # Continue anyway as the file creation might still succeed

--- a/backend/django/apps/Imagi/Build/services/create_file_service.py
+++ b/backend/django/apps/Imagi/Build/services/create_file_service.py
@@ -8,6 +8,7 @@ import logging
 from datetime import datetime
 from rest_framework.exceptions import ValidationError, NotFound
 from apps.Imagi.ProjectManager.models import Project
+from .safe_paths import resolve_safe
 
 logger = logging.getLogger(__name__)
 
@@ -258,11 +259,12 @@ const emit = defineEmits<{{
                             file_name = os.path.basename(file_path)
                             file_path = f"static/css/{file_name}"
             
-            # Create full file path
-            full_file_path = os.path.join(project_path, file_path)
-            
+            # Resolve inside the project — file_path comes straight from the
+            # request body, so it can carry '..' segments or be absolute.
+            full_file_path = resolve_safe(project_path, file_path)
+
             # Create directory if it doesn't exist
-            os.makedirs(os.path.dirname(os.path.abspath(full_file_path)), exist_ok=True)
+            os.makedirs(os.path.dirname(full_file_path), exist_ok=True)
             
             # Generate default content if none provided or if content is whitespace-only
             if not content or not content.strip():

--- a/backend/django/apps/Imagi/Build/services/delete_file_service.py
+++ b/backend/django/apps/Imagi/Build/services/delete_file_service.py
@@ -6,6 +6,7 @@ import os
 import logging
 from rest_framework.exceptions import ValidationError, NotFound
 from apps.Imagi.ProjectManager.models import Project
+from .safe_paths import resolve_safe
 
 logger = logging.getLogger(__name__)
 
@@ -57,8 +58,8 @@ class DeleteFileService:
         """Delete a file."""
         try:
             project_path = self.get_project_path(project_id)
-            full_path = os.path.join(project_path, file_path)
-            
+            full_path = resolve_safe(project_path, file_path)
+
             if not os.path.exists(full_path) or not os.path.isfile(full_path):
                 raise NotFound(f"File not found: {file_path}")
             

--- a/backend/django/apps/Imagi/Build/services/preview_service.py
+++ b/backend/django/apps/Imagi/Build/services/preview_service.py
@@ -24,6 +24,31 @@ NPM_INSTALL_TIMEOUT = 600
 # serialize instead of corrupting node_modules under each other.
 NPM_INSTALL_LOCK_DIRNAME = '.imagi_npm_install.lock'
 
+# The only variables a generated project's dev server, and any npm lifecycle
+# script it runs, inherit from Imagi. The code under these processes is written
+# by the user (directly, or by the agent on their behalf), so Imagi's own
+# environment — DJANGO_SECRET_KEY, DATABASE_URL, the Stripe and OpenAI keys —
+# is not handed to it. Anything the child genuinely needs is passed explicitly
+# by the caller instead of arriving through inheritance.
+CHILD_ENV_PASSTHROUGH = (
+    'PATH', 'HOME', 'USER', 'LOGNAME', 'SHELL',
+    'TMPDIR', 'TEMP', 'TMP',
+    'LANG', 'LC_ALL', 'LC_CTYPE', 'TZ', 'TERM',
+    'SSL_CERT_FILE', 'SSL_CERT_DIR', 'SYSTEMROOT',
+)
+
+
+def child_env(**overrides):
+    """Build the environment for a generated project's subprocess.
+
+    Starts from the allowlist above rather than ``os.environ.copy()``, so
+    nothing secret leaks into user-authored code.
+    """
+    env = {k: v for k, v in os.environ.items() if k in CHILD_ENV_PASSTHROUGH}
+    env.setdefault('PATH', os.defpath)
+    env.update({k: v for k, v in overrides.items() if v is not None})
+    return env
+
 
 @contextlib.contextmanager
 def npm_install_lock(frontend_path, timeout=NPM_INSTALL_TIMEOUT):
@@ -245,8 +270,7 @@ class PreviewService:
             logger.info(f"Using Django project: {project_name}")
 
             # Set up environment
-            env = os.environ.copy()
-            env['DJANGO_SETTINGS_MODULE'] = f"{project_name}.settings"
+            env = child_env(DJANGO_SETTINGS_MODULE=f"{project_name}.settings")
 
             # Find available port for backend (avoiding conflict with main project on 8000)
             self.backend_port = self._find_available_port_excluding(8080, 8100, exclude_ports=[8000])
@@ -320,9 +344,10 @@ class PreviewService:
 
             # Set up environment for Vite. VITE_BACKEND_URL points the generated
             # app's /api proxy at its own Django backend rather than the default.
-            env = os.environ.copy()
-            env['PORT'] = str(self.frontend_port)
-            env['VITE_BACKEND_URL'] = f"http://localhost:{self.backend_port}"
+            env = child_env(
+                PORT=str(self.frontend_port),
+                VITE_BACKEND_URL=f"http://localhost:{self.backend_port}",
+            )
 
             # Ensure PID file directory exists
             os.makedirs(os.path.dirname(self.frontend_pid_file), exist_ok=True)
@@ -395,12 +420,15 @@ class PreviewService:
                 # Even if the install we waited on finished, run npm install
                 # ourselves: it is a fast no-op on a complete node_modules and
                 # repairs a partial one left by a failed/killed installer.
+                # package.json here is user-editable, so its lifecycle scripts
+                # run under the same restricted environment as the dev servers.
                 result = subprocess.run(
                     [npm, 'install'],
                     cwd=frontend_path,
                     capture_output=True,
                     text=True,
                     timeout=NPM_INSTALL_TIMEOUT,
+                    env=child_env(),
                 )
         except subprocess.TimeoutExpired:
             return f"npm install timed out after {NPM_INSTALL_TIMEOUT} seconds"
@@ -462,9 +490,10 @@ class PreviewService:
         project_name = os.path.basename(self.project.project_path)
 
         # Set up environment
-        env = os.environ.copy()
-        env['PYTHONPATH'] = self.project.project_path
-        env['DJANGO_SETTINGS_MODULE'] = f"{project_name}.settings"
+        env = child_env(
+            PYTHONPATH=self.project.project_path,
+            DJANGO_SETTINGS_MODULE=f"{project_name}.settings",
+        )
 
         # Start the development server
         with open(self.backend_log_file, 'w') as log_fh:

--- a/backend/django/apps/Imagi/Build/services/safe_paths.py
+++ b/backend/django/apps/Imagi/Build/services/safe_paths.py
@@ -1,0 +1,46 @@
+"""Path containment for anything that turns a user-supplied path into a real one.
+
+Every file path that reaches the Build services comes from the user — the REST
+endpoints take it from the request body or from a ``<path:file_path>`` URL
+segment, both of which happily carry ``..`` segments and absolute paths. Joining
+one of those onto the project root escapes it (``os.path.join`` discards the root
+entirely when the second argument is absolute), so each read, write and delete
+resolves the path through :func:`resolve_within` first.
+"""
+
+import os
+
+
+class UnsafePathError(ValueError):
+    """A user-supplied path resolved outside the project directory."""
+
+
+def resolve_within(project_path, file_path):
+    """Resolve ``file_path`` against ``project_path`` and confine it there.
+
+    Returns the absolute, symlink-resolved path. Raises :class:`UnsafePathError`
+    when the result lands outside the project directory, whether by ``..``
+    segments, an absolute path, or a symlink pointing out of the tree.
+    """
+    if not project_path:
+        raise UnsafePathError('Project path is not set')
+
+    root = os.path.realpath(project_path)
+    full = os.path.realpath(os.path.join(root, file_path))
+    if full != root and not full.startswith(root + os.sep):
+        raise UnsafePathError(f"Path '{file_path}' is outside the project directory")
+    return full
+
+
+def resolve_safe(project_path, file_path):
+    """:func:`resolve_within` for the REST services — rejects with a 400.
+
+    The services let exceptions propagate to DRF, so raising ``ValidationError``
+    here turns a traversal attempt into a plain bad request rather than a 500.
+    """
+    from rest_framework.exceptions import ValidationError
+
+    try:
+        return resolve_within(project_path, file_path)
+    except UnsafePathError as exc:
+        raise ValidationError(str(exc))

--- a/backend/django/apps/Imagi/Build/services/tools.py
+++ b/backend/django/apps/Imagi/Build/services/tools.py
@@ -29,6 +29,7 @@ from apps.Imagi.Build.services.view_file_service import ViewFileService
 from apps.Imagi.Build.services.create_file_service import CreateFileService
 from apps.Imagi.Build.services.delete_file_service import DeleteFileService
 from apps.Imagi.Build.services.directory_service import DirectoryService
+from apps.Imagi.Build.services.safe_paths import resolve_within
 
 logger = logging.getLogger(__name__)
 
@@ -122,11 +123,7 @@ def resolve_safe_path(project, file_path: str) -> str:
     segments or absolute paths), so tools can never read or write outside the
     user's project directory.
     """
-    root = os.path.realpath(project.project_path)
-    full = os.path.realpath(os.path.join(root, file_path))
-    if full != root and not full.startswith(root + os.sep):
-        raise ValueError(f"Path '{file_path}' is outside the project directory")
-    return full
+    return resolve_within(project.project_path, file_path)
 
 
 def infer_file_type(file_path: str) -> str:

--- a/backend/django/apps/Imagi/Build/services/view_file_service.py
+++ b/backend/django/apps/Imagi/Build/services/view_file_service.py
@@ -8,6 +8,7 @@ import logging
 from datetime import datetime
 from rest_framework.exceptions import ValidationError, NotFound
 from apps.Imagi.ProjectManager.models import Project
+from .safe_paths import resolve_safe
 
 logger = logging.getLogger(__name__)
 
@@ -345,10 +346,10 @@ class ViewFileService:
         """Update the content of a file."""
         try:
             project_path = self.get_project_path(project_id)
-            full_path = os.path.join(project_path, file_path)
-            
+            full_path = resolve_safe(project_path, file_path)
+
             # Create directory if it doesn't exist
-            os.makedirs(os.path.dirname(os.path.abspath(full_path)), exist_ok=True)
+            os.makedirs(os.path.dirname(full_path), exist_ok=True)
             
             # Write content to file with UTF-8 encoding
             with open(full_path, 'w', encoding='utf-8') as f:
@@ -383,11 +384,11 @@ class ViewFileService:
         """Get details about a specific file."""
         try:
             project_path = self.get_project_path(project_id)
-            full_path = os.path.join(project_path, file_path)
-            
+            full_path = resolve_safe(project_path, file_path)
+
             if not os.path.exists(full_path) or not os.path.isfile(full_path):
                 raise NotFound(f"File not found: {file_path}")
-            
+
             # Get file stats
             stats = os.stat(full_path)
             
@@ -416,7 +417,7 @@ class ViewFileService:
         """
         try:
             project_path = self.get_project_path(project_id)
-            full_path = os.path.join(project_path, file_path)
+            full_path = resolve_safe(project_path, file_path)
 
             if not os.path.exists(full_path) or not os.path.isfile(full_path):
                 project = self._resolve_project(project_id)

--- a/backend/django/apps/Imagi/Build/tests/test_builder.py
+++ b/backend/django/apps/Imagi/Build/tests/test_builder.py
@@ -29,6 +29,7 @@ from apps.Imagi.Build.services.browser_preview_service import (
 )
 from apps.Imagi.Build.services.create_app_service import CreateAppService
 from apps.Imagi.Build.services.create_file_service import CreateFileService
+from apps.Imagi.Build.services.preview_service import child_env
 from apps.Imagi.Build.services.codegen.prebuilt_apps import PREBUILT_MAP
 
 
@@ -247,6 +248,88 @@ class BuilderAPITests(APITestCase):
         )
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         self.assertEqual(resp.data['content'], 'the content')
+
+
+class FilePathContainmentTests(APITestCase):
+    """Paths from the request body and the URL stay inside the project.
+
+    Owning a project must not be a licence to reach the rest of the filesystem:
+    both the create-file body's `path` and the `<path:file_path>` URL segment
+    are attacker-controlled, and `<path:...>` matches `..` segments verbatim.
+    """
+
+    def setUp(self):
+        self.user = User.objects.create_user(username='pathuser', password='testpass123')
+        self.token = Token.objects.create(user=self.user)
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.token.key}')
+
+        self.sandbox = tempfile.mkdtemp(prefix='builder_sandbox_')
+        self.addCleanup(lambda: shutil.rmtree(self.sandbox, ignore_errors=True))
+        self.project_root = os.path.join(self.sandbox, 'project')
+        os.makedirs(self.project_root)
+        self.project = PMProject.objects.create(
+            user=self.user, name="Path Project", project_path=self.project_root
+        )
+
+        # A file belonging to nobody in particular, next to the project
+        self.outsider = os.path.join(self.sandbox, 'outside.txt')
+        with open(self.outsider, 'w', encoding='utf-8') as f:
+            f.write('original')
+
+    def test_create_file_rejects_traversal_in_path(self):
+        resp = self.client.post(
+            reverse('api-create-file', args=[self.project.id]),
+            {'path': '../outside.txt', 'content': 'pwned'},
+            format='json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        with open(self.outsider, encoding='utf-8') as f:
+            self.assertEqual(f.read(), 'original')
+
+    def test_create_file_rejects_absolute_path(self):
+        # os.path.join drops the project root entirely for an absolute path
+        target = os.path.join(self.sandbox, 'absolute.txt')
+        resp = self.client.post(
+            reverse('api-create-file', args=[self.project.id]),
+            {'path': target, 'content': 'pwned'},
+            format='json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertFalse(os.path.exists(target))
+
+    def test_file_content_write_rejects_traversal(self):
+        resp = self.client.post(
+            reverse('api-file-content', args=[self.project.id, '../outside.txt']),
+            {'content': 'pwned'},
+            format='json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        with open(self.outsider, encoding='utf-8') as f:
+            self.assertEqual(f.read(), 'original')
+
+    def test_file_content_read_rejects_traversal(self):
+        resp = self.client.get(
+            reverse('api-file-content', args=[self.project.id, '../outside.txt'])
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_delete_file_rejects_traversal(self):
+        resp = self.client.delete(
+            reverse('api-delete-file', args=[self.project.id, '../outside.txt'])
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertTrue(os.path.exists(self.outsider))
+
+    def test_traversal_that_lands_back_inside_is_allowed(self):
+        # Containment is about where the path resolves, not whether it is tidy
+        relative_path = 'frontend/../src/App.vue'
+        resp = self.client.post(
+            reverse('api-create-file', args=[self.project.id]),
+            {'path': relative_path, 'content': 'fine'},
+            format='json',
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(os.path.exists(os.path.join(self.project_root, 'src/App.vue')))
 
 
 class CreateFileServiceTests(TestCase):
@@ -500,3 +583,37 @@ class PreviewEndpointTests(APITestCase):
         )
         resp = self.client.get(reverse('api-preview-frame', args=[other_project.id]))
         self.assertEqual(resp.status_code, 404)
+
+
+class PreviewChildEnvTests(TestCase):
+    """A generated project's processes must not inherit Imagi's secrets.
+
+    The code under a preview is written by the user (or by the agent on their
+    behalf) and runs in this same container, so the environment it is handed is
+    an allowlist rather than a copy of Imagi's own.
+    """
+
+    def test_platform_secrets_are_not_passed_through(self):
+        secrets = {
+            'DJANGO_SECRET_KEY': 'super-secret',
+            'DATABASE_URL': 'postgres://user:pw@host/db',
+            'STRIPE_SECRET_KEY': 'sk_live_xxx',
+            'STRIPE_WEBHOOK_SECRET': 'whsec_xxx',
+            'OPENAI_KEY': 'sk-openai',
+        }
+        with patch.dict(os.environ, secrets):
+            env = child_env()
+        for name in secrets:
+            self.assertNotIn(name, env)
+
+    def test_essentials_survive_and_overrides_apply(self):
+        with patch.dict(os.environ, {'PATH': '/usr/bin', 'HOME': '/home/app'}):
+            env = child_env(PORT='5174', VITE_BACKEND_URL='http://localhost:8081')
+        self.assertEqual(env['PATH'], '/usr/bin')
+        self.assertEqual(env['HOME'], '/home/app')
+        self.assertEqual(env['PORT'], '5174')
+        self.assertEqual(env['VITE_BACKEND_URL'], 'http://localhost:8081')
+
+    def test_path_is_never_empty(self):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertTrue(child_env()['PATH'])

--- a/backend/django/apps/Payments/api/views.py
+++ b/backend/django/apps/Payments/api/views.py
@@ -797,7 +797,14 @@ def handle_payment_intent_succeeded(payment_intent):
         if not transaction:
             logger.warning(f"Transaction not found for payment intent {payment_intent.id}")
             return
-        
+
+        # process_payment confirms the intent inline and credits immediately, so
+        # this webhook usually arrives for a transaction that is already paid up.
+        # add_credits enforces this too; checking here keeps the log honest.
+        if transaction.status == 'completed':
+            logger.info(f"Transaction for payment intent {payment_intent.id} already credited")
+            return
+
         # Add credits to user's balance
         credit_service.add_credits(transaction.user, float(transaction.amount), transaction)
         

--- a/backend/django/apps/Payments/services/credit_service.py
+++ b/backend/django/apps/Payments/services/credit_service.py
@@ -38,28 +38,51 @@ class CreditService:
     def add_credits(self, user, amount: float, transaction_obj=None) -> Dict[str, Any]:
         """
         Add credits to a user's balance.
-        
+
+        When a transaction is supplied, crediting it is idempotent: the
+        transaction row is locked and re-read, and an already-completed one is
+        never credited a second time. A single purchase can otherwise be
+        credited twice — ``process_payment`` confirms the PaymentIntent inline
+        and credits, and Stripe then delivers ``payment_intent.succeeded`` for
+        the same intent — and two concurrent deliveries would otherwise race.
+
         Args:
             user: The user
             amount: The amount to add
             transaction_obj: Optional transaction object to update
-            
+
         Returns:
             Dict with the new balance and success status
         """
         try:
             with transaction.atomic():
-                balance, created = CreditBalance.objects.get_or_create(user=user)
-                
+                if transaction_obj:
+                    locked = type(transaction_obj).objects.select_for_update().get(
+                        pk=transaction_obj.pk
+                    )
+                    if locked.status == 'completed':
+                        logger.info(
+                            f"Transaction {locked.pk} already credited; skipping duplicate"
+                        )
+                        balance, _ = CreditBalance.objects.get_or_create(user=user)
+                        return {
+                            'success': True,
+                            'new_balance': float(balance.balance),
+                            'credits_added': 0,
+                            'duplicate': True,
+                        }
+
+                balance, created = CreditBalance.objects.select_for_update().get_or_create(user=user)
+
                 # Update balance
                 balance.balance = Decimal(str(float(balance.balance) + amount))
                 balance.save()
-                
+
                 # Update transaction if provided
                 if transaction_obj:
                     transaction_obj.status = 'completed'
                     transaction_obj.save()
-                
+
             return {
                 'success': True,
                 'new_balance': float(balance.balance),

--- a/backend/django/apps/Payments/tests.py
+++ b/backend/django/apps/Payments/tests.py
@@ -132,6 +132,35 @@ class CreditServiceTests(APITestCase):
         txn.refresh_from_db()
         self.assertEqual(txn.status, 'completed')
 
+    def test_crediting_the_same_transaction_twice_is_a_no_op(self):
+        # process_payment credits inline and Stripe then delivers
+        # payment_intent.succeeded for the same intent — the second credit for
+        # one transaction must not add a second helping of credits.
+        txn = Transaction.objects.create(
+            user=self.user, amount=Decimal('30'), transaction_type='purchase',
+            status='pending', stripe_payment_intent_id='pi_dupe',
+        )
+        self.service.add_credits(self.user, 30.0, txn)
+        second = self.service.add_credits(self.user, 30.0, txn)
+
+        self.assertTrue(second['success'])
+        self.assertTrue(second.get('duplicate'))
+        self.assertEqual(second['credits_added'], 0)
+        self.assertEqual(self.service.get_balance(self.user), 30.0)
+
+    def test_webhook_does_not_recredit_a_completed_transaction(self):
+        from apps.Payments.api.views import handle_payment_intent_succeeded
+
+        txn = Transaction.objects.create(
+            user=self.user, amount=Decimal('25'), transaction_type='purchase',
+            status='pending', stripe_payment_intent_id='pi_webhook',
+        )
+        self.service.add_credits(self.user, 25.0, txn)
+
+        handle_payment_intent_succeeded(SimpleNamespace(id='pi_webhook'))
+
+        self.assertEqual(self.service.get_balance(self.user), 25.0)
+
     def test_deduct_credits_reduces_balance_and_records_usage(self):
         self.service.add_credits(self.user, 50.0)
         result = self.service.deduct_credits(self.user, 20.0, 'Model run')

--- a/backend/django/imagi/settings.py
+++ b/backend/django/imagi/settings.py
@@ -249,6 +249,17 @@ CSRF_COOKIE_HTTPONLY = False  # frontend reads it from document.cookie
 SESSION_COOKIE_SAMESITE = 'Lax'
 CSRF_COOKIE_SAMESITE = 'Lax'
 
+# TLS terminates at the edge and nginx forwards X-Forwarded-Proto, so Django
+# needs to be told about it — without this request.is_secure() is always False
+# behind the proxy and the flags below would never apply. Off in DEBUG, where
+# the dev servers are plain HTTP.
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+SESSION_COOKIE_SECURE = not DEBUG
+CSRF_COOKIE_SECURE = not DEBUG
+# SECURE_SSL_REDIRECT is deliberately left off: the edge already serves HTTPS
+# only, while the Railway healthcheck and the backend<->workspace calls travel
+# plain HTTP over *.railway.internal, and a redirect would break both.
+
 
 # Stripe / Payments
 STRIPE_SECRET_KEY = os.environ.get('STRIPE_SECRET_KEY', '')


### PR DESCRIPTION
The Build file endpoints turned request-supplied paths into real filesystem paths without containment: the create-file body's `path` and the `<path:file_path>` URL segment both reach os.path.join(project_path, ...) verbatim, so `..` segments escaped the project and an absolute path discarded the project root entirely. Add one shared resolver — safe_paths.resolve_within, with a resolve_safe wrapper that rejects with a 400 — and route create, read, write, details, delete and the view-layer makedirs through it. tools.py's resolve_safe_path, which already did this correctly for the agent tools, now delegates to the same helper so there is a single implementation.

Generated projects' dev servers and their npm installs inherited Imagi's whole environment via os.environ.copy(), handing DJANGO_SECRET_KEY, DATABASE_URL and the Stripe/OpenAI keys to code the user authors. Build the child environment from an allowlist instead.

A direct credit purchase was credited twice: process_payment confirms the PaymentIntent inline and credits, then Stripe delivers payment_intent.succeeded for the same intent and the handler credited again. add_credits now locks the transaction row and skips one already completed, which also closes the race between two concurrent deliveries.

Finally, set the cookie-security flags `manage.py check --deploy` was flagging. SECURE_SSL_REDIRECT stays off deliberately — the healthcheck and the backend<->workspace calls travel plain HTTP over *.railway.internal.