### PR TITLE
Show usage as percent only in the build workspace

### DIFF
--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
@@ -338,7 +338,7 @@ import { useAgentStore } from '../../../stores/agentStore'
 // than by an ancestor layout: a var(--iw-*) with no token behind it resolves
 // to nothing, which would leave this pane's popovers transparent.
 import '../../../styles/workspace.css'
-import { useUsageStore, formatResetTime, formatUsd } from '@/shared/stores/usage'
+import { useUsageStore, formatResetTime } from '@/shared/stores/usage'
 import { ChatConversation } from '../../organisms/chat'
 import CheckInQueue from '../../molecules/sidebar/CheckInQueue.vue'
 import WorkspacePaneHeader from '../../molecules/sidebar/WorkspacePaneHeader.vue'
@@ -544,11 +544,10 @@ const usageMeters = computed(() => {
     key,
     label,
     percent,
-    // Dollars spent against the window's allowance — the unit the plan is
-    // actually sold in. Unknown usage stays an em-dash, never $0.
-    usedText: win && win.usedUsd !== null && win.limitUsd !== null
-      ? `${formatUsd(win.usedUsd)} of ${formatUsd(win.limitUsd)}`
-      : '—',
+    // How much of the window's allowance is gone, on a 0-100 scale — the
+    // dollar figures behind it stay out of the workspace. Unknown usage
+    // stays an em-dash, never 0%.
+    usedText: percent !== null ? `${percent}% used` : '—',
     resetsAt: formatResetTime(win?.resetsAt ?? null),
   }))
 })


### PR DESCRIPTION
The usage panel in the build sidebar showed each rolling window as a dollar figure — `$0.40 of $2.00` — which were the only dollar amounts left anywhere in the workspace. Now both windows read as a plain 0-100 percent used, matching the header usage card that already showed `12%` with a meter.

## Changes

- `BuilderSidebarChat.vue`: the 5-hour and weekly meter rows render `12% used` instead of `$0.40 of $2.00`, sourced from the store getters that were already computing the percent for the bars. Dropped the now-unused `formatUsd` import.

Unknown usage still renders as an em-dash with no bar — never `0%`. The reset-time line, the meter bars, and everything else on the panel are unchanged. `formatUsd` itself stays in the store; it's still used by the payments success view, where dollar amounts belong.

## Verification

- `npm run type-check` passes.
- `usage.spec.ts` (8 tests) passes — the percent getters this now depends on are already covered there, including the unknown-data cases.

---
_Generated by [Claude Code](https://claude.ai/code/session_018GtWG7mEQLhh498mgxcLVK)_