### PR TITLE
Close the 7px dead strip under the navbar in the app shell

### DIFF
--- a/frontend/vuejs/src/shared/components/organisms/navigation/BaseNavbar.vue
+++ b/frontend/vuejs/src/shared/components/organisms/navigation/BaseNavbar.vue
@@ -1,6 +1,9 @@
 <template>
   <nav class="crisp-nav fixed w-full z-50 font-body bg-white/80 dark:bg-[#0a0a0a]/80 backdrop-blur-xl border-b border-blue-950/[0.08] dark:border-white/[0.08] transition-colors duration-300">
     <div class="relative px-6 sm:px-8 lg:px-12" :class="fluid ? 'w-full' : 'max-w-7xl mx-auto'">
+      <!-- The bar is fixed, so everything below it is pushed down by the
+           `nav` spacing token (tailwind.config.js) — this row's height plus
+           the hairline above. Change one and change the other. -->
       <div class="relative flex items-center h-14">
         <!-- Left section -->
         <div class="flex items-center z-10">

--- a/frontend/vuejs/src/shared/layouts/DashboardLayout.vue
+++ b/frontend/vuejs/src/shared/layouts/DashboardLayout.vue
@@ -19,13 +19,13 @@
            page. On mobile it drops below the navbar and becomes an off-canvas
            drawer that floats over the content. -->
       <aside
-        class="sidebar-panel fixed bottom-0 left-0 z-30 flex flex-col max-md:top-16 border-r border-blue-950/[0.08] dark:border-white/[0.08] bg-white/80 dark:bg-[#0a0a0a]/80 backdrop-blur-xl max-md:shadow-[0_24px_60px_-20px_rgba(15,23,42,0.35)] dark:max-md:shadow-[0_24px_60px_-20px_rgba(0,0,0,0.7)]"
+        class="sidebar-panel fixed bottom-0 left-0 z-30 flex flex-col max-md:top-nav border-r border-blue-950/[0.08] dark:border-white/[0.08] bg-white/80 dark:bg-[#0a0a0a]/80 backdrop-blur-xl max-md:shadow-[0_24px_60px_-20px_rgba(15,23,42,0.35)] dark:max-md:shadow-[0_24px_60px_-20px_rgba(0,0,0,0.7)]"
         :class="[
           asideWidthClass,
           // The stacked frame drops the panel below the full-width top bar so
           // the bar's toggle + wordmark own the true top-left corner; other
           // sections keep the panel flush to the top on desktop.
-          stackedNav ? 'top-16' : 'md:top-0',
+          stackedNav ? 'top-nav' : 'md:top-0',
           isSidebarCollapsed ? '-translate-x-full pointer-events-none' : 'translate-x-0'
         ]"
         :aria-hidden="isSidebarCollapsed ? 'true' : undefined"
@@ -139,7 +139,7 @@
 
         <!-- Main content area -->
         <main
-          class="flex-1 flex flex-col relative pt-16 bg-white dark:bg-[#0a0a0a] overflow-hidden"
+          class="flex-1 flex flex-col relative pt-nav bg-white dark:bg-[#0a0a0a] overflow-hidden"
           :class="appShell ? 'min-h-0' : ''"
         >
           <slot :isSidebarCollapsed="isSidebarCollapsed"></slot>
@@ -160,7 +160,7 @@
       >
         <div
           v-if="!isSidebarCollapsed"
-          class="md:hidden fixed top-16 left-0 right-0 bottom-0 z-20 bg-blue-950/25 dark:bg-black/45 backdrop-blur-[1px]"
+          class="md:hidden fixed top-nav left-0 right-0 bottom-0 z-20 bg-blue-950/25 dark:bg-black/45 backdrop-blur-[1px]"
           aria-hidden="true"
           @click="setSidebarCollapsed(true)"
         ></div>

--- a/frontend/vuejs/tailwind.config.js
+++ b/frontend/vuejs/tailwind.config.js
@@ -64,6 +64,12 @@ export default {
       },
       spacing: {
         'header': '64px',
+        // The fixed top bar's true height: BaseNavbar's h-14 row plus its 1px
+        // bottom hairline. Anything that sits under the bar (the shell's
+        // sidebar, main content and mobile scrim) offsets by this, so the
+        // panels sit flush against it instead of leaving a dead strip.
+        // Keep in sync with the row height in BaseNavbar.vue.
+        'nav': 'calc(3.5rem + 1px)',
       },
       animation: {
         'fade-in': 'fade-in 0.5s ease-out forwards',


### PR DESCRIPTION
## What

The build workspace showed a small gap between the navbar and the tops of both the agent panel and the browser pane. The cause was a height mismatch, not a stray margin:

`BaseNavbar`'s row is `h-14` plus a 1px bottom hairline — **57px** — but `DashboardLayout` pushed everything below the bar down by `16` (**64px**). The 7px difference was a dead strip under the bar.

## Why it was only visible in the workspace

Docs had the identical gap above its sidebar, and other sections had it too — they just hid it, because their content is the same white as the bar. The workspace's panes have their own surfaces and borders, so the strip read as a visible seam.

## Changes

- **`tailwind.config.js`** — new `nav` spacing token, `calc(3.5rem + 1px)`, so the offset has one source of truth instead of a hardcoded guess.
- **`DashboardLayout.vue`** — the four places that sit under the bar use it: the sidebar's desktop `top`, its mobile `top`, `main`'s `pt`, and the mobile scrim's `top`.
- **`BaseNavbar.vue`** — comment tying the row height to the token, so the two can't drift apart again.

## Verification

Ran the dev server and measured the live DOM. Before: navbar bottom `57`, sidebar top `64`, main content top `64`. After, at both 1440×900 and 375×812: navbar bottom, sidebar top, and main padding-top all land at exactly **57px** — zero gap in both panes, desktop and mobile. Docs (the other `DashboardLayout` consumer) renders correctly and is now flush as well.

Note: the config still has an unused `header: '64px'` spacing token, likely where the 64px assumption originated. Nothing references it; left alone rather than widening the scope of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)