### PR TITLE
Make the main thread report its subagents' work

### DIFF
--- a/frontend/vuejs/src/apps/imagi/build/components/__tests__/ChatConversation.spec.ts
+++ b/frontend/vuejs/src/apps/imagi/build/components/__tests__/ChatConversation.spec.ts
@@ -100,27 +100,63 @@ describe('ChatConversation dispatch card', () => {
     return mount(ChatConversation, { props: { messages: [user('hi'), reply] } })
   }
 
-  it('reports what a finished subagent did, and that it landed', () => {
-    // A task that merged itself queues nothing, so this card is the whole
-    // report — it has to say both what happened and where the work went.
-    const wrapper = withSubagent({
-      reviewStatus: 'accepted',
-      lastMessagePreview: 'Added a /contact route with a validated form.',
-    })
-
-    const card = wrapper.find('.dispatch-card')
-    expect(card.text()).toContain('Added to your app')
-    expect(card.text()).toContain('Added a /contact route with a validated form.')
-  })
-
-  it('says nothing about results while the subagent is still working', () => {
+  it('names the task and says it is being worked on', () => {
     const wrapper = withSubagent({
       isProcessing: true,
       lastMessagePreview: 'Reading the router…',
     })
 
     const card = wrapper.find('.dispatch-card')
-    expect(card.text()).toContain('Working in the background…')
+    expect(card.classes()).toContain('dispatch-card--working')
+    expect(card.text()).toContain('Contact page')
+    expect(card.text()).toContain('Working on this now…')
+    // Mid-run chatter is not a result; the card stays a status, not a log.
     expect(card.text()).not.toContain('Reading the router…')
+  })
+
+  it('turns into a confirmation once the work lands', () => {
+    // The card is the notice, not the transcript: it confirms the named task
+    // landed, and the subagent's full account stays in its own thread (one
+    // click away) rather than being pasted into the main thread.
+    const wrapper = withSubagent({
+      reviewStatus: 'accepted',
+      lastMessagePreview: 'Added a /contact route with a validated form.',
+    })
+
+    const card = wrapper.find('.dispatch-card')
+    expect(card.classes()).toContain('dispatch-card--done')
+    expect(card.text()).toContain('Contact page')
+    expect(card.text()).toContain('Done')
+    expect(card.text()).not.toContain('Added a /contact route with a validated form.')
+  })
+
+  it('surfaces a subagent that is blocked on a question', () => {
+    // The question is answered in the check-in queue above the composer, but
+    // it has to be readable from the card too — a status line alone cannot be
+    // acted on.
+    const wrapper = withSubagent({
+      reviewStatus: 'input',
+      lastMessagePreview: 'Should the form email you or open a ticket?',
+    })
+
+    const card = wrapper.find('.dispatch-card')
+    expect(card.classes()).toContain('dispatch-card--asking')
+    expect(card.text()).toContain('Needs an answer from you')
+    expect(card.text()).toContain('Should the form email you or open a ticket?')
+  })
+
+  it('falls back to starting when the store has no instance yet', () => {
+    // A reloaded transcript renders its cards before the instances load.
+    const store = useAgentStore()
+    store.instances = []
+    const reply: AIMessage = {
+      ...assistant('On it.'),
+      dispatchedTasks: [{ conversationId: 7, title: 'Contact page' }],
+    }
+    const wrapper = mount(ChatConversation, { props: { messages: [user('hi'), reply] } })
+
+    const card = wrapper.find('.dispatch-card')
+    expect(card.text()).toContain('Contact page')
+    expect(card.text()).toContain('Starting…')
   })
 })

--- a/frontend/vuejs/src/apps/imagi/build/components/molecules/chat/DispatchCard.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/molecules/chat/DispatchCard.vue
@@ -1,0 +1,451 @@
+<!--
+  DispatchCard.vue — a subagent, as it appears in the main thread.
+
+  One card per task the lead handed off. It says two things and nothing else:
+  what the subagent is working on (its title is the task), and where that work
+  stands. While the run is live the card is lit and moving; when the work lands
+  it flips to a confirmation the user can read at a glance without going
+  anywhere. The subagent's full account of what it did stays one click away in
+  its own thread — this card is the notice, not the transcript.
+
+  It borrows the crew ledger's state vocabulary (AgentInstanceCard): a rail
+  down the left edge, ink travelling while live, so a card here and a card
+  there report the same state the same way. The one place it departs is
+  "done" — settled work recedes to a hairline in the ledger, but in the
+  transcript a finished task is news, so it lands in an affirmative green.
+-->
+<template>
+  <button
+    type="button"
+    :class="['dispatch-card', `dispatch-card--${state.tone}`]"
+    :title="`Open this subagent's thread`"
+    @click="emit('open')"
+  >
+    <span class="dispatch-card__rail" aria-hidden="true"></span>
+
+    <span class="dispatch-card__chip">
+      <i :class="state.icon"></i>
+    </span>
+
+    <span class="dispatch-card__body">
+      <!-- What it is working on: the brief, in one line -->
+      <span class="dispatch-card__title">{{ title || 'Background subagent' }}</span>
+
+      <!-- Where it stands -->
+      <span class="dispatch-card__status">{{ state.label }}</span>
+
+      <!-- The one thing worth spelling out inline: a question can't be acted
+           on from a status line, so it is shown here as well as in the queue
+           above the composer where it gets answered. -->
+      <span v-if="state.body" class="dispatch-card__question">{{ state.body }}</span>
+    </span>
+
+    <i class="fas fa-chevron-right dispatch-card__chevron" aria-hidden="true"></i>
+  </button>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { AgentInstance } from '../../../types/services'
+
+const props = defineProps<{
+  /** The task's title from the transcript — survives a reload even when the
+   *  live instance has not loaded yet, so the card always names its work. */
+  title: string
+  /** The live subagent behind this card, when the store knows about it. */
+  instance?: AgentInstance | null
+}>()
+
+const emit = defineEmits<{ (e: 'open'): void }>()
+
+/**
+ * Where this subagent stands, as the three things the card renders: a tone
+ * (which drives every colour on the card), an icon, and a line of text.
+ *
+ * A live run beats every stored status — a task re-prompted after finishing is
+ * working again whatever its last outcome was.
+ */
+const state = computed(() => {
+  const instance = props.instance
+  if (!instance) {
+    return { tone: 'starting', icon: 'fas fa-hourglass-start', label: 'Starting…', body: '' }
+  }
+  if (instance.isProcessing) {
+    return {
+      tone: 'working',
+      icon: 'fas fa-circle-notch fa-spin',
+      label: 'Working on this now…',
+      body: '',
+    }
+  }
+  switch (instance.reviewStatus) {
+    case 'input':
+      return {
+        tone: 'asking',
+        icon: 'fas fa-circle-question',
+        // The subagent stopped on ask_user, so its closing line is the
+        // question itself.
+        label: 'Needs an answer from you',
+        body: instance.lastMessagePreview || '',
+      }
+    case 'ready':
+      return {
+        tone: 'asking',
+        icon: 'fas fa-check',
+        label: 'Finished — waiting on you',
+        body: '',
+      }
+    case 'accepted':
+      return { tone: 'done', icon: 'fas fa-check', label: 'Done', body: '' }
+    case 'dismissed':
+      return { tone: 'settled', icon: 'fas fa-xmark', label: 'Discarded', body: '' }
+    default:
+      return { tone: 'starting', icon: 'fas fa-hourglass-start', label: 'Starting…', body: '' }
+  }
+})
+</script>
+
+<style scoped>
+/* ── The card ───────────────────────────────────────────────────────────── */
+
+/* Every colour on the card comes from these four, so a state change is one
+   block of overrides rather than a rule per element. */
+.dispatch-card {
+  --rail: rgba(23, 37, 84, 0.14);
+  --status: rgba(23, 37, 84, 0.5);
+  --chip-bg: rgba(23, 37, 84, 0.08);
+  --chip-fg: rgba(23, 37, 84, 0.8);
+
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.625rem;
+  width: 100%;
+  padding: 0.5rem 0.625rem 0.5rem 0.875rem;
+  border-radius: var(--iw-r-lg);
+  border: 1px solid rgba(23, 37, 84, 0.08);
+  background: rgba(239, 246, 255, 0.5);
+  text-align: left;
+  overflow: hidden;
+  cursor: pointer;
+  transition:
+    background-color var(--iw-dur-3) var(--iw-ease-out),
+    border-color var(--iw-dur-3) var(--iw-ease-out),
+    box-shadow var(--iw-dur-2) var(--iw-ease-out),
+    transform var(--iw-dur-2) var(--iw-ease-out);
+}
+
+.dark .dispatch-card {
+  --rail: rgba(255, 255, 255, 0.16);
+  --status: rgba(219, 234, 254, 0.55);
+  --chip-bg: rgba(243, 237, 226, 0.12);
+  --chip-fg: rgba(243, 237, 226, 0.9);
+  border-color: rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.dispatch-card:hover {
+  border-color: rgba(23, 37, 84, 0.14);
+  box-shadow: var(--iw-shadow-2);
+  transform: translateY(-1px);
+}
+
+.dark .dispatch-card:hover {
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.dispatch-card:active {
+  transform: translateY(0) scale(0.99);
+  box-shadow: var(--iw-shadow-1);
+  transition-duration: var(--iw-dur-1);
+}
+
+.dispatch-card:focus-visible {
+  outline: none;
+  box-shadow: var(--iw-focus-ring);
+}
+
+/* ── States ─────────────────────────────────────────────────────────────── */
+
+/* Dispatched, run not yet fired: the rail is drawn but not filled. */
+.dispatch-card--starting {
+  --rail: repeating-linear-gradient(
+    180deg,
+    rgba(23, 37, 84, 0.3) 0 3px,
+    transparent 3px 7px
+  );
+}
+
+.dark .dispatch-card--starting {
+  --rail: repeating-linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.3) 0 3px,
+    transparent 3px 7px
+  );
+}
+
+/* Live: ink travels down the rail and the left edge breathes — the same
+   treatment a working agent gets in the crew ledger. */
+.dispatch-card--working {
+  --rail: rgba(37, 99, 235, 0.32);
+  --status: theme('colors.blue.600');
+  --chip-bg: rgba(59, 130, 246, 0.13);
+  --chip-fg: theme('colors.blue.600');
+}
+
+.dark .dispatch-card--working {
+  --rail: rgba(147, 197, 253, 0.3);
+  --status: theme('colors.blue.300');
+  --chip-bg: rgba(147, 197, 253, 0.16);
+  --chip-fg: theme('colors.blue.300');
+}
+
+.dispatch-card--working::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 40%;
+  pointer-events: none;
+  background: linear-gradient(90deg, rgba(59, 130, 246, 0.09) 0%, rgba(59, 130, 246, 0) 100%);
+  animation: rail-breathe 3.2s var(--iw-ease-ambient) infinite;
+}
+
+.dark .dispatch-card--working::before {
+  background: linear-gradient(90deg, rgba(147, 197, 253, 0.1) 0%, rgba(147, 197, 253, 0) 100%);
+}
+
+.dispatch-card--working .dispatch-card__rail::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    theme('colors.blue.500') 40%,
+    theme('colors.blue.400') 60%,
+    transparent 100%
+  );
+  animation: rail-travel 2.6s var(--iw-ease-ambient) infinite;
+}
+
+.dark .dispatch-card--working .dispatch-card__rail::after {
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    theme('colors.blue.300') 40%,
+    theme('colors.blue.200') 60%,
+    transparent 100%
+  );
+}
+
+/* Wants the user — a question to answer or a draft to pick. Solid navy ink,
+   the workspace's "this one is on you" mark. */
+.dispatch-card--asking {
+  --rail: theme('colors.blue.950');
+  --status: rgba(23, 37, 84, 0.78);
+  --chip-bg: rgba(23, 37, 84, 0.1);
+  --chip-fg: theme('colors.blue.950');
+  border-color: rgba(23, 37, 84, 0.16);
+}
+
+.dark .dispatch-card--asking {
+  --rail: #f3ede2;
+  --status: rgba(243, 237, 226, 0.85);
+  --chip-bg: rgba(243, 237, 226, 0.16);
+  --chip-fg: #f3ede2;
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+/* Done. The ledger lets settled work recede, but here the flip from "working"
+   to "landed in your app" is the single moment this card exists to report, so
+   it arrives in green and says so — and plays a one-shot settle rather than
+   simply being repainted. */
+.dispatch-card--done {
+  --rail: theme('colors.green.600');
+  --status: theme('colors.green.700');
+  --chip-bg: theme('colors.green.100');
+  --chip-fg: theme('colors.green.700');
+  border-color: rgba(22, 163, 74, 0.28);
+  background: rgba(240, 253, 244, 0.85);
+  animation: done-settle var(--iw-dur-4) var(--iw-ease-spring) both;
+}
+
+.dark .dispatch-card--done {
+  --rail: theme('colors.green.400');
+  --status: theme('colors.green.300');
+  --chip-bg: rgba(74, 222, 128, 0.16);
+  --chip-fg: theme('colors.green.300');
+  border-color: rgba(74, 222, 128, 0.28);
+  background: rgba(74, 222, 128, 0.07);
+}
+
+.dispatch-card--done:hover {
+  border-color: rgba(22, 163, 74, 0.45);
+}
+
+.dark .dispatch-card--done:hover {
+  border-color: rgba(74, 222, 128, 0.45);
+}
+
+/* Discarded work recedes — it is a record, not news. */
+.dispatch-card--settled {
+  opacity: 0.7;
+}
+
+.dispatch-card--settled:hover {
+  opacity: 1;
+}
+
+/* ── Parts ──────────────────────────────────────────────────────────────── */
+
+.dispatch-card__rail {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 0.1875rem;
+  background: var(--rail);
+  transition: background-color var(--iw-dur-3) var(--iw-ease-out);
+}
+
+.dispatch-card__chip {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 1.5rem;
+  height: 1.5rem;
+  margin-top: 0.0625rem;
+  border-radius: var(--iw-r-sm);
+  background: var(--chip-bg);
+  color: var(--chip-fg);
+  font-size: 0.625rem;
+  transition:
+    background-color var(--iw-dur-3) var(--iw-ease-out),
+    color var(--iw-dur-3) var(--iw-ease-out);
+}
+
+/* Above the working state's edge glow, which would otherwise wash over it. */
+.dispatch-card__body {
+  position: relative;
+  z-index: 1;
+  flex: 1;
+  min-width: 0;
+}
+
+/* The task itself. Set in the brand serif like the crew ledger's byline, so
+   the thing being worked on reads as a name rather than a log line. */
+.dispatch-card__title {
+  display: block;
+  font-family: theme('fontFamily.display');
+  font-variation-settings: 'opsz' 11, 'SOFT' 30, 'WONK' 1;
+  font-size: 0.8125rem;
+  font-weight: 550;
+  line-height: 1.3;
+  letter-spacing: -0.006em;
+  color: rgba(23, 37, 84, 0.88);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dark .dispatch-card__title {
+  color: rgba(255, 255, 255, 0.86);
+}
+
+.dispatch-card__status {
+  display: block;
+  margin-top: 0.125rem;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  line-height: 1.35;
+  color: var(--status);
+  transition: color var(--iw-dur-3) var(--iw-ease-out);
+}
+
+.dispatch-card__question {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  margin-top: 0.25rem;
+  font-size: 0.6875rem;
+  line-height: 1.45;
+  color: rgba(23, 37, 84, 0.65);
+}
+
+.dark .dispatch-card__question {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.dispatch-card__chevron {
+  position: relative;
+  z-index: 1;
+  flex-shrink: 0;
+  align-self: center;
+  font-size: 0.625rem;
+  color: rgba(23, 37, 84, 0.3);
+  transition:
+    color var(--iw-dur-2) var(--iw-ease-out),
+    transform var(--iw-dur-2) var(--iw-ease-out);
+}
+
+.dark .dispatch-card__chevron {
+  color: rgba(255, 255, 255, 0.3);
+}
+
+.dispatch-card:hover .dispatch-card__chevron {
+  color: rgba(23, 37, 84, 0.6);
+  transform: translateX(2px);
+}
+
+.dark .dispatch-card:hover .dispatch-card__chevron {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+/* ── Motion ─────────────────────────────────────────────────────────────── */
+
+@keyframes rail-travel {
+  0% { transform: translateY(-100%); }
+  100% { transform: translateY(100%); }
+}
+
+@keyframes rail-breathe {
+  0%, 100% { opacity: 0.55; }
+  50% { opacity: 1; }
+}
+
+/* The arrival. Work landing in the app should register even out of the corner
+   of the eye, so the card takes a beat of extra height and settles back. */
+@keyframes done-settle {
+  0% { transform: scale(0.985); }
+  45% { transform: scale(1.012); }
+  100% { transform: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dispatch-card--working::before {
+    animation: none;
+    opacity: 0.8;
+  }
+
+  .dispatch-card--working .dispatch-card__rail::after {
+    animation: none;
+    background: theme('colors.blue.500');
+  }
+
+  .dispatch-card--done {
+    animation: none;
+  }
+
+  .dispatch-card:hover,
+  .dispatch-card:active {
+    transform: none;
+  }
+}
+</style>

--- a/frontend/vuejs/src/apps/imagi/build/components/molecules/sidebar/WorkspacePaneHeader.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/molecules/sidebar/WorkspacePaneHeader.vue
@@ -9,13 +9,22 @@
 -->
 <template>
   <div class="pane-header shrink-0 flex items-center gap-2.5 px-3.5 py-2.5">
-    <!-- Identity: mark + name + what's happening right now -->
-    <div class="relative shrink-0">
-      <div :class="['pane-mark', tone === 'primary' ? 'pane-mark--primary' : 'pane-mark--muted']">
+    <!-- Identity: mark + name + what's happening right now. A pane can go
+         without a mark (a subagent's thread names its task and needs no badge
+         beside it); the live dot then stands on its own where the mark was. -->
+    <div v-if="icon || live" class="relative shrink-0">
+      <div
+        v-if="icon"
+        :class="['pane-mark', tone === 'primary' ? 'pane-mark--primary' : 'pane-mark--muted']"
+      >
         <i :class="[icon, 'text-[11px]']"></i>
       </div>
       <!-- A run is live in this pane -->
-      <span v-if="live" class="pane-pulse" aria-hidden="true"></span>
+      <span
+        v-if="live"
+        :class="['pane-pulse', icon ? '' : 'pane-pulse--bare']"
+        aria-hidden="true"
+      ></span>
     </div>
 
     <div class="flex-1 min-w-0">
@@ -70,8 +79,9 @@
 <script setup lang="ts">
 withDefaults(
   defineProps<{
-    /** Font Awesome classes for the pane's mark */
-    icon: string
+    /** Font Awesome classes for the pane's mark. Omit for a pane whose title
+     *  already identifies it — the plate then leads with the name. */
+    icon?: string
     /** 'primary' is the thread the user drives; 'muted' is everything observed */
     tone?: 'primary' | 'muted'
     title: string
@@ -206,6 +216,15 @@ const emit = defineEmits<{ (e: 'switch'): void }>()
 
 .dark .pane-pulse {
   background: theme('colors.blue.300');
+}
+
+/* With no mark to sit against, the dot holds the same left edge the mark did
+   so the title does not shift between a pane that has one and a pane that
+   does not. */
+.pane-pulse--bare {
+  position: static;
+  display: block;
+  margin: 0 0.6875rem;
 }
 
 @keyframes pane-pulse-core {

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/chat/ChatConversation.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/chat/ChatConversation.vue
@@ -44,7 +44,7 @@
               :class="{ 'animate-message-in': message.isNew }"
               :style="message.isNew ? { 'animation-delay': `${message.enterDelay}ms` } : {}">
               <AgentActivityFeed
-                v-if="message.activity?.length"
+                v-if="activityVisible && message.activity?.length"
                 :steps="message.activity"
                 :streaming="isStreamingMessage(index)"
                 class="mb-2.5"
@@ -61,38 +61,16 @@
               />
               <!-- Subagents this reply kicked off. The work streams in their
                    own threads — the main thread keeps just these cards, each
-                   one click from watching the subagent build. -->
+                   one saying what its subagent is building and where that
+                   stands, and each one click from watching it happen. -->
               <div v-if="message.dispatchedTasks?.length" class="mt-2 flex flex-col gap-1.5">
-                <button
+                <DispatchCard
                   v-for="task in message.dispatchedTasks"
                   :key="task.conversationId"
-                  type="button"
-                  class="dispatch-card group flex items-start gap-2.5 w-full border border-blue-950/[0.08] dark:border-white/[0.12] bg-blue-50/50 dark:bg-white/[0.04] px-3 py-2 text-left hover:bg-blue-100/60 dark:hover:bg-white/[0.07]"
-                  :title="`Open this subagent's thread`"
-                  @click="emit('open-task', task.conversationId)"
-                >
-                  <span class="dispatch-chip flex items-center justify-center w-6 h-6 rounded-lg shrink-0">
-                    <i class="fas fa-robot text-[10px]"></i>
-                  </span>
-                  <span class="flex-1 min-w-0">
-                    <span class="block text-[12px] font-semibold text-blue-950/85 dark:text-white/85 truncate">
-                      {{ task.title || 'Background subagent' }}
-                    </span>
-                    <span class="block text-[10px] text-blue-950/45 dark:text-white/40">
-                      {{ dispatchStatus(task.conversationId) }}
-                    </span>
-                    <!-- What the subagent actually did. A finished task is
-                         reported here and nowhere else — there is no card to
-                         accept or clear, so this line is the record. -->
-                    <span
-                      v-if="dispatchSummary(task.conversationId)"
-                      class="mt-1 text-[11px] leading-snug text-blue-950/65 dark:text-white/55 line-clamp-3"
-                    >
-                      {{ dispatchSummary(task.conversationId) }}
-                    </span>
-                  </span>
-                  <i class="fas fa-chevron-right dispatch-chevron text-[10px] mt-0.5 text-blue-950/30 dark:text-white/30 group-hover:text-blue-950/60 dark:group-hover:text-white/60 shrink-0"></i>
-                </button>
+                  :title="task.title"
+                  :instance="dispatchInstance(task.conversationId)"
+                  @open="emit('open-task', task.conversationId)"
+                />
               </div>
               <div v-if="message.filesChanged?.length" class="mt-2">
                 <span
@@ -158,9 +136,10 @@
 import { marked } from 'marked'
 import DOMPurify from 'isomorphic-dompurify'
 import { ref, nextTick, watch, onMounted, onBeforeUnmount, computed } from 'vue'
-import type { AIMessage } from '@/apps/imagi/build/types/services'
+import type { AgentInstance, AIMessage } from '@/apps/imagi/build/types/services'
 import AgentActivityFeed from '@/apps/imagi/build/components/molecules/chat/AgentActivityFeed.vue'
 import AgentPlanChecklist from '@/apps/imagi/build/components/molecules/chat/AgentPlanChecklist.vue'
+import DispatchCard from '@/apps/imagi/build/components/molecules/chat/DispatchCard.vue'
 import { useAgentStore } from '@/apps/imagi/build/stores/agentStore'
 
 marked.setOptions({
@@ -185,7 +164,15 @@ const props = defineProps<{
    *  live in a worktree, not the canonical timeline) and while a
    *  canonical-tree run is live. Omitted = fall back to !isProcessing. */
   canRestore?: boolean
+  /** Whether to show the per-reply tool-activity feed. Off on the main thread,
+   *  where the lead's only tool call is the hand-off itself and the dispatch
+   *  card below already reports it — a "Completed 1 step" fold under every
+   *  reply is a second, emptier telling of the same thing. Defaults on, so a
+   *  subagent's transcript still shows how it worked. */
+  showActivity?: boolean
 }>()
+
+const activityVisible = computed(() => props.showActivity !== false)
 
 const restoreAllowed = computed(() =>
   props.canRestore !== undefined ? props.canRestore : !props.isProcessing
@@ -220,27 +207,11 @@ const emit = defineEmits<{
 // progresses (working → finished → added), without threading props through.
 const agentStore = useAgentStore()
 
-/** Status line for a dispatch card. Mirrors the manager's card wording. */
-function dispatchStatus(conversationId: number): string {
-  const instance = agentStore.instances.find(i => i.conversationId === conversationId)
-  if (!instance) return 'Subagent'
-  if (instance.isProcessing) return 'Working in the background…'
-  switch (instance.reviewStatus) {
-    case 'input': return 'Asked you a question'
-    case 'ready': return 'Finished — waiting on you'
-    case 'accepted': return 'Added to your app'
-    case 'dismissed': return 'Discarded'
-    default: return 'Starting…'
-  }
-}
-
-/** What a finished subagent says it accomplished — its closing line, which is
- *  the whole report now that a self-merging task queues nothing. Nothing while
- *  it is still working: a mid-run line would read as a result. */
-function dispatchSummary(conversationId: number): string {
-  const instance = agentStore.instances.find(i => i.conversationId === conversationId)
-  if (!instance || instance.isProcessing) return ''
-  return instance.lastMessagePreview || ''
+/** The live subagent behind a dispatch card, or null before the store has it
+ *  (a card rendered straight from a reloaded transcript, or a dispatch whose
+ *  instance has not been adopted yet) — the card falls back to "Starting…". */
+function dispatchInstance(conversationId: number): AgentInstance | null {
+  return agentStore.instances.find(i => i.conversationId === conversationId) ?? null
 }
 
 // Refs and reactive state
@@ -446,71 +417,6 @@ const copyToClipboard = (code: string) => {
    user bubble opens a turn with extra breathing room above it. */
 .msg-row + .msg-row {
   margin-top: 1rem;
-}
-
-/* A subagent handed off mid-reply. It is the one clickable object inside the
-   transcript, so it behaves like the cards in the crew ledger do: rises to
-   meet the pointer, gives under the press. */
-.dispatch-card {
-  border-radius: var(--iw-r-lg);
-  transition:
-    background-color var(--iw-dur-2) var(--iw-ease-out),
-    border-color var(--iw-dur-2) var(--iw-ease-out),
-    box-shadow var(--iw-dur-2) var(--iw-ease-out),
-    transform var(--iw-dur-2) var(--iw-ease-out);
-}
-
-.dispatch-card:hover {
-  border-color: rgba(23, 37, 84, 0.14);
-  box-shadow: var(--iw-shadow-2);
-  transform: translateY(-1px);
-}
-
-.dark .dispatch-card:hover {
-  border-color: rgba(255, 255, 255, 0.2);
-}
-
-.dispatch-card:active {
-  transform: translateY(0) scale(0.99);
-  box-shadow: var(--iw-shadow-1);
-  transition-duration: var(--iw-dur-1);
-}
-
-.dispatch-card:focus-visible {
-  outline: none;
-  box-shadow: var(--iw-focus-ring);
-}
-
-.dispatch-chevron {
-  transition:
-    color var(--iw-dur-2) var(--iw-ease-out),
-    transform var(--iw-dur-2) var(--iw-ease-out);
-}
-
-.dispatch-card:hover .dispatch-chevron {
-  transform: translateX(2px);
-}
-
-/* Dispatch-card chip: same navy-ink / cream pairing as the check-in queue. */
-.dispatch-chip {
-  background: rgba(23, 37, 84, 0.08);
-  box-shadow: inset 0 0 0 1px rgba(23, 37, 84, 0.06);
-  color: rgba(23, 37, 84, 0.8);
-  transition: background-color var(--iw-dur-2) var(--iw-ease-out);
-}
-
-.dispatch-card:hover .dispatch-chip {
-  background: rgba(23, 37, 84, 0.12);
-}
-
-.dark .dispatch-chip {
-  background: rgba(243, 237, 226, 0.12);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
-  color: rgba(243, 237, 226, 0.9);
-}
-
-.dark .dispatch-card:hover .dispatch-chip {
-  background: rgba(243, 237, 226, 0.18);
 }
 
 .msg-row + .user-row {

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/AgentManagerPanel.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/AgentManagerPanel.vue
@@ -20,7 +20,6 @@
          must not displace the thread you are actually talking in. -->
     <div v-if="opened" key="opened" class="pane-nav-view flex flex-col h-full">
       <WorkspacePaneHeader
-        icon="fas fa-robot"
         tone="muted"
         :title="opened.title || 'Background agent'"
         :status="openedStatus"

--- a/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
+++ b/frontend/vuejs/src/apps/imagi/build/components/organisms/sidebar/BuilderSidebarChat.vue
@@ -8,7 +8,7 @@
          per-message checkpoint chips), so the header carries no history
          controls. -->
     <WorkspacePaneHeader
-      :icon="isTaskThread ? 'fas fa-robot' : 'fas fa-comments'"
+      :icon="isTaskThread ? undefined : 'fas fa-comments'"
       :tone="isTaskThread ? 'muted' : 'primary'"
       :title="headerTitle"
       :status="headerStatus"
@@ -33,6 +33,7 @@
         :is-processing="!!activeInstance?.isProcessing"
         :status-text="activeInstance?.statusText || ''"
         :can-restore="canRestoreCheckpoints"
+        :show-activity="!isLeadThread"
         @restore-checkpoint="emit('restore-checkpoint', $event)"
         @open-task="onOpenTask"
         class="flex-1"


### PR DESCRIPTION
## What changed

The main agent hands every job to a background subagent, but the thread it leaves behind barely said so. A dispatch card read **"Working in the background…"** for the entire run — no indication of *what* was being built — then silently swapped to a clipped line of the subagent's closing prose. Work landing in the app was something you discovered later rather than something you watched happen.

Dispatch cards are now their own component (`DispatchCard.vue`) that says exactly two things: **the task**, and **where it stands**.

| State | Reads |
|---|---|
| Working | Blue rail with ink travelling down it, spinner chip — task title + *"Working on this now…"* |
| Done | Flips to green: green rail, filled check, task title + *"Done"*, with a one-shot settle animation |
| Question | Solid navy rail, question chip, *"Needs an answer from you"* + the question inline |
| Waiting on review | Navy rail, *"Finished — waiting on you"* |
| Starting / discarded | Dashed rail *"Starting…"* / muted *"Discarded"* |

The working and done treatments reuse the crew ledger's existing state vocabulary (`AgentInstanceCard`), so a card here and a card there report the same state the same way. The one deliberate departure is **done**: settled work recedes to a hairline in the ledger, but in the transcript a finished task is *news*, so it lands in an affirmative green.

The long summary blob under finished cards is gone — the card is the notice, not the transcript. The subagent's full account stays one click away in its own thread.

Three smaller cleanups to things the main thread was saying twice, or not meaning:

- **Subagent threads drop the robot badge** and lead with the task name. `WorkspacePaneHeader`'s mark is now optional; when a markless thread is live, the pulse dot holds the mark's left edge so the title doesn't shift between panes.
- **The per-reply activity feed is off on the lead thread** (new `showActivity` prop). The lead's only tool call is the hand-off itself, so a *"Completed 1 step"* fold under every reply was a second, emptier telling of what the card below already reports. Subagent transcripts keep it, where the steps are worth reading.
- **"Done"** rather than *"Done — added to your app"*.

## Why

This came out of driving the workspace live and watching what the main thread actually feels like while a subagent builds. The thread had no way to tell you what was being worked on, and completion was a silent swap — look away for thirty seconds and you'd miss the entire event. Because a solo task auto-merges and files no check-in, the queue stays empty too, so the card was the *only* surface that could carry the news, and it wasn't carrying it.

## Verification

Driven end to end in the browser against a real project, not just unit tests:

1. Sent the main agent a job; it triaged, dispatched, and replied with one line.
2. Watched the card render blue-and-spinning with the task named, then flip to green **Done**.
3. Confirmed the edit reached the project on disk (`AboutView.vue`, commit `Task 68 changes`) — the loop genuinely completed.
4. Checked light and dark mode.

`npm run type-check` clean. 76/76 build-workspace tests pass — the two dispatch-card specs were rewritten to the new contract, plus three added: the question state, and the fallback when a reloaded transcript renders before its instances load.

## Notes for review

- **Deliberate information tradeoff**: removing the inline summary means the main thread no longer shows *what* a subagent changed, only that it finished. That was the ask — the card became a confirmation rather than a report — and the detail is preserved in the subagent's thread. Worth a second opinion on whether the one-click hop is the right cost.
- The green `done` tone is a new colour in an otherwise navy-ink/cream workspace. Precedent exists (`ConfirmModal`'s success variant), and "obvious when work lands" was the explicit goal, but it is a palette decision.
- The subagent *thread header* still reads "Added to your app" as its status line. That's a different string from the card label and currently the only statement of outcome on that screen, so it was left alone.

## Not included

The main agent's header still says *"Ready when you are"* while a subagent is working — `headerStatus` only knows about the lead's own run. That's the remaining place the main thread claims to be idle when it isn't, and it's the obvious follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)